### PR TITLE
chore: update llama.cpp from b5716 to b5760

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,7 @@ jobs:
       - get_jextract:
           os: "macosx"
           platform: "aarch64"
-          "llama-cpp-version": b5716
+          "llama-cpp-version": b5760
       - checkout:
           path: "/Users/distiller/llamaj.cpp"
       - download_model:
@@ -410,7 +410,7 @@ jobs:
       - get_jextract:
           os: "linux"
           platform: "x86_64"
-          "llama-cpp-version": b5716
+          "llama-cpp-version": b5760
       - checkout:
           path: "/home/circleci/llamaj.cpp"
       - download_model:
@@ -433,7 +433,7 @@ jobs:
       - get_jextract:
           os: "macosx"
           platform: "aarch64"
-          "llama-cpp-version": b5716
+          "llama-cpp-version": b5760
       - checkout:
           path: "/Users/distiller/llamaj.cpp"
       - generate_sources:
@@ -451,7 +451,7 @@ jobs:
       - get_jextract:
           os: "linux"
           platform: "x86_64"
-          "llama-cpp-version": b5716
+          "llama-cpp-version": b5760
       - checkout:
           path: "/home/circleci/llamaj.cpp"
       - generate_sources:

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit-jupiter-api.version>5.13.2</junit-jupiter-api.version>
         <assertj-core.version>3.27.3</assertj-core.version>
-        <llama.cpp.version>b5716</llama.cpp.version>
+        <llama.cpp.version>b5760</llama.cpp.version>
         <llama.cpp.dir>${project.basedir}/../llama.cpp</llama.cpp.dir>
         <jextract.dir>${project.basedir}/../jextract/bin</jextract.dir>
     </properties>


### PR DESCRIPTION
This PR updates llama.cpp from b5716 to b5760