### PR TITLE
feat: speculative decoding (draft model + n-gram, greedy & sampling)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,11 +257,7 @@ commands:
           steps:
             - persist_to_workspace:
                 root: "/home/circleci/llamaj.cpp"
-                paths:
-                  [
-                    "src/main/resources/linux",
-                    "target/generated-sources/io/gravitee/llama/cpp/linux",
-                  ]
+                paths: ["target/generated-sources/io/gravitee/llama/cpp/linux"]
       - when:
           condition:
             and:
@@ -269,11 +265,7 @@ commands:
           steps:
             - persist_to_workspace:
                 root: "/Users/distiller/llamaj.cpp"
-                paths:
-                  [
-                    "src/main/resources/macosx",
-                    "target/generated-sources/io/gravitee/llama/cpp/macosx",
-                  ]
+                paths: ["target/generated-sources/io/gravitee/llama/cpp/macosx"]
 
   release_tag:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,6 +409,10 @@ jobs:
           repo: "gpustack/jina-reranker-v1-tiny-en-GGUF"
           files: "jina-reranker-v1-tiny-en-Q4_K_M.gguf"
           destinations: "models/jina-reranker.gguf"
+      - download_models:
+          repo: "Qwen/Qwen3-1.7B-GGUF"
+          files: "Qwen3-1.7B-Q8_0.gguf"
+          destinations: "models/spec-target.gguf"
       - run-tests:
           os: "macosx"
           platform: "aarch64"
@@ -461,6 +465,10 @@ jobs:
           repo: "gpustack/jina-reranker-v1-tiny-en-GGUF"
           files: "jina-reranker-v1-tiny-en-Q4_K_M.gguf"
           destinations: "models/jina-reranker.gguf"
+      - download_models:
+          repo: "Qwen/Qwen3-1.7B-GGUF"
+          files: "Qwen3-1.7B-Q8_0.gguf"
+          destinations: "models/spec-target.gguf"
       - run-tests:
           os: "linux"
           platform: "x86_64"

--- a/README.md
+++ b/README.md
@@ -1,674 +1,109 @@
-#  Llamaj.cpp
+# Llamaj.cpp
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/gravitee-io/llamaj.cpp/LICENSE.txt)
-[![Releases](https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release)](https://github.com/gravitee-io/llamaj.cpp/releases)
+[![llamaj.cpp](https://img.shields.io/github/v/release/gravitee-io/llamaj.cpp?label=llamaj.cpp&color=orange&sort=semver)](https://github.com/gravitee-io/llamaj.cpp/releases)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](./LICENSE.txt)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/gravitee-io/llamaj.cpp/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/gravitee-io/llamaj.cpp/tree/main)
 [![Community Forum](https://img.shields.io/badge/Gravitee-Community%20Forum-white?logo=githubdiscussion&logoColor=white)](https://community.gravitee.io?utm_source=readme)
 
-**Llamaj.cpp** is a Java and JVM port of llama.cpp using jextract, enabling local large language model (LLM) inference through native foreign function & memory API interop. Natively supports macOS M-series and Linux x86_64 with GPU acceleration. Platform and hardware support (Windows, ARM, CUDA, etc.) can be extended through custom builds.
+[![llama.cpp](https://img.shields.io/badge/llama.cpp-b9673-blue.svg)](https://github.com/ggml-org/llama.cpp/releases/tag/b9673)
+[![llama.cpp license](https://img.shields.io/badge/llama.cpp%20license-MIT-green.svg)](./licenses/LICENSE-llama-cpp)
 
-## Keywords
-
-`llama.cpp` · `java` · `jvm` · `llm` · `large language models` · `inference` · `ai` · `native interop` · `foreign function & memory api` · `jextract`
+**Llamaj.cpp** is a Java and JVM port of [llama.cpp](https://github.com/ggml-org/llama.cpp) using jextract, enabling local large language model (LLM) inference through the native foreign function & memory API. It natively supports macOS M-series and Linux x86_64 with GPU acceleration; other platforms (Windows, ARM, CUDA, …) can be added through [custom builds](./docs/custom-builds/README.md).
 
 ## Requirements
 
 - Java 25
-- mvn
-- MacOS M-series / Linux x86_64 (CPU) (you can check the last section if you do not see your platform here)
+- Maven
+- macOS M-series / Linux x86_64 (other platforms via [custom builds](./docs/custom-builds/README.md))
 
-## How to use
+## Installation
 
-Include the dependency in your pom.xml
-```
-    <dependencies>
-        ...
-        <dependency>
-            <groupId>io.gravitee.llama.cpp</groupId>
-            <artifactId>llamaj.cpp</artifactId>
-            <version>x.x.x</version>
-        </dependency>
-    </dependencies>
+```xml
+<dependency>
+    <groupId>io.gravitee.llama.cpp</groupId>
+    <artifactId>llamaj.cpp</artifactId>
+    <version>1.3.0</version>
+</dependency>
 ```
 
-> **Note:** All examples below use `LlamaVocab` to handle tokenization. It's obtained from a loaded `LlamaModel` and is essential for converting between tokens and text representations.
+## Capabilities
 
-### Example 1: Basic Conversation
+Full documentation lives in **[`docs/`](./docs/README.md)** — one page per capability. New here? Start with **[Getting Started](./docs/getting-started/README.md)**.
+
+### Core
+- **[Getting Started](./docs/getting-started/README.md)** — runtime init, load a model, build a context, tokenize, and the `Arena`/`Freeable` resource model.
+- **[Text Generation & Sampling](./docs/text-generation/README.md)** — stream a conversation with `ConversationState` + `DefaultLlamaIterator` and a `LlamaSampler` chain.
+- **[Chat Templates](./docs/chat-templates/README.md)** — render role-tagged messages into a model-specific prompt.
+- **[Log Probabilities](./docs/logprobs/README.md)** — per-token logprobs with top-N alternatives.
+
+### Scale & serve
+- **[Parallel Conversations](./docs/parallel-conversations/README.md)** — decode many conversations through one shared context with `BatchIterator`.
+- **[Speculative Decoding](./docs/speculative-decoding/README.md)** — draft→verify→accept speedup (draft model or n-gram), greedy (lossless) or sampling (exact).
+- **[Distributed Inference (RPC)](./docs/distributed-inference/README.md)** — offload layers/KV-cache to remote `rpc-server` backends.
+- **[Quantized KV Cache](./docs/quantized-kv-cache/README.md)** — shrink KV-cache memory by quantizing the K/V cache type.
+
+### Retrieval & multimodal
+- **[Embeddings](./docs/embeddings/README.md)** — dense vectors with `LlamaEmbedder`.
+- **[Reranking](./docs/reranking/README.md)** — score documents against a query with `LlamaReranker`.
+- **[Multimodal (Vision & Audio)](./docs/multimodal/README.md)** — attach images and audio via `MtmdContext`.
+
+### Advanced generation
+- **[Reasoning & Tool Calls](./docs/reasoning-and-tool-calls/README.md)** — tag reasoning / answer / tool-call sections during generation.
+- **[LoRA Adapters](./docs/lora-adapters/README.md)** — load and attach a GGUF LoRA adapter.
+
+### Operations
+- **[Devices & Memory](./docs/device-and-memory/README.md)** — enumerate backends/devices, query memory, read model dims and performance metrics.
+- **[Logging](./docs/logging/README.md)** — custom log callback and level filtering.
+- **[Custom Builds & Platform Support](./docs/custom-builds/README.md)** — build llama.cpp and regenerate the jextract bindings for other platforms.
+
+## Quick start
 
 ```java
-import io.gravitee.llama.cpp.*;
-import java.lang.foreign.Arena;
-import java.nio.file.Path;
+var arena = Arena.ofConfined();
+LlamaRuntime.llama_backend_init();
+LlamaRuntime.ggml_backend_load_all_from_path(arena, LlamaLibLoader.load());
 
-public class BasicExample {
-    public static void main(String[] args) {
-        var arena = Arena.ofConfined();
+var model   = new LlamaModel(arena, Path.of("models/model.gguf"), new LlamaModelParams(arena));
+var context = new LlamaContext(arena, model, new LlamaContextParams(arena).nCtx(2048).nBatch(512));
+var vocab   = new LlamaVocab(model);
+var sampler = new LlamaSampler(arena).temperature(0.7f).topK(40).topP(0.9f, 1).seed(42);
 
-        // Initialize runtime
-        LlamaRuntime.llama_backend_init();
+var state = ConversationState.create(arena, context, new LlamaTokenizer(vocab, context), sampler)
+    .setMaxTokens(100)
+    .initialize("What is the capital of France?");
 
-        // Load model
-        var modelParams = new LlamaModelParams(arena);
-        var model = new LlamaModel(arena, Path.of("models/model.gguf"), modelParams);
-
-        // Create context
-        var contextParams = new LlamaContextParams(arena).nCtx(2048).nBatch(512);
-        var context = new LlamaContext(model, contextParams);
-
-        // Set up tokenizer and sampler
-        var vocab = new LlamaVocab(model);
-        var tokenizer = new LlamaTokenizer(vocab, context);
-        var sampler = new LlamaSampler(arena)
-            .temperature(0.7f)
-            .topK(40)
-            .topP(0.9f, 1)
-            .seed(42);
-
-        // Create conversation state
-        var state = ConversationState.create(arena, context, tokenizer, sampler, 0)
-            .setMaxTokens(100)
-            .initialize("What is the capital of France?");
-
-        // Generate response
-        var iterator = new DefaultLlamaIterator(state);
-        while (iterator.hasNext()) {
-            var output = iterator.next();
-            System.out.print(output.text());
-        }
-
-        // Cleanup
-        context.free();
-        sampler.free();
-        model.free();
-        LlamaRuntime.llama_backend_free();
-    }
-}
+new DefaultLlamaIterator(state).stream().forEach(o -> System.out.print(o.content()));
 ```
 
-### Example 2: Log Probabilities
+See [Getting Started](./docs/getting-started/README.md) and [Text Generation & Sampling](./docs/text-generation/README.md) for the full walkthrough.
 
-Enable log-probability collection to inspect the model's confidence at each token position.
-Set `topLogprobs` to the number of top-alternative tokens you want alongside the sampled one (0 = disabled, no overhead):
+## Build from source
 
-```java
-import io.gravitee.llama.cpp.*;
-import java.lang.foreign.Arena;
-import java.nio.file.Path;
-
-public class LogprobsExample {
-    public static void main(String[] args) {
-        var arena = Arena.ofConfined();
-        LlamaRuntime.llama_backend_init();
-
-        var model = new LlamaModel(arena, Path.of("models/model.gguf"), new LlamaModelParams(arena));
-        var contextParams = new LlamaContextParams(arena).nCtx(2048).nBatch(512);
-        var context = new LlamaContext(arena, model, contextParams);
-        var vocab = new LlamaVocab(model);
-        var tokenizer = new LlamaTokenizer(vocab, context);
-        var sampler = new LlamaSampler(arena).temperature(0.7f).seed(42);
-
-        var state = ConversationState.create(arena, context, tokenizer, sampler)
-            .setMaxTokens(50)
-            .setTopLogprobs(5)   // return top-5 alternatives at every token position
-            .initialize("What is the capital of France?");
-
-        var iterator = new DefaultLlamaIterator(state);
-        while (iterator.hasNext()) {
-            var output = iterator.next();
-            System.out.print(output.text());
-
-            Logprobs lp = output.logprobs();
-            System.out.printf("%n  chosen: \"%s\"  logprob=%.4f%n",
-                lp.chosenToken().token(), lp.chosenToken().logprob());
-            lp.topLogprobs().forEach(t ->
-                System.out.printf("    alt: \"%s\"  logprob=%.4f%n", t.token(), t.logprob()));
-        }
-
-        context.free();
-        sampler.free();
-        model.free();
-        LlamaRuntime.llama_backend_free();
-    }
-}
-```
-
-Each `LlamaOutput` carries a `Logprobs` object with:
-- `chosenToken()` — the token that was sampled, its text, vocabulary ID, log-probability, and raw UTF-8 bytes
-- `topLogprobs()` — up to N alternatives sorted by descending log-probability; the chosen token is always included
-
-When `topLogprobs` is `0` (the default), `output.logprobs()` is `null` and no logit processing is done.
-
-### Example 3: Parallel Conversations
-
-Process multiple conversations simultaneously in a single batch:
-
-```java
-import io.gravitee.llama.cpp.*;
-
-import java.lang.foreign.Arena;
-import java.nio.file.Path;
-
-public class ParallelExample {
-    public static void main(String[] args) {
-        var arena = Arena.ofConfined();
-
-        // Initialize runtime
-        LlamaRuntime.llama_backend_init();
-
-        // Load model
-        var modelParams = new LlamaModelParams(arena);
-        var model = new LlamaModel(arena, Path.of("models/model.gguf"), modelParams);
-
-        // Create context with multi-sequence support
-        var contextParams = new LlamaContextParams(arena)
-                .nCtx(2048)
-                .nBatch(512)
-                .nSeqMax(4);  // Support up to 4 parallel conversations
-        var context = new LlamaContext(model, contextParams);
-
-        // Set up shared tokenizer and sampler
-        var vocab = new LlamaVocab(model);
-        var tokenizer = new LlamaTokenizer(vocab, context);
-        var sampler = new LlamaSampler(arena).temperature(0.7f).seed(42);
-
-        // Create multiple conversation states with unique sequence IDs
-        var state1 = ConversationState.create(arena, context, tokenizer, sampler, 0)
-                .setMaxTokens(100).initialize("What is the capital of France?");
-        var state2 = ConversationState.create(arena, context, tokenizer, sampler, 1)
-                .setMaxTokens(100).initialize("What is the capital of England?");
-        var state3 = ConversationState.create(arena, context, tokenizer, sampler, 2)
-                .setMaxTokens(100).initialize("What is the capital of Poland?");
-
-        // Create parallel iterator - prompts are auto-processed when states are added
-        var parallel = new BatchIterator(arena, context, 512, 4)
-                .addState(state1)
-                .addState(state2)
-                .addState(state3);
-
-        // Generate tokens in parallel
-        System.out.println("=== Parallel Generation ===");
-        while (parallel.hasNext()) {
-            // Each hasNext() generates tokens for all active conversations
-            // Get all outputs from this batch (one per active conversation)
-            var outputs = parallel.getOutputs();
-            for (var output : outputs) {
-                System.out.println("Seq " + output.sequenceId() + ": " + output.text());
-            }
-        }
-        System.out.println();
-
-        // Print results
-        System.out.println("Conversation 1: " + state1.getAnswer());
-        System.out.println("  Tokens: " + state1.getAnswerTokens());
-        System.out.println("Conversation 2: " + state2.getAnswer());
-        System.out.println("  Tokens: " + state2.getAnswerTokens());
-        System.out.println("Conversation 3: " + state3.getAnswer());
-        System.out.println("  Tokens: " + state3.getAnswerTokens());
-
-        // Cleanup
-        parallel.free();
-        context.free();
-        sampler.free();
-        model.free();
-        LlamaRuntime.llama_backend_free();
-    }
-}
-```
-
-### Example 4: Distributed Inference with RPC
-
-Offload model weights and KV-cache to remote machines using the RPC backend.
-When using `--rpc`, weights are loaded **exclusively** on the remote servers -- the local GPU is not used.
-
-Start RPC server nodes first (see [containers/README.md](containers/README.md)):
+A platform-specific Maven profile downloads jextract + the pre-built llama.cpp native libraries, generates the FFM bindings, and installs the artifact:
 
 ```bash
-# On the remote machine (or another terminal)
-./scripts/start-rpc-server.sh
-```
-
-Then connect from Java:
-
-```java
-import io.gravitee.llama.cpp.*;
-import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
-import java.lang.foreign.Arena;
-import java.nio.file.Path;
-
-public class RpcExample {
-    public static void main(String[] args) {
-        var arena = Arena.ofConfined();
-
-        // Initialize runtime
-        String libPath = LlamaLibLoader.load();
-        LlamaRuntime.llama_backend_init();
-
-        // Register remote RPC servers -- returns their device handles
-        var rpcDevices = BackendRegistry.addRpcServer(arena, "127.0.0.1:50052");
-
-        // Print all discovered backends and devices
-        BackendRegistry.printSummary();
-
-        // Load model, restricting offloading to only the RPC devices
-        var modelParams = new LlamaModelParams(arena)
-            .devices(arena, rpcDevices)
-            .nGpuLayers(999);
-        var model = new LlamaModel(arena, Path.of("models/model.gguf"), modelParams);
-
-        // Everything else works exactly the same as local inference
-        var contextParams = new LlamaContextParams(arena).nCtx(2048).nBatch(512);
-        var context = new LlamaContext(model, contextParams);
-        var vocab = new LlamaVocab(model);
-        var tokenizer = new LlamaTokenizer(vocab, context);
-        var sampler = new LlamaSampler(arena).temperature(0.7f).seed(42);
-
-        var state = ConversationState.create(arena, context, tokenizer, sampler, 0)
-            .setMaxTokens(100)
-            .initialize("What is the capital of France?");
-
-        var iterator = new DefaultLlamaIterator(state);
-        while (iterator.hasNext()) {
-            System.out.print(iterator.next().text());
-        }
-
-        context.free();
-        sampler.free();
-        model.free();
-        LlamaRuntime.llama_backend_free();
-    }
-}
-```
-
-Or from the CLI:
-
-```bash
-$ java --enable-preview --enable-native-access=ALL-UNNAMED \
-  -jar llamaj.cpp-<version>.jar \
-  --model models/model.gguf \
-  --rpc 127.0.0.1:50052
-```
-
-Multiple RPC servers:
-
-```bash
-$ java --enable-preview --enable-native-access=ALL-UNNAMED \
-  -jar llamaj.cpp-<version>.jar \
-  --model models/model.gguf \
-  --rpc 192.168.1.10:50052,192.168.1.11:50052
-```
-
-### Example 5: Reranking
-
-`LlamaReranker` is a cross-encoder wrapper that scores how relevant a document is to a
-query. Pooling and attention are auto-detected from the GGUF architecture, so
-`Options.defaults()` works for most reranker models. Use `score` for a single pair and
-`scoreAll` to rank a batch of documents against one query.
-
-```java
-import io.gravitee.llama.cpp.*;
-import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
-import java.lang.foreign.Arena;
-import java.nio.file.Path;
-import java.util.Comparator;
-import java.util.List;
-
-public class RerankExample {
-    public static void main(String[] args) {
-        var arena = Arena.ofConfined();
-        String libPath = LlamaLibLoader.load();
-        LlamaRuntime.llama_backend_init();
-        LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
-
-        var model = new LlamaModel(arena, Path.of("models/reranker.gguf"), new LlamaModelParams(arena));
-        var reranker = new LlamaReranker(arena, model, LlamaReranker.Options.defaults());
-
-        String query = "What is the capital of France?";
-        List<String> documents = List.of(
-            "Paris is the capital and most populous city of France.",
-            "The Eiffel Tower is a landmark in Paris.",
-            "Bananas are a good source of potassium."
-        );
-
-        // One raw score array per document, in input order.
-        List<float[]> scores = reranker.scoreAll(query, documents);
-
-        // Rank documents by their first logit, highest first.
-        java.util.stream.IntStream.range(0, documents.size())
-            .boxed()
-            .sorted(Comparator.comparingDouble((Integer i) -> scores.get(i)[0]).reversed())
-            .forEach(i -> System.out.printf("%.4f  %s%n", scores.get(i)[0], documents.get(i)));
-
-        reranker.close();   // frees only the context; the model is owned by the caller
-        model.free();
-        LlamaRuntime.llama_backend_free();
-        arena.close();
-    }
-}
-```
-
-`score(query, document)` returns a `float[]` whose size is `reranker.nClsOut()` — typically
-`1` for BERT-style cross-encoders and `2` for chat-style rerankers. For models that need a
-structured prompt, supply a `RerankTemplate` (a `(query, document) -> String` lambda) via
-`Options.defaults().withTemplate(...)`; the default is `RerankTemplate.PLAIN`
-(`query + " " + document`).
-
-### Example 6: Reranking with Qwen3 and a custom RerankTemplate
-
-Chat-style rerankers like Qwen3-Reranker expect the (query, document) pair wrapped in a
-system/user prompt that asks the model to judge relevance. Provide that format as a
-`RerankTemplate`. Unlike a BERT cross-encoder (which emits a single raw logit), Qwen3-Reranker
-has a 2-class classifier head: `nClsOut() == 2` and `score` returns a softmax `float[2]` where
-index `0` is `P(relevant)`. That probability is still a perfectly good ranking score — sort by
-it descending to rerank a candidate set.
-
-```java
-import io.gravitee.llama.cpp.*;
-import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
-import java.lang.foreign.Arena;
-import java.nio.file.Path;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.IntStream;
-
-public class Qwen3RerankExample {
-    // Wraps the pair in Qwen3's chat format, instructing the model to answer yes/no.
-    static final RerankTemplate QWEN3_TEMPLATE = (query, document) ->
-        "<|im_start|>system\n" +
-        "Judge whether the Document is relevant to the Query. Answer 'yes' or 'no'." +
-        "<|im_end|>\n" +
-        "<|im_start|>user\n" +
-        "Query: " + query + "\n" +
-        "Document: " + document + "\n" +
-        "Relevant:<|im_end|>\n";
-
-    public static void main(String[] args) {
-        var arena = Arena.ofConfined();
-        String libPath = LlamaLibLoader.load();
-        LlamaRuntime.llama_backend_init();
-        LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
-
-        var model = new LlamaModel(arena, Path.of("models/reranker.gguf"), new LlamaModelParams(arena));
-        var reranker = new LlamaReranker(
-            arena,
-            model,
-            LlamaReranker.Options.defaults().withTemplate(QWEN3_TEMPLATE)
-        );
-
-        String query = "What is the capital of France?";
-        List<String> documents = List.of(
-            "Paris is the capital and most populous city of France.",
-            "The Eiffel Tower is a landmark in Paris.",
-            "Bananas are a good source of potassium."
-        );
-
-        List<float[]> scores = reranker.scoreAll(query, documents);
-
-        // Rank by P(relevant) = score[0], highest first.
-        IntStream.range(0, documents.size())
-            .boxed()
-            .sorted(Comparator.comparingDouble((Integer i) -> scores.get(i)[0]).reversed())
-            .forEach(i -> System.out.printf("P(relevant)=%.4f  %s%n", scores.get(i)[0], documents.get(i)));
-
-        reranker.close();
-        model.free();
-        LlamaRuntime.llama_backend_free();
-        arena.close();
-    }
-}
-```
-
-> **Classifier probabilities vs. raw scores.** Qwen3-Reranker's `score[0]` is a calibrated
-> probability in `[0, 1]`. BERT cross-encoders (`nClsOut() == 1`, Example 5) instead return a
-> single **unbounded logit** — larger means more relevant, but it is not a probability. Ranking
-> works the same way for both (sort descending); only apply `sigmoid(logit)` if you specifically
-> need a `[0, 1]` score from a single-logit model.
-
-### Example 7: Embeddings
-
-`LlamaEmbedder` turns text into a dense vector. Pooling and attention are auto-detected from
-the GGUF architecture (CLS/NON_CAUSAL for encoders, LAST/CAUSAL for decoders), so
-`Options.defaults()` covers most models. Use `embed` for a single string or `embedAll` to
-batch many texts through a single decode. Vectors are returned **un-normalised** — L2-normalise
-them yourself before computing cosine similarity.
-
-```java
-import io.gravitee.llama.cpp.*;
-import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
-import java.lang.foreign.Arena;
-import java.nio.file.Path;
-import java.util.List;
-
-public class EmbeddingExample {
-    static float[] l2normalize(float[] v) {
-        double sum = 0;
-        for (float f : v) sum += (double) f * f;
-        double norm = Math.sqrt(sum);
-        if (norm > 1e-9) for (int i = 0; i < v.length; i++) v[i] = (float) (v[i] / norm);
-        return v;
-    }
-
-    static double cosine(float[] a, float[] b) {
-        double dot = 0;
-        for (int i = 0; i < a.length; i++) dot += (double) a[i] * b[i];
-        return dot; // inputs are L2-normalised, so the dot product is the cosine
-    }
-
-    public static void main(String[] args) {
-        var arena = Arena.ofConfined();
-        String libPath = LlamaLibLoader.load();
-        LlamaRuntime.llama_backend_init();
-        LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
-
-        var model = new LlamaModel(arena, Path.of("models/embedding.gguf"), new LlamaModelParams(arena));
-        var embedder = new LlamaEmbedder(arena, model, LlamaEmbedder.Options.defaults());
-
-        System.out.println("embedding dimension: " + embedder.nEmbdOut());
-
-        List<float[]> embeddings = embedder.embedAll(List.of(
-            "The capital of France is Paris.",
-            "Paris is France's largest city.",
-            "Bananas are a good source of potassium."
-        ));
-        embeddings.forEach(EmbeddingExample::l2normalize);
-
-        System.out.printf("similar pair:   %.4f%n", cosine(embeddings.get(0), embeddings.get(1)));
-        System.out.printf("unrelated pair: %.4f%n", cosine(embeddings.get(0), embeddings.get(2)));
-
-        embedder.close();
-        model.free();
-        LlamaRuntime.llama_backend_free();
-        arena.close();
-    }
-}
-```
-
-### Example 8: Speculative Decoding
-
-Speculative decoding speeds up generation by having a cheap *drafter* propose several tokens that the
-target model verifies in a single pass. It's enabled per conversation via `setDraft` (draft model) or
-`setNgram` (prompt-lookup), works with both `DefaultLlamaIterator` and `BatchIterator`, and the output is
-unchanged — greedy stays lossless, sampling stays an exact draw of the target distribution. Track how
-well it's working with `state.acceptRate()`.
-
-```java
-// Draft with a small model (must share the target's vocab) — pass a context over the draft model:
-state.setDraft(draftContext, SpeculativeConfig.greedy(4));                  // greedy, fixed window
-state.setDraft(draftContext, SpeculativeConfig.greedyAdaptive(8, 1, 0.6f)); // greedy, stop early on low draft confidence
-state.setDraft(draftContext, new SpeculativeConfig(4, 0.8f, 40, 0.95f, 42));// sampling (temp/top-k/top-p/seed)
-
-// Or draft with no model at all — n-gram (prompt-lookup), best for repetitive output (code, JSON, RAG):
-state.setNgram(SpeculativeConfig.ngramGreedy(4, 2));                        // greedy
-state.setNgram(SpeculativeConfig.ngram(4, 2, 0.8f, 40, 0.95f, 42));         // sampling
-```
-
-A `SpeculativeConfig` can be built three interchangeable ways — pick whichever reads best:
-
-```java
-// 1. Factory presets (above): greedy / greedyAdaptive / ngramGreedy / ngram
-// 2. Fluent "withers" — start from a preset and override fields:
-SpeculativeConfig.greedy(8).withTemperature(0.8f).withTopK(40).withTopP(0.95f).withSeed(42);
-// 3. Builder:
-SpeculativeConfig.builder().nDraft(8).temperature(0.8f).topK(40).topP(0.95f).seed(42).build();
-```
-
-> **Note:** only memoryless sampling (temperature / top-k / top-p) is supported inside speculation, and
-> the distribution itself is computed by llama.cpp's native sampler — these settings just configure it.
-> For the fused `BatchIterator` path, size the target context with `nBatch >= sum(nDraft + 1)` across
-> sequences.
-
-## Build
-
-The build uses a **platform-specific Maven profile** to download the correct jextract tool and pre-built llama.cpp native libraries, generate the Java FFM bindings, format the code, apply license headers, and install the artifact to your local Maven repository.
-
-**macOS (Apple Silicon):**
-
-```bash
-cd llamaj.cpp/
+# macOS (Apple Silicon)
 mvn prettier:write license:format clean generate-sources -Pmacosx-aarch64 install
-```
 
-**Linux (x86_64):**
-
-```bash
-cd llamaj.cpp/
+# Linux (x86_64) — then export the library path at runtime:
 mvn prettier:write license:format clean generate-sources -Plinux-x86_64 install
+export LD_LIBRARY_PATH="$HOME/.llama.cpp:$LD_LIBRARY_PATH"
 ```
 
-> On Linux, you also need to set the library path at runtime:
-> ```bash
-> export LD_LIBRARY_PATH="$HOME/.llama.cpp:$LD_LIBRARY_PATH"
-> ```
+For other platforms (Windows, ARM, CUDA, …) or your own llama.cpp build, see **[Custom Builds & Platform Support](./docs/custom-builds/README.md)**.
 
-## Run
+## Run the bundled CLI
 
 ```bash
-$ mvn exec:java -Dexec.mainClass=io.gravitee.llama.cpp.Main \
-    -Dexec.args="--model /path/to/model/model.gguf --system 'You are a helpful assistant. Answer question to the best of your ability'"
+java -jar llamaj.cpp-<version>.jar --model models/model.gguf \
+  --system 'You are a helpful assistant.'
 ```
 
-or
+## License & attribution
 
-```bash
-$ java --enable-preview -jar llamaj.cpp-<version>.jar \
-  --model models/model.gguf \
-  --system 'You are a helpful assistant. Answer question to the best of your ability'
-```
+- llamaj.cpp is licensed under the [Apache License 2.0](./LICENSE.txt).
+- It binds to the native **llama.cpp / ggml** libraries, which are [MIT-licensed](./licenses/LICENSE-llama-cpp).
 
-On linux, don't forget to link your libraries with the environment variable below:
-```bash
-$ export LD_LIBRARY_PATH="$HOME/.llama.cpp:$LD_LIBRARY_PATH"
-```
+## Community
 
-There are plenty of models on HuggingFace, we suggest the one [here](https://huggingface.co/Qwen/Qwen3-0.6B-GGUF)
-
-### Usage
-```
-Usage: java -jar llamaj.cpp-<version>.jar --model <path_to_gguf_model> [options...]
-Options:
---system <message>       : System message (default: "You are a helpful AI assistant.")
---n_gpu_layers <int>     : Number of GPU layers (default: 999)
---use_mlock <boolean>    : Use mlock (default: true)
---use_mmap <boolean>     : Use mmap (default: true)
---rpc <endpoints>        : Comma-separated RPC server endpoints for distributed inference
-                           (e.g., "127.0.0.1:50052,192.168.1.11:50052")
-                           When set, weights are offloaded exclusively to the remote servers
---temperature <float>    : Sampler temperature (default: 0.4)
---min_p <float>          : Sampler min_p (default: 0.1)
---min_p_window <int>     : Sampler min_p_window (default: 40)
---top_k <int>            : Sampler top_k (default: 10)
---top_p <float>          : Sampler top_p (default: 0.2)
---top_p_window <int>     : Sampler top_p_window (default: 10)
---seed <long>            : Sampler seed (default: random)
---n_ctx <int>            : Context size (default: 512)
---n_batch <int>          : Batch size (default: 512)
---n_seq_max <int>        : Max sequence length (default: 512)
---quota <int>            : Iterator quota (default: 512)
---n_keep <int>         : Tokens to keep when exceeding ctx size (default: 256)
---log_level <level>      : Logging level (ERROR, WARN, INFO, DEBUG, default: ERROR)
-```
-
-## Use your own llama.cpp build
-
-1. Clone `llama.cpp` repository
-
-> Make sure the jextract folder is in the same path level as your repository
-
-```bash
-$ git clone https://github.com/ggml-org/llama.cpp
-$ cd llama.cpp
-```
-
-2. Compile sources
-
-> Make sure you have gcc / g++ compiler
-
-```bash
-$ gcc --help
-$ g++ --help
-```
-
-On Linux:
-```bash
-$ cmake -B build
-$ cmake --build build --config Release -j $(nproc)  
-```
-
-On MacOs:
-```bash
-$ cmake -B build
-$ cmake --build build --config Release  -j $(sysctl -n hw.ncpu)
-```
-
-If you wish to build llama.cpp with particular configuration (CUDA, OpenBLAS, AVX2, AVX512, ...)
-Please refer to the [llama.cpp](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md) documentation
-
-3. Link sources
-
-You can use the environment variable `LLAMA_CPP_LIB_PATH=/path/to/llama.cpp/build/bin/`
-This will directly load the dynamically shared object library files (`.so` for linux, `.dylib` for macos) 
-You can also decide to copy these files into a temporary folder using the environment variable `LLAMA_CPP_USE_TMP_LIB_PATH=true`
-The path temporary file will be used to load the shared object libraries
-
-## Beyond Apple M-Series and Linux x86_64
-
-To add support for other platforms (Windows, ARM, CUDA, etc.), follow this approach:
-
-### 1. Build llama.cpp
-
-Clone and build llama.cpp for your target platform:
-
-```bash
-git clone https://github.com/ggerganov/llama.cpp.git
-cd llama.cpp
-cmake -B build
-cmake --build build --config Release
-```
-
-### 2. Generate FFM API Bindings with jextract
-
-Download jextract for your platform from [OpenJDK early-access builds](https://download.java.net/java/early_access/jextract/25/2/), then generate the Java bindings:
-
-```bash
-# Example for Windows x86_64
-jextract -t io.gravitee.llama.cpp.windows.x86_64 \
-  --include-dir /path/to/llama.cpp/ggml/include \
-  --include-dir /path/to/llama.cpp/include \
-  --output src/main/java \
-  --header-class-name llama_h \
-  /path/to/llama.cpp/tools/mtmd/mtmd.h \
-  /path/to/llama.cpp/tools/mtmd/mtmd-helper.h \
-  /path/to/llama.cpp/include/llama.h \
-  /path/to/llama.cpp/ggml/include/ggml-rpc.h
-```
-
-### 3. Post-process Generated Sources
-
-Check the generated sources and apply any necessary fixes (e.g., visibility modifiers, fully-qualified method calls).
-
-### 4. Build the Bindings JAR
-
-Compile the generated sources and build a JAR using your own build system (Maven, Gradle, etc.).
-
-### 5. Integrate into Your Classpath
-
-Add the generated JAR to your project's classpath and ensure the native libraries from step 1 are available at runtime.
+Questions and discussion: [Gravitee Community Forum](https://community.gravitee.io?utm_source=readme).

--- a/README.md
+++ b/README.md
@@ -482,6 +482,40 @@ public class EmbeddingExample {
 }
 ```
 
+### Example 8: Speculative Decoding
+
+Speculative decoding speeds up generation by having a cheap *drafter* propose several tokens that the
+target model verifies in a single pass. It's enabled per conversation via `setDraft` (draft model) or
+`setNgram` (prompt-lookup), works with both `DefaultLlamaIterator` and `BatchIterator`, and the output is
+unchanged — greedy stays lossless, sampling stays an exact draw of the target distribution. Track how
+well it's working with `state.acceptRate()`.
+
+```java
+// Draft with a small model (must share the target's vocab) — pass a context over the draft model:
+state.setDraft(draftContext, SpeculativeConfig.greedy(4));                  // greedy, fixed window
+state.setDraft(draftContext, SpeculativeConfig.greedyAdaptive(8, 1, 0.6f)); // greedy, stop early on low draft confidence
+state.setDraft(draftContext, new SpeculativeConfig(4, 0.8f, 40, 0.95f, 42));// sampling (temp/top-k/top-p/seed)
+
+// Or draft with no model at all — n-gram (prompt-lookup), best for repetitive output (code, JSON, RAG):
+state.setNgram(SpeculativeConfig.ngramGreedy(4, 2));                        // greedy
+state.setNgram(SpeculativeConfig.ngram(4, 2, 0.8f, 40, 0.95f, 42));         // sampling
+```
+
+A `SpeculativeConfig` can be built three interchangeable ways — pick whichever reads best:
+
+```java
+// 1. Factory presets (above): greedy / greedyAdaptive / ngramGreedy / ngram
+// 2. Fluent "withers" — start from a preset and override fields:
+SpeculativeConfig.greedy(8).withTemperature(0.8f).withTopK(40).withTopP(0.95f).withSeed(42);
+// 3. Builder:
+SpeculativeConfig.builder().nDraft(8).temperature(0.8f).topK(40).topP(0.95f).seed(42).build();
+```
+
+> **Note:** only memoryless sampling (temperature / top-k / top-p) is supported inside speculation, and
+> the distribution itself is computed by llama.cpp's native sampler — these settings just configure it.
+> For the fused `BatchIterator` path, size the target context with `nBatch >= sum(nDraft + 1)` across
+> sequences.
+
 ## Build
 
 The build uses a **platform-specific Maven profile** to download the correct jextract tool and pre-built llama.cpp native libraries, generate the Java FFM bindings, format the code, apply license headers, and install the artifact to your local Maven repository.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,39 @@
+# llamaj.cpp — Capabilities
+
+One folder per capability, one page each. Start with **[Getting Started](./getting-started/README.md)** — every other page builds on it.
+
+### Core
+| Capability | What it does |
+| --- | --- |
+| [Getting Started](./getting-started/README.md) | Initialize the runtime, load a GGUF model, build a context, and tokenize — plus the `Arena`/`Freeable` resource model. |
+| [Text Generation & Sampling](./text-generation/README.md) | Stream a conversation token-by-token via `ConversationState` + `DefaultLlamaIterator`, controlled by a `LlamaSampler` chain, max tokens, and stop strings. |
+| [Chat Templates](./chat-templates/README.md) | Render role-tagged messages into a model-specific prompt with `LlamaTemplate` and the `Role` enum. |
+| [Log Probabilities](./logprobs/README.md) | Collect per-token logprobs (sampled token + top-N alternatives) via `setTopLogprobs`. |
+
+### Scale & serve
+| Capability | What it does |
+| --- | --- |
+| [Parallel Conversations](./parallel-conversations/README.md) | Decode many conversations through one shared context with `BatchIterator`, isolated by sequence id. |
+| [Speculative Decoding](./speculative-decoding/README.md) | Draft→verify→accept speedup via a draft model or n-gram prompt-lookup; greedy (lossless) or sampling (exact). |
+| [Distributed Inference (RPC)](./distributed-inference/README.md) | Offload layers and KV-cache to remote `rpc-server` backends across machines. |
+| [Quantized KV Cache](./quantized-kv-cache/README.md) | Shrink KV-cache memory by quantizing the K/V cache `ggml_type` (flash attention for a quantized V cache). |
+
+### Retrieval & multimodal
+| Capability | What it does |
+| --- | --- |
+| [Embeddings](./embeddings/README.md) | Turn text into dense vectors with `LlamaEmbedder` over an embedding-mode context. |
+| [Reranking](./reranking/README.md) | Score documents against a query with `LlamaReranker` (BERT cross-encoders and Qwen3-style rerankers). |
+| [Multimodal (Vision & Audio)](./multimodal/README.md) | Attach images and audio to a prompt via `MtmdContext` (mmproj/clip projector). |
+
+### Advanced generation
+| Capability | What it does |
+| --- | --- |
+| [Reasoning & Tool Calls](./reasoning-and-tool-calls/README.md) | Tag reasoning / answer / tool-call sections during generation for per-section token counts and `TOOL_CALL` detection. |
+| [LoRA Adapters](./lora-adapters/README.md) | Load a GGUF LoRA adapter and attach it to a model with `initLoraAdapter`. |
+
+### Operations
+| Capability | What it does |
+| --- | --- |
+| [Devices & Memory](./device-and-memory/README.md) | Enumerate backends/devices, query CPU/GPU/RPC memory, read model dims, and read performance metrics. |
+| [Logging](./logging/README.md) | Install a custom log callback over llama.cpp/ggml and filter by level. |
+| [Custom Builds & Platform Support](./custom-builds/README.md) | Build llama.cpp and regenerate the jextract FFM bindings for other platforms (Windows, ARM, CUDA, …). |

--- a/docs/chat-templates/README.md
+++ b/docs/chat-templates/README.md
@@ -1,0 +1,58 @@
+# Chat Templates
+
+> Render a list of role-tagged chat messages into a single prompt string using the model's built-in Jinja2 chat template.
+
+## Overview
+Instruction-tuned GGUF models ship with a chat template (e.g. Qwen3's `<|im_start|>` / `<|im_end|>` markers) that defines how `system`, `user`, and `assistant` turns are formatted. `LlamaTemplate` reads that template from the model and applies it to a `LlamaChatMessages` list, returning the formatted prompt string you then tokenize and feed to a `LlamaContext`. Use it whenever you generate from a chat/instruct model so the prompt matches what the model was trained on.
+
+## Key types
+- `LlamaTemplate` — wraps the model's chat template; `applyTemplate(...)` formats messages, `templateString()` returns the raw Jinja2 template.
+- `LlamaChatMessage` — one message, built from an `Arena`/allocator, a `Role`, and a `String` content.
+- `LlamaChatMessages` — an ordered, contiguous native array of `LlamaChatMessage` passed to `applyTemplate`.
+- `Role` — enum of the supported roles: `SYSTEM`, `USER`, `ASSISTANT`.
+
+## Usage
+```java
+try (Arena arena = Arena.ofConfined()) {
+  var model = new LlamaModel(arena, Path.of("models/model.gguf"), new LlamaModelParams(arena));
+  var contextParams = new LlamaContextParams(arena).nCtx(2048).nBatch(512);
+
+  // Build the conversation
+  var messages = new LlamaChatMessages(
+    arena,
+    List.of(
+      new LlamaChatMessage(arena, Role.SYSTEM, "You are a helpful assistant"),
+      new LlamaChatMessage(arena, Role.USER, "What's the capital of France?")
+    )
+  );
+
+  // Apply the model's chat template -> formatted prompt string
+  var template = new LlamaTemplate(model);
+  String prompt = template.applyTemplate(arena, messages, contextParams.nCtx());
+
+  // (optional) inspect the raw Jinja2 template the model ships with
+  String raw = template.templateString(); // null if the model has no template
+
+  System.out.println(prompt); // feed `prompt` to tokenization / generation
+}
+```
+
+## Options
+| Knob | Where | Meaning |
+| --- | --- | --- |
+| `Role.SYSTEM` / `Role.USER` / `Role.ASSISTANT` | `new LlamaChatMessage(arena, role, content)` | The role tag rendered by the template; mapped to native labels `"system"`, `"user"`, `"assistant"`. |
+| `nCtx` | `applyTemplate(arena, messages, nCtx)` | Initial size of the output buffer; the call auto-grows and retries if the rendered prompt is longer. |
+
+## Notes
+- `applyTemplate` always renders with the add-generation-prompt flag enabled, so the output ends with the assistant turn opener ready for generation.
+- The buffer starts at `nCtx` chars; if the template needs more, `LlamaTemplate` reallocates to the required length and renders again, so passing your context size is safe.
+- A negative result from the native call raises `IllegalStateException("failed to apply the chat template.")`.
+- `templateString()` returns `null` when the model carries no embedded chat template; otherwise it is the raw Jinja2 source (useful for debugging which markers a model expects).
+- All three types extend `MemorySegmentAware` and allocate from the supplied `Arena`/`SegmentAllocator`; scope them in a try-with-resources `Arena.ofConfined()` so native memory is freed when the arena closes. `LlamaChatMessages` copies each message struct into one contiguous native array, so keep the messages alive for the duration of the call.
+- `Role.fromLabel(label)` throws `IllegalArgumentException("Invalid role: ...")` for unknown labels; only the three roles above are supported.
+
+## See also
+- [Getting Started](../getting-started/README.md) — load a model and create a context before templating.
+- [Text Generation & Sampling](../text-generation/README.md) — tokenize the templated prompt and generate a response.
+- [Reasoning & Tool Calls](../reasoning-and-tool-calls/README.md) — structured chat with reasoning traces and tool invocations.
+- [Multimodal (Vision & Audio)](../multimodal/README.md) — chat messages combined with image/audio inputs.

--- a/docs/custom-builds/README.md
+++ b/docs/custom-builds/README.md
@@ -1,0 +1,126 @@
+# Custom Builds & Platform Support
+
+> Build the llama.cpp native libraries and regenerate the jextract FFM bindings for platforms beyond the two shipped out of the box (macOS Apple Silicon and Linux x86_64).
+
+## Overview
+llamaj.cpp ships pre-built bindings and native libraries for **macOS `aarch64`** and **Linux `x86_64`** only, selected at build time by a Maven profile. To run on anything else (Windows, ARM Linux, x86_64 macOS, or a CUDA / OpenBLAS / AVX-512 build), you compile llama.cpp yourself, regenerate the Java FFM bindings with `jextract`, fix up a couple of generated files, package them into a JAR, and drop the matching native libraries where `LlamaLibLoader` can find them. The runtime is platform-agnostic: `OperatingSystem` already includes `WINDOWS` and `LlamaLibLoader` already knows how to load `.dll`/`.so`/`.dylib` — the only missing pieces for a new target are the generated bindings and the native libs.
+
+## Key types
+- `LlamaLibLoader` — resolves and `System.load()`s the native libraries; `load()` (auto-detect) and `load(String path)` return the directory that was loaded.
+- `Platform` / `PlatformResolver` — `PlatformResolver.platform()` detects OS + arch; `Platform.getPackage()` returns the dotted name (e.g. `windows.x86_64`) used for **both** the jextract target package and the native-lib resource folder.
+- `OperatingSystem` — supported OS values: `MAC_OS_X` (`macosx`), `LINUX` (`linux`), `WINDOWS` (`windows`).
+- `Architecture` — supported arch values: `X86_64` (`x86_64`), `AARCH64` (`aarch64`).
+- `LlamaRuntime` — backend lifecycle: `llama_backend_init()`, `ggml_backend_load_all_from_path(arena, libPath)`, `llama_backend_free()`.
+
+## Usage
+
+### Shipped platforms — one Maven command
+The `macosx-aarch64` / `linux-x86_64` profiles download the right `jextract`, download the matching pre-built llama.cpp release (pinned by the `llama.cpp.version` property, currently `b9673`), run `jextract`, post-process, format, and install the artifact:
+
+```bash
+# macOS (Apple Silicon)
+mvn prettier:write license:format clean generate-sources -Pmacosx-aarch64 install
+
+# Linux (x86_64) — then point the loader at the libs at runtime
+mvn prettier:write license:format clean generate-sources -Plinux-x86_64 install
+export LD_LIBRARY_PATH="$HOME/.llama.cpp:$LD_LIBRARY_PATH"
+```
+
+### A new platform (e.g. Windows x86_64) — manual pipeline
+
+```bash
+# 1. Build llama.cpp for the target (add -DGGML_CUDA=ON etc. as needed — see llama.cpp/docs/build.md)
+git clone https://github.com/ggml-org/llama.cpp.git
+cd llama.cpp
+cmake -B build
+cmake --build build --config Release
+
+# 2. Generate the FFM bindings with jextract (from OpenJDK EA build 25/2).
+#    The target package MUST be io.gravitee.llama.cpp.<os>.<arch> — it has to match
+#    Platform.getPackage() for the detected platform (here: windows.x86_64).
+jextract -t io.gravitee.llama.cpp.windows.x86_64 \
+  --include-dir /path/to/llama.cpp/ggml/include \
+  --include-dir /path/to/llama.cpp/include \
+  --output src/main/java \
+  --header-class-name llama_h \
+  /path/to/llama.cpp/tools/mtmd/mtmd.h \
+  /path/to/llama.cpp/tools/mtmd/mtmd-helper.h \
+  /path/to/llama.cpp/include/llama.h \
+  /path/to/llama.cpp/ggml/include/ggml-rpc.h
+
+# 3. Post-process the generated sources (see Notes): make llama_h_1 / llama_h_2 public,
+#    and fully-qualify ggml_backend_graph_copy.layout() in the new package.
+
+# 4. Compile + package the generated sources into a bindings JAR (Maven/Gradle/javac).
+
+# 5. Place the native libraries (.dll for Windows) under the resource folder that
+#    matches the package — src/main/resources/windows/x86_64/ — so they get packaged
+#    into the JAR and resolved by LlamaLibLoader at runtime.
+```
+
+### Consuming a custom build at runtime
+This mirrors every integration test (`LlamaLibLoader.load()` then `ggml_backend_load_all_from_path`):
+
+```java
+import io.gravitee.llama.cpp.*;
+import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
+import java.lang.foreign.Arena;
+
+var arena = Arena.ofConfined();
+
+// Resolve + System.load() the native libs, then init the backend and load plugins.
+String libPath = LlamaLibLoader.load();              // returns the loaded directory
+LlamaRuntime.llama_backend_init();
+LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
+
+// ... load model / context / sampler exactly as on a shipped platform ...
+
+LlamaRuntime.llama_backend_free();
+arena.close();
+```
+
+Point the loader at libraries built outside the JAR by exporting `LLAMA_CPP_LIB_PATH`:
+
+```bash
+export LLAMA_CPP_LIB_PATH=/path/to/llama.cpp/build/bin
+java --enable-preview --enable-native-access=ALL-UNNAMED -jar your-app.jar ...
+```
+
+## Options
+
+### Helper scripts (used by the Maven profiles, runnable standalone)
+| Script | Purpose |
+| --- | --- |
+| `scripts/download-jextract.sh -o <os> -p <platform> [-d <dir>]` | Download the matching `jextract` EA build into `.jextract/` (only `macosx/aarch64`, `linux/x86_64` are wired up). |
+| `scripts/download-native-libraries.sh -o <os> -p <platform> -v <version> -d <dest>` | Download a pre-built llama.cpp release and flatten the `.so`/`.dylib` files into `<dest>/<os>/<platform>`. |
+
+### `jextract` flags (per the README / pom invocation)
+| Flag | Value |
+| --- | --- |
+| `-t` | Target package `io.gravitee.llama.cpp.<os>.<arch>` (must equal `Platform.getPackage()`). |
+| `--include-dir` | `…/ggml/include` and `…/include` from your llama.cpp checkout. |
+| `--header-class-name` | `llama_h`. |
+| `--output` | Source output dir (e.g. `src/main/java` or `target/generated-sources`). |
+| headers | `mtmd.h`, `mtmd-helper.h`, `llama.h`, `ggml-rpc.h`. |
+
+### Native-library resolution (`LlamaLibLoader`)
+| Mechanism | Effect |
+| --- | --- |
+| `LLAMA_CPP_LIB_PATH` (env var) | Load `.so`/`.dylib`/`.dll` directly from this directory; takes priority over bundled resources. |
+| `-DLLAMA_CPP_USE_TMP_LIB_PATH=true` (JVM system property) | Copy the libraries into a fresh temp dir before loading instead of caching in `~/.llama.cpp`. |
+| (default) | Extract the libs bundled under the `Platform.getPackage()` resource folder into `~/.llama.cpp` and load from there. |
+
+## Notes
+- **Target package is load-bearing.** `jextract -t` and the native-lib folder must both equal `Platform.getPackage()` (`<osName>.<arch>`, e.g. `windows.x86_64`). At runtime `LlamaLibLoader` looks for native libs under exactly that package (`os.getOsName() + "." + arch.getArch()`); a mismatch means the libs are never found.
+- **Post-processing is required** because jextract emits package-private overflow classes. The shipped profiles: (1) rewrite `class llama_h_1 …`/`class llama_h_2 …` to `public class …`, and (2) fully-qualify `ggml_backend_graph_copy.layout()` to `io.gravitee.llama.cpp.<os>.<arch>.ggml_backend_graph_copy.layout()`. Re-apply the equivalent fixes for your generated package, then verify the sources compile.
+- **`jextract` versions are pinned** to the OpenJDK 25/2 early-access build; use the same major to keep the generated `MethodHandle`/`MemoryLayout` API compatible with the hand-written wrappers. Requires **Java 25** and `--enable-preview --enable-native-access=ALL-UNNAMED` at runtime.
+- **The loader already supports Windows** (`.dll`) and arbitrary arches at the Java level — `OperatingSystem.WINDOWS` and the `DLL_EXT` branch exist. Only the generated bindings + native binaries are missing for an unsupported target.
+- **Linux plugin layout.** On Linux, `LlamaLibLoader` deliberately loads only soname-versioned files (`libfoo.so.N`) and skips backend plugins (`libggml-cpu/cuda/…`); those are dlopen'd by `ggml_backend_load_all_from_path`. Keep the full release layout (don't rename/strip versions) so the backend registry resolves to a single instance. Set `LD_LIBRARY_PATH=$HOME/.llama.cpp` so NEEDED dependencies resolve.
+- **Building with accelerators** (CUDA, OpenBLAS, AVX2/AVX-512, Vulkan, …) is a llama.cpp cmake concern — pass the relevant `-D…=ON` flags; see llama.cpp's `docs/build.md`. The bindings themselves do not change, only the native libraries you ship.
+- **Resource lifecycle** is identical to the shipped platforms: `model.free()`, `context.free()`, `sampler.free()`, then `LlamaRuntime.llama_backend_free()` and `arena.close()`.
+
+## See also
+- [Getting Started](../getting-started/README.md) — first run on a shipped platform; backend init and `LlamaLibLoader.load()`.
+- [Distributed Inference (RPC)](../distributed-inference/README.md) — uses the `ggml-rpc.h` binding that this build includes.
+- [Devices & Memory](../device-and-memory/README.md) — selecting backends/devices once the native libs are loaded.
+- [Logging](../logging/README.md) — surface native-library load and backend-registration diagnostics.

--- a/docs/device-and-memory/README.md
+++ b/docs/device-and-memory/README.md
@@ -1,0 +1,97 @@
+# Devices & Memory
+
+> Discover the GGML backends/devices llama.cpp registered, query CPU/GPU/RPC memory, read model dimensions, and inspect generation performance.
+
+## Overview
+These utilities let you introspect the runtime before and after a model is loaded: enumerate registered backends and devices (`BackendRegistry`), measure available memory on CPU RAM, the best local GPU, or remote RPC servers, cheaply read a GGUF model's dimensions without allocating its weights (`LlamaModelDims`), and read throughput/timing metrics from a running iterator (`LlamaPerformance`). Use them to drive capacity planning (will this model fit?), pick a device/`SplitMode`, or surface tokens/sec to users.
+
+## Key types
+- `BackendRegistry` — static facade: `listBackends()`, `listDevices()`, `supportsRpc()`, `loadBackend()`, `addRpcServer(s)()`, `queryRpcMemory()`, `printSummary()`.
+- `GgmlBackendInfo` — record `(String name, long index)` for one registered backend (CPU, Metal, CUDA, RPC, ...).
+- `GgmlDeviceInfo` — record `(String name, String description, long index, String backendName)` for one device.
+- `CpuMemoryQuery` — `query()` returns `CpuMemoryInfo(freeBytes, totalBytes)` from the JDK MXBean (nullable, never throws).
+- `GpuMemoryQuery` — `queryBest()` returns `GpuMemoryInfo(freeBytes, totalBytes)` for the GPU with most free VRAM (nullable).
+- `RpcMemoryQuery` — `queryAll(List<String> endpoints)` returns aggregated `RpcMemoryInfo(freeBytes, totalBytes, serverCount)` (nullable).
+- `LlamaModelDims` — record `(totalWeightBytes, nLayers, nHead, nHeadKv, headDim)`; `loadFrom(Path)` reads GGUF metadata without allocating weights.
+- `LlamaPerformance` — `(ContextPerformance context, SamplerPerformance sampler)`; obtained via `LlamaIterator.getPerformance()`.
+- `SplitMode` — `NONE`, `LAYER`, `ROW` (multi-GPU split strategy on `LlamaModelParams`).
+- `AttentionType` — `UNSPECIFIED`, `CAUSAL`, `NON_CAUSAL` (on `LlamaContextParams`).
+
+## Usage
+```java
+import io.gravitee.llama.cpp.*;
+import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
+import java.lang.foreign.Arena;
+import java.nio.file.Path;
+
+// 1. Initialise the runtime and register every backend in the lib directory.
+String libPath = LlamaLibLoader.load();
+LlamaRuntime.llama_backend_init();
+try (Arena arena = Arena.ofConfined()) {
+  LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
+
+  // 2. Enumerate backends and devices.
+  for (GgmlBackendInfo backend : BackendRegistry.listBackends()) {
+    System.out.println(backend); // e.g. GgmlBackendInfo[name=Metal, index=1]
+  }
+  for (GgmlDeviceInfo device : BackendRegistry.listDevices()) {
+    System.out.println(device);  // name, description, index, backend
+  }
+  BackendRegistry.printSummary(); // backends + devices + RPC/GPU offload flags
+
+  // 3. Query memory: GPU first, fall back to system RAM.
+  GpuMemoryQuery.GpuMemoryInfo gpu = GpuMemoryQuery.queryBest();
+  if (gpu != null) {
+    System.out.printf("GPU free=%d total=%d%n", gpu.freeBytes(), gpu.totalBytes());
+  } else {
+    CpuMemoryQuery.CpuMemoryInfo cpu = CpuMemoryQuery.query(); // null on failure
+    System.out.printf("CPU free=%d total=%d%n", cpu.freeBytes(), cpu.totalBytes());
+  }
+
+  // 4. Estimate model footprint WITHOUT loading the weights (O(ms)).
+  LlamaModelDims dims = LlamaModelDims.loadFrom(Path.of("/path/to/model.gguf"));
+  System.out.printf(
+    "weightBytes=%,d nLayers=%d nHead=%d nHeadKv=%d headDim=%d%n",
+    dims.totalWeightBytes(), dims.nLayers(),
+    dims.nHead(), dims.nHeadKv(), dims.headDim()
+  );
+}
+LlamaRuntime.llama_backend_free();
+
+// 5. After running an iterator, read throughput/timing metrics.
+//    (iterator obtained from the text-generation path)
+// LlamaPerformance perf = iterator.getPerformance();
+// perf.generationTokensPerSecond();
+// perf.promptTokensPerSecond();
+// perf.totalProcessingTimeMs();
+// perf.context().tokensGenerated();
+// perf.sampler().averageSamplingTimeMs();
+```
+
+## Options
+
+| Type / method | Values / shape | Notes |
+|---|---|---|
+| `SplitMode` | `NONE`, `LAYER`, `ROW` | `LlamaModelParams.splitMode(...)`; how layers/KV are spread across GPUs. |
+| `AttentionType` | `UNSPECIFIED`, `CAUSAL`, `NON_CAUSAL` | `LlamaContextParams.attentionType(...)`; encoder vs decoder attention. |
+| `GpuMemoryQuery.queryBest()` | `GpuMemoryInfo(freeBytes, totalBytes)` \| `null` | Picks the GPU/GPU_UMA device with the most free VRAM. |
+| `CpuMemoryQuery.query()` | `CpuMemoryInfo(freeBytes, totalBytes)` \| `null` | JDK `OperatingSystemMXBean`; no native lib needed. |
+| `RpcMemoryQuery.queryAll(endpoints)` | `RpcMemoryInfo(freeBytes, totalBytes, serverCount)` \| `null` | Sums free/total across de-duplicated `host:port` servers. |
+| `BackendRegistry.queryRpcMemory(arena, endpoint, device)` | `RpcDeviceMemory(freeBytes, totalBytes)` | Single remote device; `usedBytes()` derived. |
+| `LlamaPerformance.context()` | `ContextPerformance(startTimeMs, loadTimeMs, promptEvalTimeMs, evalTimeMs, promptTokensEvaluated, tokensGenerated, tokensReused)` | Timing + token counts. |
+| `LlamaPerformance.sampler()` | `SamplerPerformance(samplingTimeMs, sampleCount)` | `averageSamplingTimeMs()` derived. |
+
+## Notes
+- `BackendRegistry`, `GpuMemoryQuery`, `RpcMemoryQuery`, and `LlamaModelDims` use FFM bindings: call `LlamaRuntime.llama_backend_init()` and `ggml_backend_load_all_from_path(...)` first, then `llama_backend_free()` at shutdown. `CpuMemoryQuery` is pure JDK and needs no native init.
+- Memory queries return `null` on any failure (no GPU present, native lib not loaded, network error) and never throw — always null-check.
+- `LlamaModelDims.loadFrom(Path)` loads with `noAlloc(true)`, `useExtraBufferTypes(false)`, `useMmap(false)`, `nGpuLayers(0)` and frees the model immediately, so it does not allocate weight bytes. It is safe to call even after all backends are registered (avoids the `GGML_ASSERT(!ml.no_alloc)` crash) and is idempotent.
+- `addRpcServer`/`addRpcServers` perform a TCP pre-flight check and throw `LlamaException` on unreachable hosts; the remote `rpc-server` must match the client llama.cpp version or the native client will `abort()` the process. RPC devices are NOT in the global registry — pass the returned `MemorySegment` handles to `LlamaModelParams.devices(arena, list)`.
+- `LlamaPerformance` is read from a live `LlamaIterator` via `getPerformance()`; derived getters return `0` when no prompt eval / generation / sampling occurred.
+- `humanReadable` formatting (B/KiB/MiB/GiB/TiB) is built into `RpcDeviceMemory.toString()`; the memory records elsewhere expose raw bytes via `freeBytes()` / `totalBytes()`.
+- All `Arena`-taking methods allocate in the supplied arena; use `Arena.ofConfined()` in a try-with-resources to bound native lifetime.
+
+## See also
+- [Distributed Inference (RPC)](../distributed-inference/README.md) — register and split a model across remote RPC servers.
+- [Getting Started](../getting-started/README.md) — backend init, model/context setup, and the iterator that exposes `getPerformance()`.
+- [Custom Builds & Platform Support](../custom-builds/README.md) — which backends (Metal, CUDA, CPU) get loaded per platform.
+- [Quantized KV Cache](../quantized-kv-cache/README.md) — reduce context memory once you know the model dimensions.

--- a/docs/distributed-inference/README.md
+++ b/docs/distributed-inference/README.md
@@ -1,0 +1,115 @@
+# Distributed Inference (RPC)
+
+> Offload a model's layers and KV-cache to one or more remote `rpc-server` backends so inference runs across several machines.
+
+## Overview
+llama.cpp ships an `rpc-server` binary that exposes a machine's GPU/CPU as a network backend. llamaj.cpp lets you register those endpoints as devices and pin model offloading to them, so the heavy weights live on the remote nodes instead of (or in addition to) the local GPU. Use this when a model is too large for one machine, or to pool VRAM across a cluster. When several servers are registered with `splitMode=LAYER`, llama.cpp distributes layers proportionally to each server's free VRAM.
+
+## Key types
+- `BackendRegistry` — static helper to discover backends/devices and register RPC servers (`supportsRpc`, `addRpcServer`, `addRpcServers`, `queryRpcMemory`, `printSummary`).
+- `BackendRegistry.RpcDeviceMemory` — record `(long freeBytes, long totalBytes)` with `usedBytes()`, for a single remote device.
+- `RpcMemoryQuery` — pre-flight, registration-free aggregate VRAM check across endpoints; `queryAll(List<String>)` returns `null` on any failure (never throws).
+- `RpcMemoryQuery.RpcMemoryInfo` — record `(long freeBytes, long totalBytes, int serverCount)` summed across all servers.
+- `LlamaModelParams` — model load params; `rpcServers(...)`, `devices(...)`, `nGpuLayers(...)`, `splitMode(...)`.
+- `SplitMode` — `NONE`, `LAYER`, `ROW` (how layers/KV are split across devices).
+
+## Usage
+
+Start one or more RPC server nodes first. The helper script downloads the matching prebuilt `rpc-server` and runs it (defaults to `0.0.0.0:50052`, Metal-only on macOS):
+
+```bash
+# On each remote machine (or another terminal)
+./scripts/start-rpc-server.sh                       # 0.0.0.0:50052
+./scripts/start-rpc-server.sh -H 127.0.0.1 -p 50053 # custom host/port
+./scripts/start-rpc-server.sh -d CPU                # force CPU device
+```
+
+Then point the client at it. Registering an RPC server returns its device handles, which you pass to `devices(...)` so offloading targets only the remote nodes:
+
+```java
+import io.gravitee.llama.cpp.*;
+import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
+import java.lang.foreign.Arena;
+import java.nio.file.Path;
+
+public class RpcExample {
+  public static void main(String[] args) {
+    var arena = Arena.ofConfined();
+
+    // Initialize runtime (loads native libs incl. the RPC backend plugin)
+    String libPath = LlamaLibLoader.load();
+    LlamaRuntime.llama_backend_init();
+
+    if (!BackendRegistry.supportsRpc()) {
+      throw new IllegalStateException("RPC backend not available in this build");
+    }
+
+    // Optional pre-flight: check pooled free VRAM before loading the model
+    var mem = RpcMemoryQuery.queryAll(java.util.List.of("127.0.0.1:50052"));
+    if (mem != null) {
+      System.out.printf("RPC pool: %d bytes free across %d server(s)%n",
+        mem.freeBytes(), mem.serverCount());
+    }
+
+    // Register remote RPC servers -- returns their device handles
+    var rpcDevices = BackendRegistry.addRpcServer(arena, "127.0.0.1:50052");
+
+    // Print all discovered backends and devices (diagnostics)
+    BackendRegistry.printSummary();
+
+    // Load the model, restricting offloading to ONLY the RPC devices
+    var modelParams = new LlamaModelParams(arena)
+      .devices(arena, rpcDevices)
+      .nGpuLayers(999);
+    var model = new LlamaModel(arena, Path.of("models/model.gguf"), modelParams);
+
+    // Everything else is identical to local inference
+    var contextParams = new LlamaContextParams(arena).nCtx(2048).nBatch(512);
+    var context = new LlamaContext(arena, model, contextParams);
+    var vocab = new LlamaVocab(model);
+    var tokenizer = new LlamaTokenizer(vocab, context);
+    var sampler = new LlamaSampler(arena).temperature(0.7f).seed(42);
+
+    var state = ConversationState.create(arena, context, tokenizer, sampler, 0)
+      .setMaxTokens(100)
+      .initialize("What is the capital of France?");
+
+    var iterator = new DefaultLlamaIterator(state);
+    while (iterator.hasNext()) {
+      System.out.print(iterator.next().text());
+    }
+
+    context.free();
+    sampler.free();
+    model.free();
+    LlamaRuntime.llama_backend_free();
+  }
+}
+```
+
+Multiple servers: call `BackendRegistry.addRpcServers(arena, "192.168.1.10:50052", "192.168.1.11:50052")` (duplicate endpoints are ignored), or use `modelParams.rpcServers(arena, ...)` which registers them and lets llama.cpp split across all devices automatically. From the CLI, pass `--rpc host1:port,host2:port`.
+
+## Options
+
+| Knob | Where | Values / default | Effect |
+| --- | --- | --- | --- |
+| `splitMode(SplitMode)` | `LlamaModelParams` | `NONE`, `LAYER` (default for multi-device), `ROW` | How layers/KV split across devices; `LAYER` spreads proportionally to free VRAM, `ROW` uses tensor parallelism where supported |
+| `nGpuLayers(int)` | `LlamaModelParams` | e.g. `999` | Layers to offload; use a large value to push all layers to the (remote) GPU devices |
+| `devices(arena, List<MemorySegment>)` | `LlamaModelParams` | RPC device handles | Pins offloading to exactly these devices (e.g. only the remote ones, skipping local Metal) |
+| `rpcServers(arena, String...)` | `LlamaModelParams` | `host:port` list | Registers servers and offloads across all devices automatically |
+| `-v / -H / -p / -d` | `start-rpc-server.sh` | version / host / port / device (`MTL0`, `CPU`, ...) | Server bind + backend selection |
+
+## Notes
+- **Version must match.** The remote `rpc-server` must be the same llama.cpp build as the client library; a protocol mismatch makes the native RPC client `abort()` and kill the JVM. The bundled `start-rpc-server.sh` pins the matching release tag and caches the binary in `$HOME/.llama.cpp/rpc-server/` (delete that dir to force re-download).
+- **Pre-flight TCP check.** `addRpcServer` opens a TCP socket (5s timeout) before calling native code and throws `LlamaException` on an unreachable host, avoiding an unrecoverable native crash. `RpcMemoryQuery.queryAll` instead returns `null` on any failure and never throws — prefer it for safe capacity checks before loading.
+- **RPC devices are not global.** Devices returned by `addRpcServer`/`addRpcServers` are NOT in the global device registry; you must hand them to `devices(...)` (or rely on `rpcServers(...)`) for the model to use them. `getRpcDeviceHandles()` retrieves the accumulated handles.
+- **Exclusive offload.** Using `devices(arena, rpcDevices)` loads weights only on the remote servers — the local GPU is not used.
+- **Memory aggregation.** `RpcMemoryInfo.freeBytes`/`totalBytes` are the **sum** across servers and endpoints are deduplicated, since llama.cpp shares one registry entry per unique `host:port`.
+- **Lifecycle.** Allocate native params from an `Arena` and `free()` `context`, `sampler`, and `model` (then `LlamaRuntime.llama_backend_free()`) when done; an `Arena.ofConfined()` releases everything it owns on close.
+- **Ordering.** Register RPC servers after `llama_backend_init()` / `ggml_backend_load_all_from_path(...)` and before constructing the `LlamaModel`.
+
+## See also
+- [Devices & Memory](../device-and-memory/README.md) — device enumeration, VRAM estimation, and offload tuning.
+- [Getting Started](../getting-started/README.md) — runtime init, model loading, and the basic generation loop.
+- [Text Generation & Sampling](../text-generation/README.md) — the iterator/sampler API used after the model loads.
+- [Custom Builds & Platform Support](../custom-builds/README.md) — ensuring the RPC backend plugin is present in your build.

--- a/docs/embeddings/README.md
+++ b/docs/embeddings/README.md
@@ -1,0 +1,102 @@
+# Embeddings
+
+> Turn text into dense float vectors with `LlamaEmbedder`, a high-level wrapper that handles pooling, attention, tokenization and batching for you.
+
+## Overview
+`LlamaEmbedder` produces a dense embedding vector (`float[]`) for a piece of text, suitable for semantic search, clustering, RAG retrieval and cosine-similarity comparisons. It wraps a `LlamaContext` created in embedding mode and reduces the API to `String -> float[]`. Pooling and attention are auto-detected from the GGUF architecture, so `Options.defaults()` works for most embedding models (BERT-family encoders as well as decoder embedding models like Qwen3-Embedding). Vectors are returned **un-normalised** — L2-normalise them yourself before computing cosine similarity.
+
+## Key types
+- `LlamaEmbedder` — high-level wrapper; `embed(String)` for one text, `embedAll(List<String>)` to batch many through a single decode. Implements `Freeable`/`AutoCloseable`.
+- `LlamaEmbedder.Options` — record of `nCtx`, `nBatch`, `nSeqMax`, `pooling`, `attention`; any `null` field is auto-detected. Use `Options.defaults()` plus `withX(...)` overrides.
+- `PoolingType` — how token states are pooled into one vector: `CLS`, `MEAN`, `LAST`, `RANK`, `NONE`, `UNSPECIFIED`.
+- `AttentionType` — `CAUSAL` (decoders) or `NON_CAUSAL` (encoders); `UNSPECIFIED` for auto.
+- `LlamaModel` — caller-owned, pre-loaded model; reused across embedders and **not** freed by the embedder.
+
+## Usage
+```java
+import io.gravitee.llama.cpp.*;
+import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
+import java.lang.foreign.Arena;
+import java.nio.file.Path;
+import java.util.List;
+
+public class EmbeddingExample {
+    static float[] l2normalize(float[] v) {
+        double sum = 0;
+        for (float f : v) sum += (double) f * f;
+        double norm = Math.sqrt(sum);
+        if (norm > 1e-9) for (int i = 0; i < v.length; i++) v[i] = (float) (v[i] / norm);
+        return v;
+    }
+
+    static double cosine(float[] a, float[] b) {
+        double dot = 0;
+        for (int i = 0; i < a.length; i++) dot += (double) a[i] * b[i];
+        return dot; // inputs are L2-normalised, so the dot product is the cosine
+    }
+
+    public static void main(String[] args) {
+        var arena = Arena.ofConfined();
+        String libPath = LlamaLibLoader.load();
+        LlamaRuntime.llama_backend_init();
+        LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
+
+        var model = new LlamaModel(arena, Path.of("models/embedding.gguf"), new LlamaModelParams(arena));
+        var embedder = new LlamaEmbedder(arena, model, LlamaEmbedder.Options.defaults());
+
+        System.out.println("embedding dimension: " + embedder.nEmbdOut());
+        System.out.println("pooling: " + embedder.poolingType());
+
+        // Single text
+        float[] one = embedder.embed("The capital of France is Paris.");
+
+        // Or batch many through a single decode (same order out as in)
+        List<float[]> embeddings = embedder.embedAll(List.of(
+            "The capital of France is Paris.",
+            "Paris is France's largest city.",
+            "Bananas are a good source of potassium."
+        ));
+        embeddings.forEach(EmbeddingExample::l2normalize);
+
+        System.out.printf("similar pair:   %.4f%n", cosine(embeddings.get(0), embeddings.get(1)));
+        System.out.printf("unrelated pair: %.4f%n", cosine(embeddings.get(0), embeddings.get(2)));
+
+        embedder.close(); // frees only the internal context
+        model.free();     // caller owns the model
+        LlamaRuntime.llama_backend_free();
+        arena.close();
+    }
+}
+```
+
+## Options
+`LlamaEmbedder.Options` — every field is nullable; `null` means auto-detect / use llama.cpp's default.
+
+| Field | Type | Default (`null`) | Notes |
+|-------|------|------------------|-------|
+| `nCtx` | `Integer` | `0` → model's trained context (`n_ctx_train`) | Context size in tokens. |
+| `nBatch` | `Integer` | llama.cpp default (`2048`) | Max tokens per decode; a single input exceeding this throws `LlamaException`. |
+| `nSeqMax` | `Integer` | llama.cpp default (`1`) | Sequences packed per decode in `embedAll`; higher = more parallelism, more KV memory. |
+| `pooling` | `PoolingType` | `CLS` for encoders, `LAST` for decoders | How token states collapse into one vector. |
+| `attention` | `AttentionType` | `NON_CAUSAL` for encoders, `CAUSAL` for decoders | Encoders attend bidirectionally; decoders are left-to-right. |
+
+Build with `Options.defaults()` and chain overrides, e.g. `Options.defaults().withPooling(PoolingType.MEAN).withNSeqMax(8)`.
+
+**`PoolingType` values:** `UNSPECIFIED`, `NONE`, `MEAN`, `CLS`, `LAST`, `RANK`.
+**`AttentionType` values:** `UNSPECIFIED`, `CAUSAL`, `NON_CAUSAL`.
+
+## Notes
+- The embedder always builds its `LlamaContext` with `embeddings(true)`; you do not set this yourself. If you drop down to the raw `LlamaContext` API, the context must be created in embedding mode or `getEmbeddingsSeq`/`getEmbeddingsIth` return null.
+- Auto-detection reads the GGUF `general.architecture` metadata: BERT-family encoders (`bert`, `nomic-bert`, `modern-bert`, `jina-bert-*`, `neo-bert`, `eurobert`) get `CLS` + `NON_CAUSAL`; all other (decoder) architectures get `LAST` + `CAUSAL`.
+- Vectors are **un-normalised** — apply L2 normalisation before cosine similarity (cosine then reduces to a dot product).
+- `embed`/`embedAll` return fresh `float[]` copies of length `nEmbdOut()`; the same text yields a deterministic result.
+- `embedAll` packs sequences until they fill `nBatch` tokens or `nSeqMax` sequences, then decodes the batch once — much faster than one decode per text. Batched and single-call outputs are semantically equivalent (cosine ≈ 1.0) but not bit-exact, since packing changes the FP compute order.
+- Resource ownership: the caller owns the `LlamaModel` and must `free()` it. `close()`/`free()` on the embedder releases only its internal context, so one model can back multiple embedder / reranker / classifier instances.
+- Not thread-safe — create one embedder per thread or synchronise externally.
+- Lifecycle: pass a confined `Arena`, and at shutdown close the embedder, free the model, call `LlamaRuntime.llama_backend_free()`, then close the arena (track native resources so Metal buffers free before JVM exit).
+
+## See also
+- [Reranking](../reranking/README.md) — score query/document relevance using the same model-as-context pattern (`RANK` pooling).
+- [Getting Started](../getting-started/README.md) — backend init, model loading and arena lifecycle.
+- [Text Generation & Sampling](../text-generation/README.md) — generative inference on a non-embedding context.
+- [Quantized KV Cache](../quantized-kv-cache/README.md) — reduce KV memory when packing many sequences.

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,0 +1,117 @@
+# Getting Started
+
+> Initialize the native runtime, load a GGUF model, build an inference context, and tokenize text.
+
+## Overview
+llamaj.cpp is a Java FFM (Project Panama) binding over llama.cpp. Every program follows the
+same bootstrap sequence: initialize the GGML backends, load the model weights, create a context
+that holds the KV-cache and runtime state, then derive a vocab and tokenizer from the model.
+This page covers that lifecycle and the `Arena`/`Freeable` resource-management model that keeps
+native memory from leaking. Read it first — all other capabilities build on these types.
+
+## Key types
+- `LlamaRuntime` — static entry points to the native library: `llama_backend_init()`, `ggml_backend_load_all_from_path()`, `llama_backend_free()`.
+- `LlamaLibLoader` — resolves and `System.load()`s the bundled (or `LLAMA_CPP_LIB_PATH`) native libs; `load()` returns the directory path to feed to `ggml_backend_load_all_from_path`.
+- `LlamaModelParams` — builder over `llama_model_default_params` (GPU layers, mmap, mlock, vocab-only, ...).
+- `LlamaModel` — a loaded GGUF model; `Freeable`. Exposes metadata helpers (`desc`, `metaVal`, `meta`, `nCtxTrain`, `nEmbdOut`).
+- `LlamaContextParams` — builder over `llama_context_default_params` (`nCtx`, `nBatch`, `nUBatch`, `nSeqMax`, threads, ...).
+- `LlamaContext` — the inference session bound to a model; `Freeable`. Owns the KV-cache.
+- `LlamaVocab` — token <-> piece access derived from the model.
+- `LlamaTokenizer` — encodes a `String` into token ids (`tokenize`) and decodes pieces (`tokenToPiece`).
+- `Freeable` — interface with `free()`; all native-owning handles implement it and must be freed.
+- `BackendRegistry` — optional high-level helper to enumerate backends/devices after init.
+
+## Usage
+```java
+import io.gravitee.llama.cpp.*;
+import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
+import java.lang.foreign.Arena;
+import java.lang.foreign.ValueLayout;
+import java.nio.file.Path;
+
+public class GettingStarted {
+    public static void main(String[] args) {
+        // 1. One Arena owns all the native param/segment allocations.
+        var arena = Arena.ofConfined();
+
+        // 2. Load the native libraries, then initialize and register the backends.
+        String libPath = LlamaLibLoader.load();          // returns the native lib directory
+        LlamaRuntime.llama_backend_init();
+        LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
+
+        // 3. Load the model. Builder methods return `this` for chaining.
+        var modelParams = new LlamaModelParams(arena)
+            .nGpuLayers(99)        // offload all layers to GPU (0 = CPU only)
+            .useMmap(true);
+        var model = new LlamaModel(arena, Path.of("models/model.gguf"), modelParams);
+
+        // 4. Build a context (KV-cache + runtime state) from the model.
+        var contextParams = new LlamaContextParams(arena)
+            .nCtx(2048)            // context window in tokens
+            .nBatch(512)           // logical batch size
+            .nUBatch(512);         // physical (micro) batch size
+        var context = new LlamaContext(arena, model, contextParams);
+
+        // 5. Derive the vocab and tokenizer from the model.
+        var vocab = new LlamaVocab(model);
+        var tokenizer = new LlamaTokenizer(vocab, context);
+
+        // 6. Tokenize some text. The response holds a native int buffer + token count.
+        var tokens = tokenizer.tokenize(arena, "What is the capital of France?");
+        System.out.println("Token count: " + tokens.size());
+
+        // Read the first token id and decode it back to its UTF-8 piece.
+        int firstToken = tokens.data().getAtIndex(ValueLayout.JAVA_INT, 0);
+        byte[] piece = vocab.tokenToPiece(firstToken);
+        System.out.println("First piece: " + new String(piece));
+
+        // Inspect the model.
+        System.out.println("Model: " + model.desc(arena));
+
+        // 7. Free native resources in reverse creation order, then the Arena.
+        context.free();
+        model.free();
+        LlamaRuntime.llama_backend_free();
+        arena.close();
+    }
+}
+```
+
+## Options
+
+### `LlamaModelParams`
+| Method | Default | Purpose |
+| --- | --- | --- |
+| `nGpuLayers(int)` | model-dependent | Number of layers to offload to GPU (0 = CPU only). |
+| `useMmap(boolean)` | `true` | Memory-map weights instead of copying into RAM. |
+| `useMlock(boolean)` | `false` | Lock weights in RAM (prevents swap). |
+| `vocabOnly(boolean)` | `false` | Load only the vocab (skips tensors; zeroes `nEmbdOut`/`desc`). |
+| `splitMode(SplitMode)` | — | How to split weights across multiple GPUs. |
+| `mainGpu(int)` | `0` | Primary GPU index. |
+
+### `LlamaContextParams`
+| Method | Default | Purpose |
+| --- | --- | --- |
+| `nCtx(int)` | from model | Context window size in tokens. |
+| `nBatch(int)` | `512` | Logical batch size for a single `decode`. |
+| `nUBatch(int)` | `512` | Physical (micro) batch size. |
+| `nSeqMax(int)` | `1` | Max parallel sequences (see Parallel Conversations). |
+| `nThreads(int)` / `nThreadsBatch(int)` | CPU count | Threads for generation / prompt processing. |
+| `poolingType(PoolingType)` | model-dependent | Embedding pooling (see Embeddings / Reranking). |
+| `embeddings(boolean)` | `false` | Output embeddings instead of logits. |
+
+## Notes
+- **Bootstrap order matters**: `LlamaLibLoader.load()` → `llama_backend_init()` → `ggml_backend_load_all_from_path(arena, libPath)` must run before any model is loaded. Override the lib directory with the `LLAMA_CPP_LIB_PATH` env var.
+- **Context constructor takes the Arena**: use `new LlamaContext(arena, model, contextParams)` (3-arg). The model and context params are read at construction time.
+- **`Freeable` resources**: `LlamaModel` and `LlamaContext` (and `LlamaSampler`) own native handles and must be `free()`d explicitly, in reverse order of creation (context before model). `free()` is idempotent-guarded — calling a method after `free()` throws.
+- **Params vs. handles**: `LlamaModelParams`, `LlamaContextParams`, and `LlamaVocab` are backed by Arena-scoped segments (they extend `MemorySegmentAware`), so they are released when the `Arena` closes — you do not call `free()` on them.
+- **One Arena to rule them**: allocate params and tokenizer buffers from a single confined `Arena` and `close()` it last; this frees all the small native allocations at once.
+- **Construction can fail**: loading a missing/corrupt model or an invalid context configuration throws `LlamaException` (e.g. a quantized V-cache without flash attention).
+- **Metal teardown caveat**: on Apple Silicon, every native handle must be freed before the JVM exits or llama.cpp can abort from a static destructor — always `free()` your model/context (in tests, track them for teardown).
+- **`nGpuLayers(99)`** is the idiomatic "offload everything"; it is silently clamped to the model's layer count.
+
+## See also
+- [Text Generation & Sampling](../text-generation/README.md) — generate tokens with a sampler and iterator on top of the context built here.
+- [Chat Templates](../chat-templates/README.md) — format multi-turn messages before tokenizing.
+- [Devices & Memory](../device-and-memory/README.md) — enumerate backends/devices and estimate memory before loading.
+- [Embeddings](../embeddings/README.md) — reuse this setup with `embeddings(true)` and a pooling type.

--- a/docs/logging/README.md
+++ b/docs/logging/README.md
@@ -1,0 +1,79 @@
+# Logging
+
+> Install a custom log callback over llama.cpp / ggml and filter messages by severity level.
+
+## Overview
+llama.cpp and its ggml backends emit diagnostic messages (model loading, backend
+selection, performance, warnings). `LlamaLogger` registers a native log callback
+(`llama_log_set` / `ggml_log_callback`) that routes those messages to a Java
+`Consumer<String>`, with a `LlamaLogLevel` threshold to drop messages below the
+level you care about. Use it to silence noisy startup logs, raise the threshold to
+warnings/errors in production, or pipe llama.cpp output into your own logging
+framework (SLF4J, Logback, etc.).
+
+## Key types
+- `LlamaLogger` — `ArenaAware` handler that installs the native log callback; created with an `Arena`.
+- `LlamaLogLevel` — severity enum used as the filter threshold (`NONE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `CONT`).
+
+## Usage
+```java
+import io.gravitee.llama.cpp.*;
+import java.lang.foreign.Arena;
+
+Arena arena = Arena.ofConfined();
+
+// The logger must be installed before loading models/contexts so you capture
+// backend and model-load messages.
+var logger = new LlamaLogger(arena);
+
+// 1) Simplest form: threshold only — messages are written to System.out.
+logger.setLogging(LlamaLogLevel.DEBUG);
+
+// 2) Custom sink: forward llama.cpp / ggml output to your own logger.
+logger.setLogging(LlamaLogLevel.WARN, message -> myLogger.warn(message));
+
+// From here on, model and context creation emit messages through the callback.
+var modelParameters = new LlamaModelParams(arena);
+var model = new LlamaModel(arena, modelPath, modelParameters);
+var context = new LlamaContext(arena, model, new LlamaContextParams(arena));
+```
+
+## Options
+
+### `LlamaLogLevel` (threshold, lowest to highest)
+| Value   | Effect when used as threshold                                  |
+|---------|----------------------------------------------------------------|
+| `NONE`  | Logs everything (no message is filtered out).                  |
+| `DEBUG` | Logs `DEBUG` and above — verbose, includes per-token detail.   |
+| `INFO`  | Logs `INFO`, `WARN`, `ERROR`, `CONT`.                          |
+| `WARN`  | Logs warnings and errors only.                                 |
+| `ERROR` | Logs errors (and `CONT` continuation lines) only.             |
+| `CONT`  | Highest ordinal; continuation marker for multi-part messages.  |
+
+### `setLogging` overloads
+| Method                                              | Behavior                                              |
+|-----------------------------------------------------|-------------------------------------------------------|
+| `setLogging(LlamaLogLevel level)`                   | Threshold only; sink defaults to `System.out::print`. |
+| `setLogging(LlamaLogLevel level, Consumer<String>)` | Threshold plus a custom message sink.                 |
+
+## Notes
+- Filtering rule: a message is delivered when its native level is `>=` the
+  configured threshold's `ordinal()`. So `DEBUG` is the most verbose useful
+  threshold, while `NONE` (ordinal 0) filters nothing.
+- The enum ordinals map directly onto ggml's log levels — keep the declaration
+  order (`NONE, DEBUG, INFO, WARN, ERROR, CONT`) intact.
+- `LlamaLogger` is `ArenaAware`: the native callback stub is allocated from the
+  `Arena` you pass in. Keep that `Arena` (and the `LlamaLogger`) alive for as long
+  as you want logging active; closing/freeing the `Arena` invalidates the callback.
+- Install the logger early — before `new LlamaModel(...)` / `new LlamaContext(...)`
+  — to capture backend registration and model-load diagnostics.
+- `llama_log_set` is process-global: the last installed callback wins for the
+  whole JVM, not per model or per context.
+- The sink runs on llama.cpp's calling (native) thread; keep it cheap and
+  thread-safe, and avoid throwing out of the `Consumer`.
+
+## See also
+- [Getting Started](../getting-started/README.md) — backend init and the load order this logger should precede.
+- [Devices & Memory](../device-and-memory/README.md) — backend/device selection messages surfaced through the log callback.
+- [Text Generation & Sampling](../text-generation/README.md) — the inference loop whose performance/debug output you can capture.
+- [Custom Builds & Platform Support](../custom-builds/README.md) — native library loading whose diagnostics flow through logging.

--- a/docs/logprobs/README.md
+++ b/docs/logprobs/README.md
@@ -1,0 +1,82 @@
+# Log Probabilities
+
+> Collect per-token log-probabilities (the sampled token plus its top-N alternatives) for every token the model generates.
+
+## Overview
+Enabling logprobs makes each `LlamaOutput` carry a `Logprobs` object describing the model's confidence at that token position: the token actually sampled and the `topLogprobs` most-likely alternatives, sorted by descending log-probability. This mirrors the per-token logprobs returned by OpenAI-compatible chat-completion APIs when `logprobs=true`. Use it to inspect model confidence, build re-ranking or scoring logic, or surface alternative tokens in a UI. When disabled (the default), no extra logit processing is done.
+
+## Key types
+- `Logprobs` — record for one token position: `chosenToken()` and the `topLogprobs()` list.
+- `TokenLogprob` — record for a single token: `token()`, `tokenId()`, `logprob()` (ln(p)), `bytes()` (raw UTF-8).
+- `ConversationState.setTopLogprobs(int)` — opt-in switch; sets how many alternatives to collect (0 = off).
+- `LlamaOutput.logprobs()` — returns the `Logprobs` for the emitted token, or `null` if collection is disabled.
+
+## Usage
+```java
+import io.gravitee.llama.cpp.*;
+import java.lang.foreign.Arena;
+import java.nio.file.Path;
+
+var arena = Arena.ofConfined();
+LlamaRuntime.llama_backend_init();
+
+var model = new LlamaModel(arena, Path.of("models/model.gguf"), new LlamaModelParams(arena));
+var contextParams = new LlamaContextParams(arena).nCtx(2048).nBatch(512);
+var context = new LlamaContext(arena, model, contextParams);
+var vocab = new LlamaVocab(model);
+var tokenizer = new LlamaTokenizer(vocab, context);
+var sampler = new LlamaSampler(arena).temperature(0.7f).seed(42);
+
+var state = ConversationState.create(arena, context, tokenizer, sampler)
+    .setMaxTokens(50)
+    .setTopLogprobs(5)   // return top-5 alternatives at every token position
+    .initialize("What is the capital of France?");
+
+var iterator = new DefaultLlamaIterator(state);
+while (iterator.hasNext()) {
+    var output = iterator.next();
+    System.out.print(output.text());
+
+    Logprobs lp = output.logprobs();          // null if setTopLogprobs was 0
+    TokenLogprob chosen = lp.chosenToken();
+    System.out.printf("%n  chosen: \"%s\"  logprob=%.4f%n", chosen.token(), chosen.logprob());
+    lp.topLogprobs().forEach(t ->
+        System.out.printf("    alt: \"%s\"  logprob=%.4f%n", t.token(), t.logprob()));
+}
+
+context.free();
+sampler.free();
+model.free();
+LlamaRuntime.llama_backend_free();
+```
+
+## Options
+| Method | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `setTopLogprobs(int)` | `int` | `0` | Number of top-alternative tokens to collect per position. `0` disables collection entirely (no overhead); max 20 by OpenAI convention. |
+| `getTopLogprobs()` | `int` | — | Reads back the configured value. |
+
+`Logprobs` / `TokenLogprob` fields:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `Logprobs.chosenToken()` | `TokenLogprob` | The token actually sampled at this position. |
+| `Logprobs.topLogprobs()` | `List<TokenLogprob>` | Alternatives sorted by descending `logprob`; the chosen token is always included. |
+| `TokenLogprob.token()` | `String` | Decoded token text (may be empty for special tokens). |
+| `TokenLogprob.tokenId()` | `int` | Vocabulary ID of the token. |
+| `TokenLogprob.logprob()` | `double` | `ln(p)`, always `<= 0`; `Double.NEGATIVE_INFINITY` if the model assigned probability zero. |
+| `TokenLogprob.bytes()` | `List<Integer>` | Raw UTF-8 bytes of the token piece, useful for reassembling multi-byte characters split across tokens. |
+
+## Notes
+- Logprobs are opt-in: leave `setTopLogprobs` unset (or `0`) and `output.logprobs()` is `null` for every token, avoiding the cost of reading and sorting the full vocabulary logit vector.
+- When enabled, `logprobs()` is non-null for every emitted token, and `chosenToken().token()` equals `output.content()` for that token.
+- `topLogprobs()` contains at least `topN` entries; because the chosen token is always added, the list can be one longer if the chosen token was not already in the top-N.
+- All `logprob` values are `<= 0` (they are natural logs of probabilities); the list is guaranteed sorted by descending `logprob`.
+- Lifecycle: native handles (`LlamaModel`, `LlamaContext`, `LlamaSampler`) must be `free()`d (or allocated on a managed `Arena`); the `Logprobs`/`TokenLogprob` records are plain Java objects and need no cleanup.
+- Sampler settings (temperature, seed, etc.) still drive which token is chosen; logprobs only report the per-position distribution and do not change sampling behavior.
+
+## See also
+- [Text Generation & Sampling](../text-generation/README.md) — configuring the sampler and iterating `LlamaOutput`.
+- [Getting Started](../getting-started/README.md) — model/context/tokenizer setup used above.
+- [Parallel Conversations (Batched Decoding)](../parallel-conversations/README.md) — running multiple `ConversationState`s at once.
+- [Speculative Decoding](../speculative-decoding/README.md) — draft-model acceleration on the same `ConversationState`.

--- a/docs/lora-adapters/README.md
+++ b/docs/lora-adapters/README.md
@@ -1,0 +1,62 @@
+# LoRA Adapters
+
+> Load a GGUF LoRA adapter and attach it to a model so generation runs with the fine-tuned weights.
+
+## Overview
+A LoRA (Low-Rank Adaptation) adapter is a small set of fine-tuned weights, packaged as its own GGUF file, that specializes a base model for a task (e.g. summarization, a particular style) without re-loading the full model. In llamaj.cpp you load the base model normally, then call `initLoraAdapter` to load and attach the adapter. The adapter must be built for the same base model architecture as the GGUF you loaded.
+
+## Key types
+- `LlamaModel` — the base model; exposes `initLoraAdapter(Arena, Path)` and owns the adapter's lifecycle.
+- `LlamaLoraAdapter` — thin FFM wrapper over the native `llama_adapter_lora` handle (`llama_adapter_lora_init` / `llama_adapter_lora_free`); created for you by `initLoraAdapter`.
+
+## Usage
+```java
+try (Arena arena = Arena.ofConfined()) {
+  // 1. Load the base model
+  var modelParams = new LlamaModelParams(arena);
+  var model = new LlamaModel(arena, Path.of("models/model.gguf"), modelParams);
+
+  // 2. Load + attach a LoRA adapter (fluent: returns the same model)
+  model.initLoraAdapter(arena, Path.of("models/lora-adapter.gguf").toAbsolutePath());
+
+  // 3. Build the context and generate as usual — the adapter is now in effect
+  var contextParams = new LlamaContextParams(arena)
+    .nCtx(512)
+    .nBatch(512);
+
+  var context = new LlamaContext(arena, model, contextParams);
+  var vocab = new LlamaVocab(model);
+  var sampler = new LlamaSampler(arena).seed(42).temperature(0.75f).topK(40);
+  var tokenizer = new LlamaTokenizer(vocab, context);
+
+  var state = ConversationState.create(arena, context, tokenizer, sampler)
+    .setMaxTokens(64)
+    .initialize(/* tokenized prompt */ prompt);
+
+  String output = new DefaultLlamaIterator(state)
+    .stream()
+    .reduce(LlamaOutput::merge)
+    .orElse(new LlamaOutput("", 0))
+    .content();
+
+  // 4. Cleanup — model.free() also frees the attached adapter
+  context.free();
+  sampler.free();
+  model.free();
+}
+```
+
+## Notes
+- `initLoraAdapter(Arena arena, Path loraPath)` is fluent (returns the `LlamaModel`), so it chains after construction. Call it before building the `LlamaContext` you intend to run.
+- The path is resolved to an absolute path internally, but the test/`Main` pass `Path.toAbsolutePath()` explicitly — do the same to avoid surprises with the working directory.
+- Lifecycle: the adapter is owned by the model. `model.free()` frees the adapter first (`LlamaLoraAdapter.free()` → `llama_adapter_lora_free`) and then frees the model — do **not** free the adapter separately.
+- The `Arena` passed in must stay alive at least as long as the model, since it backs the native path string used to load the adapter.
+- One adapter is tracked per model: the model holds a single `LlamaLoraAdapter` reference, so calling `initLoraAdapter` again overwrites it (the previous reference is not auto-freed). There is no separate per-context scale knob exposed by the binding.
+- The adapter GGUF must match the base model (architecture and tensor shapes). In the test suite the base is `Qwen3-0.6B` with the matching `Qwen3-0.6B-tldr-lora` adapter.
+- Reference usage: `Main` wires it to the `--lora <path>` CLI flag, and `TunedLlamaIteratorTest` exercises the full load-attach-generate flow.
+
+## See also
+- [Getting Started](../getting-started/README.md) — loading a model and running a first generation.
+- [Text Generation & Sampling](../text-generation/README.md) — the iterator/sampler flow the adapter plugs into.
+- [Devices & Memory](../device-and-memory/README.md) — Arena and native resource lifecycle.
+- [Custom Builds & Platform Support](../custom-builds/README.md) — keeping the native `llama.cpp` version in sync.

--- a/docs/multimodal/README.md
+++ b/docs/multimodal/README.md
@@ -1,0 +1,95 @@
+# Multimodal (Vision & Audio)
+
+> Feed images and audio to a vision/audio-capable model by pairing the main LLM with an mmproj (clip) projector through `MtmdContext`.
+
+## Overview
+Multimodal support lets you attach images (JPEG, PNG, GIF, BMP, WebP, TIFF) and audio (WAV) to a prompt so a vision/audio model can reason over them. Media is decoded into native `mtmd_bitmap` handles, attached to a `ConversationState` via `setMedia`, and tokenized/encoded by a `MtmdContext` that wraps the model's separate **mmproj** (clip/projector) GGUF. You drive generation with the same `DefaultLlamaIterator` as text, but constructed with the `MtmdContext`. Use it whenever your model ships a companion mmproj file and you need to pass non-text inputs.
+
+## Key types
+- `MtmdContext` — wraps the native `mtmd_context`; loads the mmproj projector and exposes `supportsVision()`, `supportsAudio()`, `getAudioSampleRate()`. Required for any multimodal generation.
+- `MtmdContextParams` — fluent config for the context (`useGpu`, `mediaMarker`, `nThreads`, `printTimings`, `flashAttnType`, image token bounds).
+- `MtmdMedia` — common `Freeable` interface for media items; backs each media marker in the prompt.
+- `MtmdImage` — image media; factories `fromFile`, `fromBytes`, `fromBufferedImage`, `fromBytesNative`.
+- `MtmdAudio` — audio media; factories `fromFile`, `fromBytes`, `fromSamples` (all take a target sample rate).
+- `MtmdMediaFactory` — auto-detects and loads media via built-in handlers (`from`, `fromFile`).
+- `MediaHandler<T>` / `ImageHandler` / `AudioHandler` — pluggable loaders; image is the fallback, audio matches WAV by extension/magic bytes.
+- `AudioLoader` / `AudioFormat` — Java Sound decoding + resampling and WAV/MP3/FLAC detection.
+- `ConversationState.setMedia(List<MtmdMedia>)` — attaches loaded media to the prompt (one item per media marker).
+
+## Usage
+```java
+Arena arena = Arena.ofShared();
+LlamaRuntime.llama_backend_init();
+
+// 1. Load the main vision model
+var modelParams = new LlamaModelParams(arena);
+var llamaModel = new LlamaModel(arena, mainModelPath, modelParams);
+
+// 2. Build the multimodal context from the mmproj (clip) projector GGUF
+var mtmdParams = new MtmdContextParams(arena)
+  .useGpu(true)
+  .mediaMarker("<IMG>")
+  .printTimings(true);
+var mtmdContext = new MtmdContext(arena, llamaModel, mmprojPath.toAbsolutePath(), mtmdParams);
+
+// 3. Regular inference context
+var ctxParams = new LlamaContextParams(arena).noPerf(false);
+var llamaContext = new LlamaContext(arena, llamaModel, ctxParams);
+
+// 4. Load an image (audio: MtmdAudio.fromFile(arena, path, mtmdContext.getAudioSampleRate()))
+var image = MtmdImage.fromFile(arena, imagePath);
+
+// 5. Build the conversation; the prompt must contain the media marker ("<IMG>")
+var vocab = new LlamaVocab(llamaModel);
+var tokenizer = new LlamaTokenizer(vocab, llamaContext);
+var sampler = new LlamaSampler(arena).greedy().seed(42);
+
+var state = ConversationState.create(arena, llamaContext, tokenizer, sampler)
+  .initialize("USER: What is in this image?\n<IMG>\nASSISTANT:")
+  .setMaxTokens(256)
+  .setMedia(List.of(image));
+
+// 6. Drive generation with the MtmdContext-aware iterator
+var it = new DefaultLlamaIterator(state, mtmdContext);
+String output = it.stream()
+  .reduce(LlamaOutput::merge)
+  .orElse(new LlamaOutput("", 0))
+  .content();
+
+// 7. Free native resources
+image.free();
+mtmdContext.free();
+llamaContext.free();
+sampler.free();
+llamaModel.free();
+```
+
+## Options
+`MtmdContextParams` (fluent setters return `this`):
+
+| Method | Default behavior | Purpose |
+|---|---|---|
+| `useGpu(boolean)` | model default | Offload the projector to GPU. |
+| `mediaMarker(String)` | native default marker | Placeholder token in the prompt where each media item is spliced in (e.g. `"<IMG>"`). |
+| `nThreads(int)` | native default | CPU threads for the projector. |
+| `printTimings(boolean)` | false | Print encode timings. |
+| `flashAttnType(FlashAttentionType)` | `AUTO` | Flash-attention mode: `AUTO`, `DISABLED`, `ENABLED`. |
+| `imageMinTokens(int)` / `imageMaxTokens(int)` | model default | Clamp per-image token budget. |
+
+`AudioFormat`: `WAV` (decoded natively), `MP3`, `FLAC` (detected only — convert to WAV before loading).
+
+## Notes
+- An mmproj/clip GGUF plus a constructed `MtmdContext` is **mandatory**; without it the iterator runs as plain text. Pass the `MtmdContext` to `new DefaultLlamaIterator(state, mtmdContext)`.
+- The prompt must include the media marker once per attached item; the number of markers must match `setMedia(...)` list size.
+- `setImages(List<MtmdImage>)` is deprecated — use `setMedia(List<MtmdMedia>)`, which accepts both images and audio.
+- Audio must be loaded at the model's sample rate: pass `mtmdContext.getAudioSampleRate()` (e.g. 16000 for Whisper-style encoders). Only WAV decodes natively via Java Sound; convert MP3/FLAC first.
+- Images are decoded to RGB via `ImageIO`; `fromBytesNative` instead uses the native stb_image decoder for byte-for-byte parity with the reference llama.cpp server.
+- Each `MtmdImage`/`MtmdAudio`/`MtmdContext` is `Freeable` — call `free()` (or track them in tests) so native `mtmd_bitmap`/context memory is released before JVM exit. Allocate with an `Arena` you control.
+- Check capabilities before loading: `mtmdContext.supportsVision()` / `supportsAudio()`; `AudioHandler` throws if the model lacks audio support.
+- `MtmdMediaFactory.from(arena, input, mtmdContext)` auto-selects a handler (audio first, image fallback) for `Path` or `byte[]` inputs; supply custom `MediaHandler`s for other sources.
+
+## See also
+- [Getting Started](../getting-started/README.md) — model/context/arena setup this builds on.
+- [Text Generation & Sampling](../text-generation/README.md) — the iterator + sampler loop reused here.
+- [Chat Templates](../chat-templates/README.md) — formatting prompts (and placing media markers) for chat models.
+- [Devices & Memory](../device-and-memory/README.md) — GPU offload and arena/lifecycle details.

--- a/docs/parallel-conversations/README.md
+++ b/docs/parallel-conversations/README.md
@@ -1,0 +1,98 @@
+# Parallel Conversations (Batched Decoding)
+
+> Decode many independent conversations together in a single shared context, each isolated by a distinct sequence id.
+
+## Overview
+`BatchIterator` runs several conversations through **one** `LlamaContext` at the same time, packing one token per active conversation into each decode step. Every conversation is a `ConversationState` tagged with a unique **sequence id**, which keeps each one's KV cache logically separate inside the shared context. Use this when you need to serve multiple prompts concurrently (e.g. a chat server handling several clients) and want to amortise the cost of each forward pass across all of them.
+
+## Key types
+- `BatchIterator` — the parallel iterator; holds the shared context, manages per-sequence state, and yields one `LlamaOutput` per token via `hasNext()`/`next()` or `stream()`.
+- `ConversationState` — one conversation: its prompt, sampler, tokenizer, generation/finish state, and its `sequenceId`.
+- `LlamaContext` — the single context shared by all states; its `nSeqMax()` caps how many sequences can run in parallel.
+- `LlamaOutput` — a record per emitted token, carrying `text()`/`content()`, `sequenceId()`, and optional `logprobs()`.
+
+## Usage
+```java
+import io.gravitee.llama.cpp.*;
+import java.lang.foreign.Arena;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+var arena = Arena.ofConfined();
+LlamaRuntime.llama_backend_init();
+
+var model = new LlamaModel(arena, Path.of("models/model.gguf"), new LlamaModelParams(arena));
+
+// One context, sized to host several sequences at once.
+var contextParams = new LlamaContextParams(arena)
+    .nCtx(2048)
+    .nBatch(512)
+    .nSeqMax(4);            // up to 4 parallel sequences
+var context = new LlamaContext(arena, model, contextParams);
+
+var vocab     = new LlamaVocab(model);
+var tokenizer = new LlamaTokenizer(vocab, context);
+var sampler   = new LlamaSampler(arena).seed(new Random().nextInt());
+
+// Each conversation gets a UNIQUE sequence id (0, 1, 2) and shares the same context.
+var state1 = ConversationState.create(arena, context, tokenizer, sampler, 0)
+    .setMaxTokens(50).initialize("What is the capital of France?");
+var state2 = ConversationState.create(arena, context, tokenizer, sampler, 1)
+    .setMaxTokens(50).initialize("What is the capital of England?");
+var state3 = ConversationState.create(arena, context, tokenizer, sampler, 2)
+    .setMaxTokens(50).initialize("What is the capital of Poland?");
+
+// Prompts are auto-processed when states are added.
+var parallel = new BatchIterator(arena, context)
+    .addState(state1)
+    .addState(state2)
+    .addState(state3);
+
+// Accumulate output per sequence — each token names which conversation it belongs to.
+Map<Integer, StringBuilder> answers = new HashMap<>();
+answers.put(0, new StringBuilder());
+answers.put(1, new StringBuilder());
+answers.put(2, new StringBuilder());
+
+parallel.stream()
+    .forEach(out -> answers.get(out.sequenceId()).append(out.text()));
+
+// Equivalent explicit loop:
+// while (parallel.hasNext()) {
+//   LlamaOutput out = parallel.next();
+//   answers.get(out.sequenceId()).append(out.text());
+// }
+
+parallel.free();
+context.free();
+sampler.free();
+model.free();
+LlamaRuntime.llama_backend_free();
+```
+
+## Options
+| Knob | Where | Role |
+| --- | --- | --- |
+| `nSeqMax(int)` | `LlamaContextParams` | Maximum number of distinct sequence ids that can run in parallel; must be ≥ the number of states you add. |
+| `nBatch(int)` | `LlamaContextParams` | Tokens decoded per step; the iterator decodes up to `nBatch` active sequences per batch (one token each). |
+| `nCtx(int)` | `LlamaContextParams` | Total KV cache budget shared across all sequences. |
+| `sequenceId` | `ConversationState.create(...)` | Unique id distinguishing this conversation in the shared context (the 4-arg `create` defaults it to `0`). |
+| `setMaxTokens(int)` | `ConversationState` | Per-conversation generation cap. |
+
+## Notes
+- **Distinct sequence ids are mandatory.** Adding two states with the same id throws `LlamaException` ("Sequence ID N is already in use").
+- **All states must share the iterator's context.** Adding a state built on a different `LlamaContext` throws `LlamaException` ("All conversation states must share the same LlamaContext").
+- **`nSeqMax` is the ceiling.** Size it for the most concurrent conversations you expect; the underlying batch is allocated with `context.nSeqMax()`.
+- **`addState` is incremental and chainable**, and is thread-safe — you can add a conversation while the iterator is already running. Prompts are processed lazily on the next batch iteration, and each conversation's first token is emitted as soon as its prompt is prefilled.
+- **`removeState(int sequenceId)`** cancels one conversation (e.g. a disconnected client) and frees its KV cache; returns `true` if found. **`stop()`** halts everything and clears all sequences; after it, `hasNext()` and `hasActiveConversations()` return `false`.
+- **Lifecycle.** `BatchIterator` is `AutoCloseable`: call `free()` (or use try-with-resources) to stop and release the batch; it does **not** free the shared `context`, `sampler`, or `model`, which you free separately. `free()`/`stop()` are idempotent.
+- **`next()` requires `hasNext()` first** — calling `next()` with nothing queued throws `NoSuchElementException`.
+- Each conversation tracks its own `getFinishReason()`, `getAnswerTokens()`, and other counters independently.
+
+## See also
+- [Getting Started](../getting-started/README.md) — model/context/sampler setup used here.
+- [Text Generation & Sampling](../text-generation/README.md) — single-conversation generation and sampler configuration.
+- [Speculative Decoding](../speculative-decoding/README.md) — draft/verify acceleration, also batched per sequence by `BatchIterator`.
+- [Log Probabilities](../logprobs/README.md) — the `logprobs()` carried on each `LlamaOutput`.

--- a/docs/quantized-kv-cache/README.md
+++ b/docs/quantized-kv-cache/README.md
@@ -1,0 +1,107 @@
+# Quantized KV Cache
+
+> Shrink the attention KV-cache footprint by storing the K and V tensors in a quantized `ggml_type` instead of the default F16.
+
+## Overview
+The KV cache grows linearly with context length and dominates memory use for long
+contexts. By setting the K and V cache data types on `LlamaContextParams` to a quantized
+format (for example `Q8_0` or `Q4_0`), you trade a small amount of accuracy for
+substantially lower KV memory. The K cache can be quantized on its own, but a quantized V
+cache requires flash attention to be enabled. Defaults are `F16` for both K and V.
+
+## Key types
+- `GgmlType` — enum of KV-suitable `ggml_type` values (`F32`, `F16`, `Q4_0`, `Q4_1`, `Q5_0`, `Q5_1`, `Q8_0`, `IQ4_NL`, `BF16`); carries an explicit `nativeValue()`.
+- `LlamaContextParams` — context configuration; `typeK(GgmlType)` / `typeV(GgmlType)` select the cache types, `flashAttnType(FlashAttentionType)` toggles flash attention.
+- `FlashAttentionType` — `AUTO` / `DISABLED` / `ENABLED`; must be `ENABLED` for a quantized V cache.
+
+## Usage
+```java
+import io.gravitee.llama.cpp.*;
+import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
+import java.lang.foreign.Arena;
+import java.nio.file.Path;
+
+public class QuantizedKvExample {
+    public static void main(String[] args) {
+        try (Arena arena = Arena.ofConfined()) {
+            LlamaLibLoader.load();
+            LlamaRuntime.llama_backend_init();
+
+            var model = new LlamaModel(
+                arena, Path.of("models/model.gguf"), new LlamaModelParams(arena));
+
+            // Quantize the KV cache. A quantized V cache REQUIRES flash attention.
+            var contextParams = new LlamaContextParams(arena)
+                .nCtx(8192)
+                .nBatch(512)
+                .flashAttnType(FlashAttentionType.ENABLED)
+                .typeK(GgmlType.Q8_0)
+                .typeV(GgmlType.Q4_0);
+
+            var context = new LlamaContext(model, contextParams);
+            var vocab = new LlamaVocab(model);
+            var tokenizer = new LlamaTokenizer(vocab, context);
+            var sampler = new LlamaSampler(arena).temperature(0.7f).seed(42);
+
+            var state = ConversationState.create(arena, context, tokenizer, sampler, 0)
+                .setMaxTokens(100)
+                .initialize("What is the capital of France?");
+
+            var iterator = new DefaultLlamaIterator(state);
+            while (iterator.hasNext()) {
+                System.out.print(iterator.next().text());
+            }
+
+            context.free();
+            sampler.free();
+            model.free();
+            LlamaRuntime.llama_backend_free();
+        }
+    }
+}
+```
+
+You can also resolve a type from a CLI/string token: `GgmlType.fromString("q8_0")`.
+
+## Options
+
+### `GgmlType` values (KV-suitable)
+| Constant | `nativeValue()` | `isQuantized()` | Notes |
+|----------|-----------------|-----------------|-------|
+| `F32`    | 0  | false | Full precision, largest |
+| `F16`    | 1  | false | Default K/V type |
+| `Q4_0`   | 2  | true  | Smallest common quant |
+| `Q4_1`   | 3  | true  | |
+| `Q5_0`   | 6  | true  | Native value gaps (legacy quants removed upstream) |
+| `Q5_1`   | 7  | true  | |
+| `Q8_0`   | 8  | true  | Good accuracy/size trade-off |
+| `IQ4_NL` | 20 | true  | Non-linear 4-bit |
+| `BF16`   | 30 | false | Brain-float, full-precision-class |
+
+### `FlashAttentionType`
+| Value | Effect |
+|-------|--------|
+| `AUTO` | Let llama.cpp decide (default) |
+| `DISABLED` | Force off |
+| `ENABLED` | Force on — required for a quantized V cache |
+
+### `LlamaContextParams` KV setters
+| Method | Default | Purpose |
+|--------|---------|---------|
+| `typeK(GgmlType)` | `F16` | K cache data type |
+| `typeV(GgmlType)` | `F16` | V cache data type (quantized ⇒ needs flash attention) |
+| `flashAttnType(FlashAttentionType)` | `AUTO` | Enable flash attention |
+
+## Notes
+- A quantized **V** cache requires flash attention: set `flashAttnType(FlashAttentionType.ENABLED)` or constructing the `LlamaContext` will fail. Quantizing only **K** does not require it.
+- The native `ggml_type` enum is non-contiguous (gaps where legacy quants like `Q4_2`/`Q4_3` were removed). Always map via `GgmlType.nativeValue()` / `GgmlType.fromNative(int)`; never use `ordinal()`.
+- The K-quant family (`Q4_K`, `Q5_K`, …) is intentionally **not** exposed: its 256-element block size does not divide typical attention head dimensions, so it is invalid for the KV cache.
+- `GgmlType.fromString(...)` and `fromNative(...)` throw `LlamaException` for unknown/unsupported tokens.
+- `LlamaContextParams` is allocated from an `Arena`; the `LlamaContext`, model, and sampler are native resources — call `free()` on each (and `llama_backend_free()`) when done. In tests, track native resources so Metal buffers are released before JVM exit.
+- Setters are fluent (return `LlamaContextParams`), so they chain with other context options.
+
+## See also
+- [Getting Started](../getting-started/README.md) — basic model/context setup the example builds on.
+- [Devices & Memory](../device-and-memory/README.md) — complementary ways to manage memory and offloading.
+- [Text Generation & Sampling](../text-generation/README.md) — the iterator/sampler loop used above.
+- [Speculative Decoding](../speculative-decoding/README.md) — cut latency with a draft model or n-gram lookup.

--- a/docs/reasoning-and-tool-calls/README.md
+++ b/docs/reasoning-and-tool-calls/README.md
@@ -1,0 +1,96 @@
+# Reasoning & Tool Calls
+
+> Tag each generated token as reasoning, answer, or tool-call output by giving the conversation the delimiter strings that wrap each section.
+
+## Overview
+Many models interleave their output: a chain-of-thought block (e.g. `<think>…</think>`), a tool-call block (e.g. `<tool_call>…</tool_call>`), and the final user-facing answer. By registering the start/end delimiters for each section on a `ConversationState`, the iterator detects the active `GenerationState` while streaming, lets you count tokens per section separately, and surfaces `FinishReason.TOOL_CALL` when generation ends inside a tool call. Use this when you need to hide/strip reasoning, route tool-call payloads to a tool executor, or bill reasoning vs answer tokens differently.
+
+## Key types
+- `GenerationState` — enum of the section the model is currently emitting: `ANSWER`, `REASONING`, `TOOLS`.
+- `StateBounds` — record `(GenerationState state, String start, String end)` pairing a section with its delimiter strings.
+- `ConversationState` — owns the generation; `setReasoning(start, end)` / `setToolCall(start, end)` register the delimiters before `initialize(prompt)`.
+- `FinishReason` — terminal reason; `TOOL_CALL` (label `"tool_calls"`) is reported when output ends inside a tool-call block, alongside `EOS` / `STOP` / `LENGTH`.
+- `DefaultLlamaIterator` — drives token-by-token generation; `getGenerationState()` on the state reflects the active section as you stream.
+
+## Usage
+```java
+var arena = Arena.ofConfined();
+
+var model = new LlamaModel(arena, modelPath, new LlamaModelParams(arena));
+var contextParams = new LlamaContextParams(arena);
+var context = new LlamaContext(arena, model, contextParams);
+var vocab = new LlamaVocab(model);
+var tokenizer = new LlamaTokenizer(vocab, context);
+var sampler = new LlamaSampler(arena).seed(42);
+
+var prompt = getPrompt(model, arena, buildMessages(arena, system, input), contextParams);
+
+// Register the delimiters BEFORE initialize(...): reasoning + tool-call detection.
+var state = ConversationState.create(arena, context, tokenizer, sampler)
+  .setReasoning("<think>", "</think>")
+  .setToolCall("<tool_call>", "</tool_call>")
+  .initialize(prompt);
+
+var it = new DefaultLlamaIterator(state);
+
+// Merge all streamed pieces into a single output (content + token count).
+LlamaOutput output = it.stream()
+  .reduce(LlamaOutput::merge)
+  .orElse(new LlamaOutput("", 0));
+
+// Per-section token counts.
+int inputTokens     = state.getInputTokens();
+int answerTokens    = state.getAnswerTokens();
+int reasoningTokens = state.getReasoningTokens();
+int toolCallTokens  = state.getToolsTokens();
+
+// output.numberOfTokens() == answerTokens + reasoningTokens + toolCallTokens
+// state.getTotalTokenCount() == inputTokens + answerTokens + reasoningTokens + toolCallTokens
+
+if (state.getFinishReason() == FinishReason.TOOL_CALL) {
+  // Output ended inside <tool_call>...</tool_call> — dispatch to your tool executor.
+}
+
+context.free();
+sampler.free();
+model.free();
+```
+
+To act on sections as they stream (rather than after the fact), inspect `state.getGenerationState()` inside the stream — it returns the active `GenerationState` for the token just produced:
+
+```java
+it.stream().forEach(chunk -> {
+  switch (state.getGenerationState()) {
+    case REASONING -> { /* hide or log chain-of-thought */ }
+    case TOOLS     -> { /* accumulate tool-call JSON */ }
+    case ANSWER    -> { /* forward to the user */ }
+  }
+});
+```
+
+## Options
+| Method | Section | Effect |
+| --- | --- | --- |
+| `setReasoning(String start, String end)` | `REASONING` | Registers a `StateBounds(REASONING, start, end)`; tokens between the delimiters count toward `getReasoningTokens()`. |
+| `setToolCall(String start, String end)` | `TOOLS` | Registers a `StateBounds(TOOLS, start, end)`; tokens between the delimiters count toward `getToolsTokens()`; ending here yields `FinishReason.TOOL_CALL`. |
+| `getReasoningTokens()` / `getToolsTokens()` / `getAnswerTokens()` | — | Per-section output token counts; `getInputTokens()` and `getTotalTokenCount()` cover the prompt and grand total. |
+
+| `GenerationState` | Meaning |
+| --- | --- |
+| `ANSWER` | Default state; the user-facing answer (everything outside a registered section). |
+| `REASONING` | Inside the reasoning delimiters configured via `setReasoning`. |
+| `TOOLS` | Inside the tool-call delimiters configured via `setToolCall`. |
+
+## Notes
+- Configure `setReasoning` / `setToolCall` **before** `initialize(prompt)` — `initialize` resets generation state (and re-reads the registered `StateBounds`). Both methods are chainable and return the same `ConversationState`.
+- The delimiter strings must match what the model actually emits (driven by its chat template / system prompt). The tool-call test, for example, instructs the model via the system prompt to wrap calls in `<tool_call>…</tool_call>` and then registers those exact delimiters.
+- These delimiters are not appended to the prompt; they are pure output classifiers. Detection works on the decoded text stream, so multi-token delimiters are handled.
+- `getAnswerTokens()` always reflects the `ANSWER` section even when reasoning/tool calls are configured; the three section counts plus the input count sum to `getTotalTokenCount()`.
+- `FinishReason.TOOL_CALL` is a marker that generation stopped inside a tool call; the natural terminal reasons remain `EOS`, `STOP`, and `LENGTH`. `isFinished()` distinguishes a real stop (EOG/length) from a marker set while generation could otherwise continue.
+- Resource lifecycle: the model, context, and sampler are native resources — `free()` them (or close the owning `Arena`) when done, in the reverse of allocation, to release Metal/CPU buffers before JVM exit.
+
+## See also
+- [Text Generation & Sampling](../text-generation/README.md) — the base streaming/iterator loop these section detectors build on.
+- [Chat Templates](../chat-templates/README.md) — building the prompt that makes models emit reasoning and tool-call blocks.
+- [Log Probabilities](../logprobs/README.md) — another per-token signal collected alongside generation via `setTopLogprobs`.
+- [Parallel Conversations (Batched Decoding)](../parallel-conversations/README.md) — running many `ConversationState`s, each with its own section tracking, in one batch.

--- a/docs/reranking/README.md
+++ b/docs/reranking/README.md
@@ -1,0 +1,131 @@
+# Reranking
+
+> Score how relevant documents are to a query using a cross-encoder, then sort the candidates by score.
+
+## Overview
+`LlamaReranker` is a high-level wrapper over `LlamaContext` that produces a relevance
+score for a `(query, document)` pair. Use it to re-order a candidate set retrieved by a
+first-pass search (e.g. an embedding/vector search): score each document against the
+query, then sort descending. Pooling (`RANK`) and attention are auto-detected from the
+GGUF architecture, so `Options.defaults()` works for most reranker models, and the wrapper
+supports both BERT-family cross-encoders (single raw logit) and chat-style rerankers like
+Qwen3-Reranker (two-class softmax) through a pluggable `RerankTemplate`.
+
+## Key types
+- `LlamaReranker` — cross-encoder wrapper; `score(query, doc)` and `scoreAll(query, docs)` return raw `float[]` scores. Implements `AutoCloseable`/`Freeable`.
+- `LlamaReranker.Options` — record of `nCtx`, `nBatch`, `nSeqMax`, `attention`, `template`; build with `Options.defaults()` plus `withXxx(...)`.
+- `RerankTemplate` — functional interface `(query, document) -> String` that formats the tokenizer input. `RerankTemplate.PLAIN` is the default (`query + " " + document`).
+- `LlamaModel` — the loaded GGUF; the caller owns and frees it (the reranker does not).
+
+## Usage
+
+### Cross-encoder (BERT-family, e.g. Jina / BGE reranker)
+
+```java
+import io.gravitee.llama.cpp.*;
+import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
+import java.lang.foreign.Arena;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.IntStream;
+
+public class RerankExample {
+    public static void main(String[] args) {
+        var arena = Arena.ofConfined();
+        String libPath = LlamaLibLoader.load();
+        LlamaRuntime.llama_backend_init();
+        LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
+
+        var model = new LlamaModel(arena, Path.of("models/reranker.gguf"), new LlamaModelParams(arena));
+        var reranker = new LlamaReranker(arena, model, LlamaReranker.Options.defaults());
+
+        String query = "What is the capital of France?";
+        List<String> documents = List.of(
+            "Paris is the capital and most populous city of France.",
+            "The Eiffel Tower is a landmark in Paris.",
+            "Bananas are a good source of potassium."
+        );
+
+        // One raw score array per document, in input order (batched decode under the hood).
+        List<float[]> scores = reranker.scoreAll(query, documents);
+
+        // BERT cross-encoder: scores[i][0] is a single raw logit, higher = more relevant.
+        IntStream.range(0, documents.size())
+            .boxed()
+            .sorted(Comparator.comparingDouble((Integer i) -> scores.get(i)[0]).reversed())
+            .forEach(i -> System.out.printf("%.4f  %s%n", scores.get(i)[0], documents.get(i)));
+
+        reranker.close(); // frees only the context; the model is owned by the caller
+        model.free();
+        LlamaRuntime.llama_backend_free();
+        arena.close();
+    }
+}
+```
+
+For a single pair, `reranker.score(query, document)` returns a `float[]` of size
+`reranker.nClsOut()` — `1` for a BERT cross-encoder.
+
+### Chat-style reranker (Qwen3-Reranker) with a custom `RerankTemplate`
+
+Qwen3-Reranker expects the pair wrapped in a system/user prompt and has a 2-class head:
+`nClsOut() == 2` and `score` returns a softmax `float[2]` where index `0` is `P(relevant)`.
+
+```java
+// Wraps the pair in Qwen3's chat format, instructing the model to answer yes/no.
+static final RerankTemplate QWEN3_TEMPLATE = (query, document) ->
+    "<|im_start|>system\n" +
+    "Judge whether the Document is relevant to the Query. Answer 'yes' or 'no'." +
+    "<|im_end|>\n" +
+    "<|im_start|>user\n" +
+    "Query: " + query + "\n" +
+    "Document: " + document + "\n" +
+    "Relevant:<|im_end|>\n";
+
+var reranker = new LlamaReranker(
+    arena,
+    model,
+    LlamaReranker.Options.defaults().withTemplate(QWEN3_TEMPLATE)
+);
+
+List<float[]> scores = reranker.scoreAll(query, documents);
+// Rank by P(relevant) = scores.get(i)[0], highest first.
+```
+
+## Options
+
+| Field / setter | Default (when `null`) | Purpose |
+| --- | --- | --- |
+| `nCtx` / `withNCtx` | `0` → model's trained context (`n_ctx_train`) | Context size in tokens. |
+| `nBatch` / `withNBatch` | llama.cpp default (e.g. `2048`) | Max tokens packed per decode; also the per-pair token cap. |
+| `nSeqMax` / `withNSeqMax` | llama.cpp default (e.g. `1`) | Max sequences packed per decode; higher = more parallelism, more KV memory. |
+| `attention` / `withAttention` | auto: `NON_CAUSAL` (encoder) / `CAUSAL` (decoder) | `AttentionType` for the context. |
+| `template` / `withTemplate` | `RerankTemplate.PLAIN` | `(query, document) -> String` input formatter. |
+
+Output interpretation by model family:
+
+| Model family | `nClsOut()` | `score(...)` meaning |
+| --- | --- | --- |
+| BERT cross-encoder (BGE, Jina) | `1` | A single unbounded relevance **logit**; apply `sigmoid` only if you need a `[0,1]` value. |
+| Qwen3-Reranker | `2` | Softmax `[P(yes), P(no)]`; `score[0]` is the `[0,1]` relevance probability. |
+
+## Notes
+- Ranking is identical for both families: sort by `score[i][0]` descending. Only the
+  absolute interpretation differs (raw logit vs. calibrated probability).
+- The GGUF must support `RANK` pooling (a classifier head must be present); otherwise
+  `getEmbeddingsSeq` returns `null` and `scoreAll` throws a `LlamaException`.
+- `scoreAll` packs multiple pairs into one `LlamaBatch` when they fit under `nBatch`
+  tokens / `nSeqMax` sequences and decodes them together — faster than one decode per
+  document. Batched vs. single-call scores are numerically equivalent but not bit-exact.
+- Any single formatted pair that tokenises to more than `nBatch` tokens throws a
+  `LlamaException`; raise `Options.nBatch` or truncate the document.
+- The caller owns the `LlamaModel`. `free()`/`close()` releases only the internally-created
+  `LlamaContext`; you must still `model.free()` and close your `Arena`.
+- `LlamaReranker` is **not thread-safe**: use one instance per thread or synchronise externally.
+
+## See also
+- [Embeddings](../embeddings/README.md) — produce the dense vectors for the first-pass retrieval that reranking re-orders.
+- [Chat Templates](../chat-templates/README.md) — how prompt formatting works for chat-style models.
+- [Parallel Conversations (Batched Decoding)](../parallel-conversations/README.md) — the batched-decode mechanism `scoreAll` builds on.
+- [Getting Started](../getting-started/README.md) — backend init, model loading, and Arena lifecycle.

--- a/docs/speculative-decoding/README.md
+++ b/docs/speculative-decoding/README.md
@@ -1,0 +1,113 @@
+# Speculative Decoding
+
+> Speed up generation by having a cheap drafter propose several tokens that the target model verifies in a single pass, with byte-for-byte identical output.
+
+## Overview
+Speculative decoding accelerates token generation without changing the result: a cheap *drafter* proposes up to `nDraft` tokens per round and the target model verifies them all in one decode, committing the run of tokens it agrees with. The drafter is either a small **draft model** (`setDraft`) sharing the target's vocab, or **n-gram / prompt-lookup** matching against the generation history with no extra model (`setNgram`). Greedy configs are *lossless* (identical to plain greedy decoding); sampling configs use rejection sampling and stay an *exact* draw of the target distribution. Use it when you have spare compute and want lower latency — especially with repetitive output (code, JSON, RAG) for the n-gram path.
+
+## Key types
+- `SpeculativeConfig` — immutable record holding the draft window, sampling knobs, adaptive early-stop, and n-gram window; built via factories, withers, or a builder.
+- `ConversationState` — per-conversation state; `setDraft(...)` / `setNgram(...)` enable speculation, `isSpeculative()` / `isNgram()` query it, `acceptRate()` reports accepted/drafted.
+- `Speculation` (internal) — drives the draft→verify→accept cycle; the per-position distribution is computed natively, the accept test / residual draw / n-gram lookup are Java.
+- `NgramIndex` (internal) — committed-token history with a position index for ~O(1) prompt-lookup proposals.
+
+## Usage
+```java
+// Target + draft contexts over models that share the same tokenizer/vocab.
+var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+var specCtx  = new LlamaContext(arena, model, cp);
+var draftCtx = new LlamaContext(arena, model, cp); // a smaller model is the usual case
+var vocab = new LlamaVocab(model);
+
+var state = ConversationState.create(
+        arena,
+        specCtx,
+        new LlamaTokenizer(vocab, specCtx),
+        new LlamaSampler(arena).greedy())
+    .setMaxTokens(24)
+    .setDraft(draftCtx, SpeculativeConfig.greedy(4)) // greedy, fixed window of 4
+    .initialize("The capital of France is");
+
+String text = new DefaultLlamaIterator(state)
+    .stream()
+    .map(LlamaOutput::content)
+    .reduce("", (a, b) -> a + b);
+
+System.out.println(text + " (accept=" + state.acceptRate() + ")");
+```
+
+A `SpeculativeConfig` can be built three interchangeable ways:
+
+```java
+// 1. Factory presets:
+SpeculativeConfig.greedy(4);                       // greedy, fixed window
+SpeculativeConfig.greedyAdaptive(8, 1, 0.6f);      // greedy, stop early below draft confidence 0.6
+new SpeculativeConfig(4, 0.8f, 40, 0.95f, 42);     // sampling (nDraft, temp, topK, topP, seed)
+
+// 2. Fluent "withers" — start from a preset and override fields:
+SpeculativeConfig.greedy(8).withTemperature(0.8f).withTopK(40).withTopP(0.95f).withSeed(42);
+
+// 3. Builder:
+SpeculativeConfig.builder().nDraft(8).temperature(0.8f).topK(40).topP(0.95f).seed(42).build();
+```
+
+N-gram (prompt-lookup) drafting needs no draft model — enable it with `setNgram`:
+
+```java
+state.setNgram(SpeculativeConfig.ngramGreedy(4, 2));                // greedy: kMax=4, ngram window=2
+state.setNgram(SpeculativeConfig.ngram(4, 2, 0.8f, 40, 0.95f, 42)); // sampling
+```
+
+## From the CLI
+`Main` (the bundled CLI) exposes speculation through flags — no code required:
+
+| Flag | Meaning |
+| --- | --- |
+| `--draft <path>` | Draft model GGUF (model drafting); must share the target's vocab. Mutually exclusive with `--ngram`. |
+| `--ngram <window>` | N-gram prompt-lookup drafting with this window; no draft model (default window 2). |
+| `--n_draft <k>` | Max tokens drafted/proposed per round (default 4). |
+| `--p_min <p>` | Adaptive early-stop: stop drafting once the draft's top-token probability drops below `p` (model drafting only; `0` = disabled). Distinct from `--min_p` (min-p sampling). |
+| `--draft_min <n>` | Min tokens to draft before `--p_min` applies (default 1; clamped to `[1, n_draft]`). |
+
+`--strategy DETERMINISTIC` selects the lossless greedy path; any temperature strategy (`CLASSIC_CHAT`/`FOCUSED`/`BALANCED`) makes speculation an exact memoryless sampler (temperature/top-k/top-p only). `CONSTRAINED`/`ADAPTIVE` and `--mmproj` are rejected up front (grammar/mirostat aren't memoryless; multimodal is unsupported).
+
+```bash
+# n-gram, lossless — great for repetitive output (code/JSON/RAG)
+java -jar llamaj.cpp-<ver>.jar --model model.gguf --strategy DETERMINISTIC --ngram 2 --n_draft 4
+
+# draft model, lossless, with adaptive early-stop
+java -jar llamaj.cpp-<ver>.jar --model target.gguf --draft draft.gguf \
+  --strategy DETERMINISTIC --n_draft 8 --p_min 0.6 --perf true
+```
+
+With `--perf true`, read the **`Effective generation`** line (emitted tokens ÷ wall-clock) and **`Speculative accept rate`** — the native `Generation speed` counter reads ~0 under speculation because batch-verified tokens aren't single-token decodes (so `n_eval` can't see them; they land under prompt eval). The realized speedup is **hardware-dependent**: largest on memory-bound datacenter GPUs where a verify batch is nearly as cheap as one decode, and more modest on Apple Silicon, where a multi-token verify batch costs meaningfully more than a single decode — so a high accept rate (more committed tokens per batch) is what makes it pay off there.
+
+## Options
+| Field | Factory / setter | Meaning |
+| --- | --- | --- |
+| `nDraft` | first ctor arg, `greedy(n)`, `.nDraft(n)`, `.withNDraft(n)` | Max tokens drafted/proposed per round (K / kMax), must be `>= 1`. |
+| `temperature` | `.temperature(t)`, `.withTemperature(t)` | Sampling temperature; `0` selects the greedy (argmax) path. |
+| `topK` | `.topK(k)`, `.withTopK(k)` | Top-K cutoff (`<= 0` disables). |
+| `topP` | `.topP(p)`, `.withTopP(p)` | Top-P / nucleus cutoff (`>= 1` disables). |
+| `seed` | `.seed(s)`, `.withSeed(s)` | RNG seed for draft sampling, the accept coin, and residual draws. |
+| `draftMin` | `greedyAdaptive(max, min, pMin)`, `.draftMin(n)` | Min tokens to draft before `pMin` early-stop applies; clamped to `[1, nDraft]`. |
+| `pMin` | `greedyAdaptive(...)`, `.pMin(p)`, `.withPMin(p)` | Draft-confidence floor; stop drafting once draft top-token prob drops below it (`<= 0` disables adaptive early stop). |
+| `ngram` | `ngramGreedy(kMax, ngram)`, `ngram(...)`, `.ngram(n)`, `.withNgram(n)` | `0` = draft model (`setDraft`); `>= 1` = n-gram prompt-lookup (`setNgram`). |
+
+Helpers: `isGreedy()` (`temperature <= 0`), `isAdaptive()` (`pMin > 0` and model-draft), `isNgram()` (`ngram > 0`). `builder()` defaults to greedy model-drafting with `nDraft == DEFAULT_N_DRAFT` (4); `toBuilder()` seeds a builder from an existing config.
+
+## Notes
+- **Only memoryless sampling is supported** inside speculation: `temperature`, `topK`, `topP`. Stateful/reshaping samplers (penalties, grammar, mirostat) are intentionally rejected because rejection sampling is exact only for memoryless distributions.
+- **Native vs Java split:** the per-position distribution (temperature → top-k → top-p → softmax) is computed by llama.cpp's native sampler chain; the rejection-sampling accept test, residual draw, and n-gram lookup are Java (no native primitive exists for them).
+- `setDraft` requires the draft context to share the target's vocab size (`draftContext.nVocab() == context.nVocab()`), otherwise it throws `LlamaException`. The conversation's main sampler is bypassed for accepted tokens — speculation is governed entirely by the `SpeculativeConfig`.
+- `setNgram` requires an n-gram config (`config.isNgram()`, i.e. `ngram >= 1`); calling it with a model-draft config throws. A missing n-gram match simply degrades the round to a single target decode — never wrong output.
+- **Lossless / exact regardless of draft quality:** the target verifies every proposed token and always commits at least one. A weaker draft only lowers `acceptRate()`, it never changes which tokens are emitted. `acceptRate()` is `0.0` until something is drafted.
+- **Adaptive early stop** (`pMin > 0`) changes only *how many* tokens are speculated per round, not *which* are emitted, so it preserves greedy losslessness and sampling exactness.
+- Works with both `DefaultLlamaIterator` (single sequence) and `BatchIterator` (fused multi-sequence). For the fused path, size the target context so `nBatch >= sum(nDraft + 1)` across sequences.
+- **Resources/lifecycle:** the `Speculation` allocates persistent native scratch (sampler chain + draft/verify batches) on the state's `Arena`, freed once on teardown. Close the iterator (try-with-resources) when abandoning a stream so the scratch is freed and the sequence cleared; the contexts stay reusable afterward.
+
+## See also
+- [Text Generation & Sampling](../text-generation/README.md) — the underlying sampler chain and iterators speculation builds on.
+- [Parallel Conversations (Batched Decoding)](../parallel-conversations/README.md) — the `BatchIterator` fused-step path used by speculative decoding.
+- [Log Probabilities](../logprobs/README.md) — per-token logprobs, also driven from the candidate distribution.
+- [Getting Started](../getting-started/README.md) — models, contexts, and arenas referenced above.

--- a/docs/text-generation/README.md
+++ b/docs/text-generation/README.md
@@ -1,0 +1,114 @@
+# Text Generation & Sampling
+
+> Stream a model's response token-by-token from a single conversation, controlling the output with a configurable sampler chain, max-token and stop-string limits.
+
+## Overview
+This is the core single-conversation generation path: you wrap a context, tokenizer and sampler in a `ConversationState`, seed it with a prompt via `initialize(...)`, then drive a `DefaultLlamaIterator` to decode tokens one at a time. Each step yields a `LlamaOutput` (the decoded text piece plus token count and optional logprobs), and generation stops when the model emits an end-of-generation token, hits `setMaxTokens(...)`, or matches a configured stop string. The `LlamaSampler` chain decides *how* the next token is picked (greedy, temperature/top-k/top-p/min-p, mirostat, penalties, grammar, fixed seed).
+
+## Key types
+- `ConversationState` — holds the context/tokenizer/sampler plus prompt, sequence id and limits; created with `create(...)` and configured with fluent setters then `initialize(prompt)`.
+- `DefaultLlamaIterator` — the autoregressive iterator over one state; exposes `stream()`, `hasNext()`/`next()`, and `close()` (it is `AutoCloseable`).
+- `LlamaIterator<T>` — base class providing `stream()` over the iterator.
+- `LlamaSampler` — a builder-style native sampler chain; each method (`temperature`, `topK`, `topP`, ...) appends a stage and returns `this`.
+- `LlamaOutput` — record of one emitted step: `content()` / `text()`, `numberOfTokens()`, `sequenceId()`, `performance()`, `logprobs()`; `merge(other)` concatenates.
+- `FinishReason` — why generation stopped: `EOS`, `STOP`, `LENGTH`, `TOOL_CALL`.
+
+## Usage
+```java
+import io.gravitee.llama.cpp.*;
+import java.lang.foreign.Arena;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Random;
+
+var arena = Arena.ofConfined();
+LlamaRuntime.llama_backend_init();
+
+// Model + context
+var model = new LlamaModel(arena, Path.of("models/model.gguf"), new LlamaModelParams(arena));
+var contextParams = new LlamaContextParams(arena).nCtx(2048).nBatch(512);
+var context = new LlamaContext(arena, model, contextParams);
+
+// Tokenizer + a configured sampler chain (order matters: stages apply in sequence)
+var vocab = new LlamaVocab(model);
+var tokenizer = new LlamaTokenizer(vocab, context);
+var sampler = new LlamaSampler(arena)
+    .seed(new Random().nextInt())
+    .temperature(0.75f)
+    .topK(40)
+    .topP(0.9f, 1)
+    .minP(0.05f, 1)
+    .penalties(64, 1.1f, 0.0f, 0.0f);
+
+// Conversation state: prompt + generation limits
+var state = ConversationState.create(arena, context, tokenizer, sampler)
+    .setMaxTokens(100)
+    .setStopStrings(List.of("\n\n", "User:"))
+    .initialize("What is the capital of France?");
+
+// Stream the response token-by-token
+var iterator = new DefaultLlamaIterator(state);
+String answer = iterator.stream()
+    .reduce(LlamaOutput::merge)
+    .orElse(new LlamaOutput("", 0))
+    .content();
+System.out.println(answer);
+
+// Or consume incrementally:
+// while (iterator.hasNext()) System.out.print(iterator.next().text());
+
+System.out.println("finish reason: " + state.getFinishReason());      // EOS / STOP / LENGTH
+System.out.println("in=" + state.getInputTokens() + " out=" + state.getAnswerTokens());
+
+// Cleanup (native resources)
+context.free();
+sampler.free();
+model.free();
+LlamaRuntime.llama_backend_free();
+```
+
+## Options
+
+### Sampler chain (`LlamaSampler`, fluent — each returns `this`)
+| Method | Effect |
+| --- | --- |
+| `greedy()` | Always pick the argmax token (deterministic). |
+| `temperature(float t)` | Scale logits; lower = sharper, higher = more random. |
+| `topK(int k)` | Keep only the `k` most-likely tokens. |
+| `topP(float p, int minKeep)` | Nucleus sampling: keep smallest set with cumulative prob ≥ `p` (at least `minKeep`). |
+| `minP(float p, int minKeep)` | Drop tokens below `p` × top-token prob (at least `minKeep`). |
+| `mirostat(int seed, float tau, float eta)` | Mirostat v2 adaptive-perplexity sampling. |
+| `penalties(int lastN, float repeat, float freq, float present)` | Repetition / frequency / presence penalties over the last `lastN` tokens. |
+| `grammar(LlamaVocab vocab, String grammar, String root)` | Constrain output to a GBNF grammar. |
+| `seed(int seed)` | Append the final distribution sampler with a fixed RNG seed (reproducible). |
+
+### Generation limits (`ConversationState`, fluent)
+| Method | Effect |
+| --- | --- |
+| `setMaxTokens(int n)` | Cap generated answer tokens; `-1` (default) means unlimited (until EOG/context full). Triggers `FinishReason.LENGTH`. |
+| `setStopStrings(List<String> stops)` | Stop as soon as the decoded tail matches any string; triggers `FinishReason.STOP`. |
+| `setTopLogprobs(int n)` | Attach top-`n` logprobs to each `LlamaOutput` (`0` = off). See the Log Probabilities doc. |
+| `initialize(String prompt)` | Tokenize the prompt and (re)set all generation state — call last. |
+
+### `FinishReason`
+| Value | Meaning |
+| --- | --- |
+| `EOS` / `STOP` | Model emitted an end-of-generation token or matched a stop string. |
+| `LENGTH` | `maxTokens` reached, or the context window filled. |
+| `TOOL_CALL` | A tool-call section completed (see Reasoning & Tool Calls). |
+
+## Notes
+- Call the fluent setters (`setMaxTokens`, `setStopStrings`, `setTopLogprobs`, ...) *before* `initialize(prompt)`; `initialize` resets generation state (and clears media) and tokenizes the prompt.
+- Build the sampler chain in the order you want stages applied. The final stochastic pick comes from `seed(...)` (a distribution sampler); use `greedy()` instead for fully deterministic output.
+- `LlamaSampler`, `LlamaContext` and `LlamaModel` own native memory — call `free()` on each (sampler and context are not freed by the iterator). In tests, `track(...)` your native resources so Metal buffers are released before JVM exit.
+- `DefaultLlamaIterator` is `AutoCloseable`: `close()` removes the sequence from the KV cache (and frees speculative scratch). Use try-with-resources if you abandon a stream early; a fully consumed stream cleans up via `onFinished()`.
+- `LlamaOutput.merge(...)` concatenates `content` and sums `numberOfTokens`, the idiomatic way to collect a full response from `stream()`.
+- After the stream ends, read `state.getFinishReason()`, `state.getInputTokens()` and `state.getAnswerTokens()`; performance metrics are available via `iterator.getPerformance()` when the context is built with `noPerf(false)`.
+- The prompt is decoded in chunks of `nBatch`; generation stops with `FinishReason.LENGTH` if the context window (`nCtx`) fills before EOG.
+
+## See also
+- [Getting Started](../getting-started/README.md) — minimal setup: backend init, model/context/sampler wiring.
+- [Log Probabilities](../logprobs/README.md) — `setTopLogprobs(n)` and the `Logprobs` payload on each `LlamaOutput`.
+- [Chat Templates](../chat-templates/README.md) — build the prompt string from system/user messages.
+- [Parallel Conversations (Batched Decoding)](../parallel-conversations/README.md) — run many `ConversationState`s in one batch.
+- [Speculative Decoding](../speculative-decoding/README.md) — draft/verify acceleration via `setDraft(...)` / `setNgram(...)`.

--- a/licenses/LICENSE-llama-cpp
+++ b/licenses/LICENSE-llama-cpp
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-2026 The ggml authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,42 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>licenses</directory>
+                <targetPath>META-INF</targetPath>
+                <includes>
+                    <include>LICENSE-llama-cpp</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>remove-native-libs-from-resources</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.basedir}/src/main/resources/macosx</directory>
+                                </fileset>
+                                <fileset>
+                                    <directory>${project.basedir}/src/main/resources/linux</directory>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
@@ -363,6 +398,7 @@
                         <licenseSet>
                             <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
                             <excludes>
+                                <exclude>licenses/LICENSE-llama-cpp</exclude>
                                 <exclude>CONTRIBUTING.adoc</exclude>
                                 <exclude>LICENSE.txt</exclude>
                                 <exclude>.circleci/config.yml</exclude>
@@ -400,6 +436,10 @@
                             <mainClass>io.gravitee.llama.cpp.Main</mainClass>
                         </manifest>
                     </archive>
+                    <excludes>
+                        <exclude>macosx/**</exclude>
+                        <exclude>linux/**</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>

--- a/scripts/download-native-libraries.sh
+++ b/scripts/download-native-libraries.sh
@@ -145,4 +145,8 @@ else
   exit 1
 fi
 
+# Drop libraries the binding never loads: llama.cpp's tool implementations (*-impl: cli, server, bench, quantize, perplexity, *-common).
+# We only call the C ABI (libllama / libmtmd / libggml*)
+find "$OUTPUT_DIR" -maxdepth 1 \( -name "*-common*" -o -name "*-impl*" \) -delete
+
 echo "✅ Downloaded and extracted libraries to $OUTPUT_DIR"

--- a/scripts/release_tag.sh
+++ b/scripts/release_tag.sh
@@ -27,10 +27,13 @@ echo "release version: $RELEASE_VERSION"
 
 mvn versions:set -DgenerateBackupPoms=false -DnewVersion="$RELEASE_VERSION"
 
+# Keep the README "Installation" dependency snippet in sync with the released version.
+sed -i'' -E "s|<version>${OLD_VERSION}</version>|<version>${RELEASE_VERSION}</version>|g" README.md
+
 conventional-changelog -p conventionalcommits -i CHANGELOG.md -s
 tail -n+3 CHANGELOG.md | sed -r "s/###/##/g" > ./release-note.md
 rm CHANGELOG.md
 
-git add pom.xml
+git add pom.xml README.md
 git commit -m "chore: release $RELEASE_VERSION [skip ci]"
 git tag -a "$RELEASE_VERSION" -m "$RELEASE_VERSION"

--- a/scripts/update_llama_cpp_version.sh
+++ b/scripts/update_llama_cpp_version.sh
@@ -23,6 +23,7 @@ CLONE_DIR="$HOME_DIR/llama.cpp"
 PROJECT_DIR="$HOME_DIR/llamaj.cpp"
 POM_FILE="$PROJECT_DIR/pom.xml"
 CIRCLECI_CONFIG="$PROJECT_DIR/.circleci/config.yml"
+README_FILE="$PROJECT_DIR/README.md"
 
 # --- Clone llama.cpp repo ---
 echo "Cloning llama.cpp into $CLONE_DIR..."
@@ -47,16 +48,25 @@ git checkout -b "$branch_name"
 echo "Updating versions from $OLD_LLAMA_CPP_VERSION to $NEW_LLAMA_CPP_VERSION..."
 sed -i'' -E "s/$OLD_LLAMA_CPP_VERSION/$NEW_LLAMA_CPP_VERSION/g" "$POM_FILE"
 sed -i'' -E "s/$OLD_LLAMA_CPP_VERSION/$NEW_LLAMA_CPP_VERSION/g" "$CIRCLECI_CONFIG"
+# README badge + attribution reference the pinned llama.cpp tag (e.g. b9673).
+sed -i'' -E "s/$OLD_LLAMA_CPP_VERSION/$NEW_LLAMA_CPP_VERSION/g" "$README_FILE"
+
+# --- Refresh the bundled llama.cpp license ---
+# Keep licenses/LICENSE-llama-cpp in sync with the version we ship
+LICENSE_DEST="$PROJECT_DIR/licenses/LICENSE-llama-cpp"
+echo "Refreshing $LICENSE_DEST from llama.cpp $NEW_LLAMA_CPP_VERSION..."
+mkdir -p "$PROJECT_DIR/licenses"
+cp "$CLONE_DIR/LICENSE" "$LICENSE_DEST"
 
 # --- Commit and push changes ---
 echo "Committing and pushing changes..."
-git add "$POM_FILE" "$CIRCLECI_CONFIG"
+git add "$POM_FILE" "$CIRCLECI_CONFIG" "$README_FILE" "$LICENSE_DEST"
 
-TITLE="chore(deps): update llama.cpp from $OLD_LLAMA_CPP_VERSION to $NEW_LLAMA_CPP_VERSION"
+TITLE="feat(deps): update llama.cpp from $OLD_LLAMA_CPP_VERSION to $NEW_LLAMA_CPP_VERSION"
 git commit -m "$TITLE"
 git push origin "$branch_name"
 
 # --- Create GitHub PR ---
 echo "Creating pull request..."
 gh pr create --title "$TITLE" \
-  --body "This PR updates llama.cpp from $OLD_LLAMA_CPP_VERSION to $NEW_LLAMA_CPP_VERSION"
+  --body "This PR updates llama.cpp from $OLD_LLAMA_CPP_VERSION to $NEW_LLAMA_CPP_VERSION."

--- a/src/main/java/io/gravitee/llama/cpp/BatchIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/BatchIterator.java
@@ -22,7 +22,9 @@ import java.util.*;
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
-public final class BatchIterator extends LlamaIterator<LlamaOutput> {
+public final class BatchIterator
+  extends LlamaIterator<LlamaOutput>
+  implements AutoCloseable {
 
   private final LlamaContext context;
   private final LlamaBatch batch;
@@ -32,6 +34,7 @@ public final class BatchIterator extends LlamaIterator<LlamaOutput> {
   private final List<LlamaOutput> currentOutputs = new ArrayList<>();
   private int currentOutputIndex = 0;
   private volatile boolean stopped = false;
+  private boolean freed = false;
 
   /**
    * Creates a parallel batch iterator.
@@ -98,6 +101,12 @@ public final class BatchIterator extends LlamaIterator<LlamaOutput> {
   private void processPromptForState(ConversationState state) {
     // Use the shared prompt processing method from base class
     processPrompt(state);
+    // Keep the draft cache (if any) in lockstep with the target after prompt prefill.
+    prefillDraft(state);
+    // Seed the n-gram history once the first token is sampled (n-gram mode, not finished).
+    if (state.isNgram() && state.getNewTokenId() != null) {
+      state.seedNgramHistory();
+    }
     // The state is now ready for parallel processing
     // (newTokenId is set, nPast is updated, first token sampled)
   }
@@ -146,10 +155,389 @@ public final class BatchIterator extends LlamaIterator<LlamaOutput> {
       return false;
     }
 
-    // Process the active states in smaller batches that fit the context's batch size (n_batch).
-    processInBatches(activeStates);
+    // Speculative states verify together in ONE target decode (fused); non-speculative states
+    // use the normal fused single-token batch.
+    List<ConversationState> speculative = new ArrayList<>();
+    List<ConversationState> normal = new ArrayList<>();
+    for (ConversationState state : activeStates) {
+      (state.isSpeculative() ? speculative : normal).add(state);
+    }
+    if (!speculative.isEmpty()) {
+      speculativeFusedStep(speculative);
+    }
+    if (!normal.isEmpty()) {
+      processInBatches(normal);
+    }
 
     return !currentOutputs.isEmpty();
+  }
+
+  /**
+   * Batched speculative decoding: draft all sequences (fused per shared draft context), then verify
+   * ALL of them in a single target decode (each sequence's {@code [idLast, drafts…]} packed under
+   * its own seq id), then accept / roll back per sequence. Greedy or rejection-sampling per the
+   * state's config.
+   *
+   * <p>The draft phase steps every sequence in lockstep: each draft step decodes one token per still
+   * drafting sequence in a single batched draft decode, so n sequences cost {@code max(nDraft)}
+   * draft forward passes instead of {@code sum(nDraft+1)} (plus one fused gap-fill decode, deferred
+   * to Phase D and run only for sequences that fully accepted). Sequences sharing a draft context
+   * fuse together; sequences become inactive when they hit their {@code nDraft} or stop early on low
+   * confidence (adaptive). Batching never changes a sequence's logits (sequences don't cross-attend),
+   * so each drafted token is identical to drafting the sequence on its own.
+   */
+  private void speculativeFusedStep(List<ConversationState> states) {
+    int n = states.size();
+    int nVocab = context.nVocab();
+
+    // Conservative pre-check: the fused target verify must hold every sequence's (nDraft + 1) tokens
+    // at once. Adaptive early stop only drafts fewer, so this upper bound stays safe.
+    long verifyTokens = 0;
+    for (ConversationState s : states) {
+      verifyTokens += s.getNDraft() + 1L;
+    }
+    if (verifyTokens > context.nBatch()) {
+      throw new LlamaException(
+        "Fused speculative verify needs n_batch >= " +
+          verifyTokens +
+          " (sum of nDraft+1 across sequences); got " +
+          context.nBatch()
+      );
+    }
+
+    int[][] drafted = new int[n][];
+    Speculation.Snapshot[][] snaps = new Speculation.Snapshot[n][];
+    LlamaSampler[] chains = new LlamaSampler[n];
+    int[] base = new int[n];
+    int[] nDrafted = new int[n];
+    // Phase A — propose drafts for all sequences. Each sequence's persistent chain (and the
+    // batches/buffers it uses) is owned by its Speculation and freed by Speculation.free() in
+    // cleanupState() on teardown, not per round. Model-draft sequences are decoded fused per shared
+    // draft context; n-gram sequences are proposed from history (no draft model, no decode).
+    for (int c = 0; c < n; c++) {
+      ConversationState s = states.get(c);
+      Speculation spec = s.getSpeculation();
+      int k = s.getNDraft();
+      chains[c] = spec.chain();
+      drafted[c] = new int[k];
+      // n-gram uses a per-position point-mass draft, so it needs no draft snapshots.
+      if (!spec.isGreedy() && !s.isNgram()) {
+        snaps[c] = new Speculation.Snapshot[k];
+      }
+    }
+    Map<LlamaContext, List<Integer>> byDraftContext = new LinkedHashMap<>();
+    for (int c = 0; c < n; c++) {
+      ConversationState s = states.get(c);
+      if (s.hasDraft()) {
+        byDraftContext
+          .computeIfAbsent(s.getDraftContext(), key -> new ArrayList<>())
+          .add(c);
+      } else {
+        // n-gram: propose up to nDraft tokens from the committed history (no draft decode).
+        int[] proposed = s.proposeNgram(s.getNDraft());
+        System.arraycopy(proposed, 0, drafted[c], 0, proposed.length);
+        nDrafted[c] = proposed.length;
+      }
+    }
+    for (var entry : byDraftContext.entrySet()) {
+      draftGroupFused(
+        states,
+        entry.getKey(),
+        entry.getValue(),
+        chains,
+        drafted,
+        snaps,
+        nDrafted
+      );
+    }
+
+    // Phase B — one fused target decode over all sequences' drafts.
+    batch.clear();
+    for (int c = 0; c < n; c++) {
+      ConversationState s = states.get(c);
+      base[c] = batch.nTokens();
+      var seq = List.of(s.getSequenceId());
+      batch.add(s.getNewTokenId(), s.getNPast(), seq, true);
+      for (int i = 0; i < nDrafted[c]; i++) {
+        batch.add(drafted[c][i], s.getNPast() + 1 + i, seq, true);
+      }
+    }
+    if (batch.decode(context) != 0) {
+      handleDecodeError(states);
+      return;
+    }
+
+    // Phase C — accept / roll back per sequence from its slice of the fused logits. Capture each
+    // sequence's pre-accept nPast and accepted count so Phase D can place the deferred fill.
+    int[] oldNPast = new int[n];
+    int[] matched = new int[n];
+    for (int c = 0; c < n; c++) {
+      oldNPast[c] = states.get(c).getNPast();
+      matched[c] = acceptSequence(
+        states.get(c),
+        chains[c],
+        base[c],
+        drafted[c],
+        nDrafted[c],
+        snaps[c],
+        nVocab
+      );
+    }
+
+    // Phase D — fused gap-fill, only for full-accept (still-running) sequences. On partial accept
+    // the rollback in Phase C already trimmed the over-drafted draft cells, so no fill is needed;
+    // skipping it saves a draft forward pass. Grouped by shared draft context like Phase A.
+    for (var entry : byDraftContext.entrySet()) {
+      fillGroupFused(
+        states,
+        entry.getKey(),
+        entry.getValue(),
+        drafted,
+        nDrafted,
+        matched,
+        oldNPast
+      );
+    }
+  }
+
+  /**
+   * Drafts a group of sequences that share one draft context, stepping them in lockstep so each
+   * draft step is a single batched decode. Writes each sequence's drafted tokens (and snapshots,
+   * for the rejection-sampling path) and actual drafted count into the per-sequence arrays, indexed
+   * by the sequence's global position {@code c}.
+   */
+  private void draftGroupFused(
+    List<ConversationState> states,
+    LlamaContext draftContext,
+    List<Integer> group,
+    LlamaSampler[] chains,
+    int[][] drafted,
+    Speculation.Snapshot[][] snaps,
+    int[] nDrafted
+  ) {
+    int g = group.size();
+    if (g > draftContext.nBatch()) {
+      throw new LlamaException(
+        "Fused speculative draft needs draft n_batch >= " +
+          g +
+          " (sequences sharing a draft context); got " +
+          draftContext.nBatch()
+      );
+    }
+    int nVocab = context.nVocab();
+    int[] prev = new int[g];
+    boolean[] active = new boolean[g];
+    float[] probOut = new float[1];
+    int maxK = 0;
+    for (int j = 0; j < g; j++) {
+      ConversationState s = states.get(group.get(j));
+      prev[j] = s.getNewTokenId();
+      active[j] = true;
+      nDrafted[group.get(j)] = 0;
+      maxK = Math.max(maxK, s.getNDraft());
+    }
+
+    // Reuse the iterator's persistent batch for the fused draft packing (cleared each step). Phase B
+    // (verify) and Phase D (fill) also clear it before their own use, so no stale tokens leak between
+    // phases, and there is no per-round draft-batch allocation.
+    int[] row = new int[g];
+    for (int step = 0; step < maxK; step++) {
+      batch.clear();
+      int packed = 0;
+      for (int j = 0; j < g; j++) {
+        if (!active[j]) {
+          continue;
+        }
+        ConversationState s = states.get(group.get(j));
+        // Logits output index == batch position (every token has logits=true).
+        row[j] = batch.nTokens();
+        batch.add(
+          prev[j],
+          s.getNPast() + step,
+          List.of(s.getSequenceId()),
+          true
+        );
+        packed++;
+      }
+      if (packed == 0) {
+        break;
+      }
+      if (batch.decode(draftContext) != 0) {
+        throw new LlamaException("Speculative draft decode failed");
+      }
+      for (int j = 0; j < g; j++) {
+        if (!active[j]) {
+          continue;
+        }
+        int c = group.get(j);
+        ConversationState s = states.get(c);
+        Speculation spec = s.getSpeculation();
+        int sampled;
+        float topProb;
+        if (spec.isGreedy()) {
+          if (spec.isAdaptive()) {
+            sampled = spec.draftGreedyConfident(
+              logitsRow(draftContext, row[j], nVocab),
+              nVocab,
+              probOut
+            );
+            topProb = probOut[0];
+          } else {
+            sampled = chains[c].sample(draftContext, row[j]);
+            topProb = 1.0f; // unused without adaptive stop
+          }
+        } else {
+          Speculation.Snapshot ds = spec.draft(
+            chains[c],
+            logitsRow(draftContext, row[j], nVocab)
+          );
+          sampled = ds.selectedId();
+          snaps[c][nDrafted[c]] = ds;
+          topProb = ds.maxProb();
+        }
+        drafted[c][nDrafted[c]] = sampled;
+        nDrafted[c]++;
+        prev[j] = sampled;
+        if (nDrafted[c] >= s.getNDraft()) {
+          active[j] = false;
+        } else if (
+          spec.isAdaptive() &&
+          nDrafted[c] >= spec.draftMin() &&
+          topProb < spec.pMin()
+        ) {
+          active[j] = false;
+        }
+      }
+    }
+  }
+
+  /**
+   * Accept the longest matching prefix for one sequence and roll back both caches. Returns the
+   * accepted count {@code matched} so the caller can issue the deferred (full-accept-only) gap-fill
+   * without re-running the accept test (which would advance the rejection-sampling RNG twice).
+   */
+  private int acceptSequence(
+    ConversationState s,
+    LlamaSampler chain,
+    int base,
+    int[] drafted,
+    int m,
+    Speculation.Snapshot[] snaps,
+    int nVocab
+  ) {
+    Speculation spec = s.getSpeculation();
+    int seqId = s.getSequenceId();
+    boolean ngram = s.isNgram();
+
+    int matched = 0;
+    int extra = -1;
+    for (int i = 0; i < m; i++) {
+      if (spec.isGreedy()) {
+        int t = chain.sample(context, base + i);
+        if (t == drafted[i]) {
+          matched++;
+        } else {
+          extra = t;
+          break;
+        }
+      } else {
+        // n-gram proposes a single certain token per position (point-mass q = 1); model drafting
+        // uses the draft snapshot's probability.
+        float qOfDrafted = ngram ? 1.0f : snaps[i].selectedProbability();
+        if (
+          spec.acceptTarget(
+            chain,
+            logitsRow(context, base + i, nVocab),
+            drafted[i],
+            qOfDrafted
+          )
+        ) {
+          matched++;
+        } else {
+          extra = ngram
+            ? spec.residualTargetPointMass(drafted[i])
+            : spec.residualTargetScatter(snaps[i]);
+          break;
+        }
+      }
+    }
+    if (matched == m) {
+      extra = spec.isGreedy()
+        ? chain.sample(context, base + m)
+        : spec.targetSelect(chain, logitsRow(context, base + m, nVocab));
+    }
+
+    int newNPast = s.getNPast() + matched + 1;
+    context.getMemory().seqRm(seqId, newNPast, -1);
+    // Roll back the draft cache only for model drafting (n-gram has none).
+    if (s.hasDraft()) {
+      s.getDraftContext().getMemory().seqRm(seqId, newNPast, -1);
+    }
+
+    boolean cont = true;
+    for (int i = 0; i < matched && cont; i++) {
+      cont = emitSpeculative(s, drafted[i], currentOutputs);
+    }
+    if (cont) {
+      emitSpeculative(s, extra, currentOutputs);
+    }
+
+    // Append the committed tokens to the n-gram history (keeps histLen == newNPast + 1).
+    if (ngram) {
+      for (int i = 0; i < matched; i++) {
+        s.appendHistory(drafted[i]);
+      }
+      s.appendHistory(extra);
+    }
+
+    s.setNPast(newNPast);
+    s.setNewTokenId(extra);
+    s.recordSpeculation(m, matched);
+    return matched;
+  }
+
+  /**
+   * Deferred gap-fill for a draft-context group: for each sequence that fully accepted its draft
+   * (and is still running), decode its last drafted token at {@code oldNPast+nDrafted} so the draft
+   * KV covers that position for the next round (no full-accept gap), fused into one draft decode.
+   * Partial-accept sequences were already trimmed by the Phase C rollback and need no fill.
+   */
+  private void fillGroupFused(
+    List<ConversationState> states,
+    LlamaContext draftContext,
+    List<Integer> group,
+    int[][] drafted,
+    int[] nDrafted,
+    int[] matched,
+    int[] oldNPast
+  ) {
+    int count = 0;
+    for (int c : group) {
+      if (matched[c] == nDrafted[c] && !states.get(c).isFinished()) {
+        count++;
+      }
+    }
+    if (count == 0) {
+      return;
+    }
+    // Reuse the iterator's persistent batch (clear first: it still holds Phase B's verify tokens, or
+    // a previous group's fill). count <= g <= draft n_batch, and g < target n_batch == batch capacity.
+    batch.clear();
+    for (int c : group) {
+      if (matched[c] == nDrafted[c] && !states.get(c).isFinished()) {
+        ConversationState s = states.get(c);
+        int m = nDrafted[c];
+        batch.add(
+          drafted[c][m - 1],
+          oldNPast[c] + m,
+          List.of(s.getSequenceId()),
+          true
+        );
+      }
+    }
+    if (batch.decode(draftContext) != 0) {
+      throw new LlamaException("Speculative draft decode failed");
+    }
   }
 
   /**
@@ -174,7 +562,7 @@ public final class BatchIterator extends LlamaIterator<LlamaOutput> {
       // is hit — this is distinct from finishReason which may be set as a
       // marker (e.g. TOOL_CALL) while the model is still producing tokens.
       if (state.isFinished()) {
-        cleanupState(state.getSequenceId());
+        cleanupState(state);
         it.remove();
         continue;
       }
@@ -184,7 +572,7 @@ public final class BatchIterator extends LlamaIterator<LlamaOutput> {
         processPromptForState(state);
         // If prompt processing immediately results in a finish condition, clean up.
         if (state.getFinishReason() != null) {
-          cleanupState(state.getSequenceId());
+          cleanupState(state);
           it.remove();
           continue;
         }
@@ -317,7 +705,7 @@ public final class BatchIterator extends LlamaIterator<LlamaOutput> {
   private void handleDecodeError(List<ConversationState> batchStates) {
     for (ConversationState state : batchStates) {
       state.setFinishReason(FinishReason.STOP);
-      cleanupState(state.getSequenceId());
+      cleanupState(state);
     }
     seqIdToState.clear();
   }
@@ -332,7 +720,7 @@ public final class BatchIterator extends LlamaIterator<LlamaOutput> {
   public boolean removeState(int sequenceId) {
     ConversationState state = seqIdToState.remove(sequenceId);
     if (state != null) {
-      cleanupState(sequenceId);
+      cleanupState(state);
       return true;
     }
     return false;
@@ -362,7 +750,7 @@ public final class BatchIterator extends LlamaIterator<LlamaOutput> {
     stopped = true;
 
     // Clean up all remaining sequences from KV cache
-    seqIdToState.values().forEach(state -> cleanupState(state.getSequenceId()));
+    seqIdToState.values().forEach(state -> cleanupState(state));
 
     seqIdToState.clear();
     firstTokenEmitted.clear();
@@ -381,7 +769,7 @@ public final class BatchIterator extends LlamaIterator<LlamaOutput> {
       .values()
       .stream()
       .filter(state -> state.getFinishReason() != null)
-      .forEach(state -> cleanupState(state.getSequenceId()));
+      .forEach(state -> cleanupState(state));
 
     seqIdToState.clear();
     firstTokenEmitted.clear();
@@ -408,15 +796,32 @@ public final class BatchIterator extends LlamaIterator<LlamaOutput> {
 
   /**
    * Frees resources used by this iterator.
-   * This stops the iterator and cleans up all sequences before freeing the batch.
+   * This stops the iterator (cleaning up all sequences, which frees their speculative scratch)
+   * before freeing the batch. Idempotent — safe to call alongside {@link #close()}.
    */
   public void free() {
+    if (freed) {
+      return;
+    }
+    freed = true;
     stop();
     batch.free();
   }
 
-  private void cleanupState(int sequenceId) {
+  /** AutoCloseable hook for try-with-resources; delegates to {@link #free()}. */
+  @Override
+  public void close() {
+    free();
+  }
+
+  private void cleanupState(ConversationState state) {
+    int sequenceId = state.getSequenceId();
     context.getMemory().seqRm(sequenceId, -1, -1);
+    // Free the speculative state's persistent native scratch (idempotent: null-on-free, so the
+    // common path of removal-then-stop never double-frees). Non-speculative states have none.
+    if (state.isSpeculative()) {
+      state.getSpeculation().free();
+    }
     firstTokenEmitted.remove(sequenceId);
     seqIdToBatchPos.remove(sequenceId);
   }

--- a/src/main/java/io/gravitee/llama/cpp/ConversationState.java
+++ b/src/main/java/io/gravitee/llama/cpp/ConversationState.java
@@ -16,6 +16,7 @@
 package io.gravitee.llama.cpp;
 
 import static io.gravitee.llama.cpp.GenerationState.ANSWER;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import io.gravitee.llama.cpp.LlamaTokenizer.TokenizerResponse;
 import io.gravitee.llama.cpp.modules.PromptMemory;
@@ -62,6 +63,20 @@ public class ConversationState {
   // Configuration
   private int maxTokens = -1;
   private int topLogprobs = 0;
+
+  // Optional speculative decoding: a draft context (separate small model, same vocab) whose
+  // KV is kept in lockstep with this state's target context. When set, the iterators run a
+  // draft→verify→accept cycle (greedy or rejection-sampling) instead of single-token decoding.
+  // For n-gram (prompt-lookup) drafting the draftContext is null and proposals come from `history`.
+  private LlamaContext draftContext;
+  private SpeculativeConfig speculativeConfig;
+  private Speculation speculation;
+  private long nDrafted;
+  private long nAccepted;
+
+  // N-gram (prompt-lookup) drafting history + position index (the committed token stream
+  // prompt+generated, on the heap, NOT the confined arena). Built lazily by setNgram().
+  private NgramIndex ngramIndex;
   private final List<StateBounds> stateBounds = new ArrayList<>();
   private List<MtmdMedia> media = new ArrayList<>();
 
@@ -163,6 +178,122 @@ public class ConversationState {
   public ConversationState setMaxTokens(int maxTokens) {
     this.maxTokens = maxTokens;
     return this;
+  }
+
+  /**
+   * Enables speculative decoding: {@code draftContext} (a small model sharing this target's
+   * tokenizer/vocab) proposes {@code config.nDraft()} tokens per step that the target verifies
+   * in a single decode. Greedy config is lossless w.r.t. greedy decoding; a sampling config
+   * (temp/top-k/top-p) uses rejection sampling, preserving the target distribution. The state's
+   * main sampler is bypassed for accepted tokens — speculative sampling is governed by
+   * {@code config}.
+   *
+   * @param draftContext A context over the draft model (must share the target's vocab size)
+   * @param config       Speculative decoding configuration
+   */
+  public ConversationState setDraft(
+    LlamaContext draftContext,
+    SpeculativeConfig config
+  ) {
+    if (draftContext.nVocab() != context.nVocab()) {
+      throw new LlamaException(
+        "Draft vocab size (" +
+          draftContext.nVocab() +
+          ") differs from target (" +
+          context.nVocab() +
+          ") — speculative decoding requires a shared tokenizer/vocab"
+      );
+    }
+    this.draftContext = draftContext;
+    this.speculativeConfig = config;
+    this.speculation = new Speculation(arena, context.nVocab(), config);
+    return this;
+  }
+
+  /**
+   * Enables n-gram (prompt-lookup) speculative decoding: proposes up to {@code config.nDraft()}
+   * tokens per round by matching the last {@code config.ngram()} committed tokens against this
+   * conversation's generation history — no draft model, no draft forward pass. The target still
+   * verifies every proposed token, so output is lossless (greedy) / exact (sampling). Requires an
+   * n-gram config ({@code config.isNgram()}).
+   */
+  public ConversationState setNgram(SpeculativeConfig config) {
+    if (!config.isNgram()) {
+      throw new LlamaException(
+        "setNgram requires an n-gram config (ngram >= 1); use setDraft for model drafting"
+      );
+    }
+    this.speculativeConfig = config;
+    this.speculation = new Speculation(arena, context.nVocab(), config);
+    this.ngramIndex = new NgramIndex(config.ngram());
+    return this;
+  }
+
+  public boolean hasDraft() {
+    return draftContext != null;
+  }
+
+  /** Whether any speculative drafting (model or n-gram) is enabled on this state. */
+  public boolean isSpeculative() {
+    return speculation != null;
+  }
+
+  /** Whether n-gram (prompt-lookup) drafting is enabled (vs model drafting). */
+  public boolean isNgram() {
+    return speculativeConfig != null && speculativeConfig.isNgram();
+  }
+
+  public LlamaContext getDraftContext() {
+    return draftContext;
+  }
+
+  public int getNDraft() {
+    return speculativeConfig.nDraft();
+  }
+
+  Speculation getSpeculation() {
+    return speculation;
+  }
+
+  /**
+   * Seeds the n-gram history with the prompt tokens plus the first sampled token (idLast). Must be
+   * called once after {@code processPrompt} has set {@code newTokenId} (n-gram mode only).
+   */
+  void seedNgramHistory() {
+    ngramIndex.clear();
+    int promptLen = tokenized.size();
+    var data = tokenized.data();
+    for (int i = 0; i < promptLen; i++) {
+      ngramIndex.append(data.getAtIndex(JAVA_INT, i));
+    }
+    ngramIndex.append(newTokenId); // idLast, position == nPast (not yet in KV)
+  }
+
+  /** Appends one committed token to the n-gram history (and its index). */
+  void appendHistory(int token) {
+    ngramIndex.append(token);
+  }
+
+  /**
+   * Proposes up to {@code kMax} draft tokens by finding the most recent earlier occurrence of the
+   * last {@code ngram} history tokens and returning the tokens that followed it (via the position
+   * index). Returns an empty array when there is no match (the round then degenerates to a single
+   * target decode). Pure heap/CPU work — no native calls, no draft KV. A wrong proposal only lowers
+   * the accept rate; the target verify is the sole arbiter of emitted tokens.
+   */
+  int[] proposeNgram(int kMax) {
+    return ngramIndex.propose(kMax);
+  }
+
+  /** Accumulates speculative accept statistics for {@link #acceptRate()}. */
+  public void recordSpeculation(int drafted, int accepted) {
+    this.nDrafted += drafted;
+    this.nAccepted += accepted;
+  }
+
+  /** Fraction of drafted tokens accepted so far — a sanity check on the speedup. */
+  public double acceptRate() {
+    return nDrafted == 0 ? 0.0 : (double) nAccepted / nDrafted;
   }
 
   /**

--- a/src/main/java/io/gravitee/llama/cpp/DefaultLlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/DefaultLlamaIterator.java
@@ -15,13 +15,26 @@
  */
 package io.gravitee.llama.cpp;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 /**
  * Default implementation of LlamaIterator that processes conversations token by token.
+ *
+ * <p>When the {@link ConversationState} has a draft context configured
+ * ({@link ConversationState#setDraft}), it runs greedy speculative decoding instead:
+ * a draft → verify → accept cycle producing a burst of tokens per step, drained one per
+ * {@link #next()} via {@link #pending}.
  *
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
-public final class DefaultLlamaIterator extends LlamaIterator<LlamaOutput> {
+public final class DefaultLlamaIterator
+  extends LlamaIterator<LlamaOutput>
+  implements AutoCloseable {
+
+  // Accepted speculative tokens awaiting emission (speculative mode only).
+  private final Deque<LlamaOutput> pending = new ArrayDeque<>();
 
   public DefaultLlamaIterator(
     ConversationState initialState,
@@ -36,6 +49,9 @@ public final class DefaultLlamaIterator extends LlamaIterator<LlamaOutput> {
 
   @Override
   protected boolean batch() {
+    if (currentState.isSpeculative()) {
+      return speculativeBatch();
+    }
     var arena = currentState.getArena();
     var context = currentState.getContext();
     var sampler = currentState.getSampler();
@@ -111,12 +127,64 @@ public final class DefaultLlamaIterator extends LlamaIterator<LlamaOutput> {
     );
   }
 
+  /** Speculative-mode step: prompt prefill (target + draft) + first token, then accept bursts. */
+  private boolean speculativeBatch() {
+    if (!pending.isEmpty()) {
+      return true;
+    }
+    if (currentState.isFinished()) {
+      return false;
+    }
+    if (currentState.getNewTokenId() == null) {
+      processPrompt(currentState);
+      prefillDraft(currentState); // no-op for n-gram (no draft context)
+      feedPromptMemory(currentState.getPiece());
+      if (currentState.getFinishReason() == null) {
+        if (currentState.isNgram()) {
+          currentState.seedNgramHistory();
+        }
+        pending.add(
+          new LlamaOutput(
+            currentState.getPiece(),
+            1,
+            currentState.getLogprobs()
+          )
+        );
+      } else {
+        currentState.setFinished(true);
+      }
+      return !pending.isEmpty();
+    }
+    pending.addAll(speculativeRound(currentState));
+    return !pending.isEmpty();
+  }
+
   @Override
   public LlamaOutput next() {
+    if (currentState.isSpeculative()) {
+      return pending.poll();
+    }
     return new LlamaOutput(
       currentState.getPiece(),
       1,
       currentState.getLogprobs()
     );
+  }
+
+  /**
+   * Releases this conversation's resources: frees the speculative state's persistent native scratch
+   * (if any) and removes its sequence from the context KV cache. Idempotent (null-on-free + a no-op
+   * seqRm), so it is safe whether the stream ran to completion or was abandoned early — call it via
+   * try-with-resources when not consuming the whole stream.
+   */
+  @Override
+  public void close() {
+    if (currentState.isSpeculative()) {
+      currentState.getSpeculation().free();
+    }
+    currentState
+      .getContext()
+      .getMemory()
+      .seqRm(currentState.getSequenceId(), -1, -1);
   }
 }

--- a/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
@@ -18,7 +18,11 @@ package io.gravitee.llama.cpp;
 import static io.gravitee.llama.cpp.FinishReason.*;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Stream;
@@ -376,11 +380,434 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
       );
   }
 
+  /* ----- speculative decoding (greedy / lossless) ----- */
+
+  /**
+   * Prefills the state's draft context with the same prompt tokens so its KV cache matches
+   * the target after {@link #processPrompt}. Text-only (speculative + multimodal is
+   * unsupported). No-op when the state has no draft.
+   */
+  protected void prefillDraft(ConversationState state) {
+    if (!state.hasDraft()) {
+      return;
+    }
+    var draft = state.getDraftContext();
+    var tokenized = state.getTokenized();
+    int total = tokenized.size();
+    int nBatch = Math.max(1, draft.nBatch());
+    int seqId = state.getSequenceId();
+    // Start from a clean draft KV for this seqId: with a shared draft context, a reused seqId
+    // would otherwise inherit stale cells from a previous sequence (degrades accept rate; can't
+    // corrupt output since the target still verifies every token).
+    draft.getMemory().seqRm(seqId, -1, -1);
+    int offset = 0;
+    while (offset < total) {
+      int chunk = Math.min(nBatch, total - offset);
+      LlamaBatch batch = new LlamaBatch(state.getArena(), chunk, 0, 1);
+      try {
+        for (int i = 0; i < chunk; i++) {
+          int tok = tokenized.data().getAtIndex(JAVA_INT, offset + i);
+          batch.add(tok, offset + i, java.util.List.of(seqId), false);
+        }
+        if (batch.decode(draft) != 0) {
+          throw new LlamaException("Draft prefill decode failed");
+        }
+      } finally {
+        batch.free();
+      }
+      offset += chunk;
+    }
+  }
+
+  /**
+   * Runs one greedy draft → verify → accept cycle for a speculative state and returns the
+   * accepted tokens as outputs. The draft proposes {@code nDraft} tokens; the target verifies
+   * them in a single decode; the longest matching prefix (plus one correction/bonus token the
+   * target picks) is committed and both KV caches are rolled back to the accepted boundary.
+   * Output is identical to greedy decoding on the target.
+   *
+   * <p>Requires {@code state.getNewTokenId()} to be set (the last token, not yet in either KV).
+   * Updates the state's {@code nPast} and {@code newTokenId}; sets the finish reason on EOG or
+   * token-limit.
+   */
+  protected List<LlamaOutput> speculativeRound(ConversationState state) {
+    if (state.isNgram()) {
+      return speculativeNgramRound(state);
+    }
+    return state.getSpeculation().isGreedy()
+      ? speculativeGreedyRound(state)
+      : speculativeStochasticRound(state);
+  }
+
+  /**
+   * One n-gram (prompt-lookup) speculative round: propose tokens from the committed history, verify
+   * them in a single target decode, accept the longest matching prefix (greedy) or via rejection
+   * sampling against a point-mass draft (stochastic), then roll back ONLY the target cache — there
+   * is no draft model and no draft KV. Output is identical to plain greedy / an exact target sample.
+   */
+  private List<LlamaOutput> speculativeNgramRound(ConversationState state) {
+    LlamaContext target = state.getContext();
+    Speculation spec = state.getSpeculation();
+    int seqId = state.getSequenceId();
+    int kMax = state.getNDraft();
+    int nPast = state.getNPast();
+    int idLast = state.getNewTokenId();
+    int nVocab = target.nVocab();
+    boolean greedy = spec.isGreedy();
+    var seq = java.util.List.of(seqId);
+
+    int[] drafted = state.proposeNgram(kMax);
+    int m = drafted.length;
+
+    LlamaSampler chain = spec.chain();
+    LlamaBatch verifyBatch = spec.verifyBatch();
+    List<LlamaOutput> out = new ArrayList<>();
+    try {
+      verifyBatch.clear();
+      verifyBatch.add(idLast, nPast, seq, true);
+      for (int i = 0; i < m; i++) {
+        verifyBatch.add(drafted[i], nPast + 1 + i, seq, true);
+      }
+      if (verifyBatch.decode(target) != 0) {
+        throw new LlamaException("Speculative verify decode failed");
+      }
+
+      int matched = 0;
+      int extra = -1;
+      if (greedy) {
+        int correction = -1;
+        for (int i = 0; i < m; i++) {
+          int t = chain.sample(target, i);
+          if (t == drafted[i]) {
+            matched++;
+          } else {
+            correction = t;
+            break;
+          }
+        }
+        extra = matched == m ? chain.sample(target, m) : correction;
+      } else {
+        for (int i = 0; i < m; i++) {
+          // n-gram proposes a single certain token per position → a point-mass draft (q = 1).
+          if (
+            spec.acceptTarget(
+              chain,
+              logitsRow(target, i, nVocab),
+              drafted[i],
+              1.0f
+            )
+          ) {
+            matched++;
+          } else {
+            extra = spec.residualTargetPointMass(drafted[i]);
+            break;
+          }
+        }
+        if (matched == m) {
+          extra = spec.targetSelect(chain, logitsRow(target, m, nVocab));
+        }
+      }
+
+      // Roll back ONLY the target cache (no draft cache exists).
+      int newNPast = nPast + matched + 1;
+      target.getMemory().seqRm(seqId, newNPast, -1);
+
+      boolean cont = true;
+      for (int i = 0; i < matched && cont; i++) {
+        cont = emitSpeculative(state, drafted[i], out);
+      }
+      if (cont) {
+        emitSpeculative(state, extra, out);
+      }
+
+      // Append the committed tokens (matched drafts + the extra) to history so the next round can
+      // look them up; keeps histLen == newNPast + 1 regardless of EOG/quota early stop.
+      for (int i = 0; i < matched; i++) {
+        state.appendHistory(drafted[i]);
+      }
+      state.appendHistory(extra);
+
+      state.setNPast(newNPast);
+      state.setNewTokenId(extra);
+      state.recordSpeculation(m, matched);
+      return out;
+    } catch (RuntimeException e) {
+      spec.free(); // release persistent native scratch on failure (idempotent)
+      throw e;
+    }
+  }
+
+  private List<LlamaOutput> speculativeGreedyRound(ConversationState state) {
+    LlamaContext target = state.getContext();
+    LlamaContext draft = state.getDraftContext();
+    Speculation spec = state.getSpeculation();
+    int seqId = state.getSequenceId();
+    int draftMax = state.getNDraft();
+    int nPast = state.getNPast();
+    int idLast = state.getNewTokenId();
+    int nVocab = target.nVocab();
+    boolean adaptive = spec.isAdaptive();
+    int draftMin = spec.draftMin();
+    float pMin = spec.pMin();
+    var seq = java.util.List.of(seqId);
+
+    // Persistent per-state scratch, reused across rounds and freed by spec.free() on teardown.
+    LlamaSampler greedy = spec.chain(); // greedy config => greedy sampler
+    LlamaBatch draftBatch = spec.draftBatch();
+    LlamaBatch verifyBatch = spec.verifyBatch();
+    List<LlamaOutput> out = new ArrayList<>();
+    float[] probOut = new float[1];
+    try {
+      // Draft up to draftMax tokens (positions nPast..nPast+m-1), stopping early once the draft's
+      // top-token probability drops below pMin (adaptive only) — those tokens would likely be
+      // rejected anyway, so drafting them wastes draft and target compute. The drafted token is
+      // always the argmax, so output stays identical to plain greedy.
+      int[] drafted = new int[draftMax];
+      int m = 0;
+      int prev = idLast;
+      for (int i = 0; i < draftMax; i++) {
+        draftBatch.clear();
+        draftBatch.add(prev, nPast + i, seq, true);
+        if (draftBatch.decode(draft) != 0) {
+          throw new LlamaException("Speculative draft decode failed");
+        }
+        int sampled = adaptive
+          ? spec.draftGreedyConfident(
+            logitsRow(draft, -1, nVocab),
+            nVocab,
+            probOut
+          )
+          : greedy.sample(draft);
+        drafted[m++] = sampled;
+        prev = sampled;
+        if (adaptive && m >= draftMin && probOut[0] < pMin) {
+          break;
+        }
+      }
+
+      // Verify all drafts in one target decode.
+      verifyBatch.clear();
+      verifyBatch.add(idLast, nPast, seq, true);
+      for (int i = 0; i < m; i++) {
+        verifyBatch.add(drafted[i], nPast + 1 + i, seq, true);
+      }
+      if (verifyBatch.decode(target) != 0) {
+        throw new LlamaException("Speculative verify decode failed");
+      }
+
+      // Accept the longest matching prefix; batch index i predicts slot drafted[i].
+      int matched = 0;
+      int correction = -1;
+      for (int i = 0; i < m; i++) {
+        int t = greedy.sample(target, i);
+        if (t == drafted[i]) {
+          matched++;
+        } else {
+          correction = t;
+          break;
+        }
+      }
+      int extra = matched == m ? greedy.sample(target, m) : correction;
+
+      // Roll back both caches to the accepted boundary.
+      int newNPast = nPast + matched + 1;
+      target.getMemory().seqRm(seqId, newNPast, -1);
+      draft.getMemory().seqRm(seqId, newNPast, -1);
+
+      // Fill decode, only on full accept: advance the draft KV by one so it covers position nPast+m
+      // for next round (no gap). On partial accept the seqRm above already trimmed the draft past
+      // nPast+matched, so a fill would be discarded — skipping it saves a draft forward pass. The
+      // sampled token is discarded.
+      if (matched == m) {
+        draftBatch.clear();
+        draftBatch.add(prev, nPast + m, seq, true);
+        if (draftBatch.decode(draft) != 0) {
+          throw new LlamaException("Speculative draft decode failed");
+        }
+      }
+
+      boolean cont = true;
+      for (int i = 0; i < matched && cont; i++) {
+        cont = emitSpeculative(state, drafted[i], out);
+      }
+      if (cont) {
+        emitSpeculative(state, extra, out);
+      }
+
+      state.setNPast(newNPast);
+      state.setNewTokenId(extra);
+      state.recordSpeculation(m, matched);
+      return out;
+    } catch (RuntimeException e) {
+      spec.free(); // release persistent native scratch on failure (idempotent)
+      throw e;
+    }
+  }
+
+  /**
+   * Rejection-sampling speculative round (temp/top-k/top-p). The native sampler chain produces
+   * the per-position distributions ({@link Speculation}); accept each drafted token with
+   * probability {@code min(1, p/q)}, else take a draw from the normalized residual.
+   */
+  private List<LlamaOutput> speculativeStochasticRound(
+    ConversationState state
+  ) {
+    LlamaContext target = state.getContext();
+    LlamaContext draft = state.getDraftContext();
+    Speculation spec = state.getSpeculation();
+    int seqId = state.getSequenceId();
+    int k = state.getNDraft();
+    int nPast = state.getNPast();
+    int idLast = state.getNewTokenId();
+    int nVocab = target.nVocab();
+    var seq = java.util.List.of(seqId);
+
+    boolean adaptive = spec.isAdaptive();
+    int draftMin = spec.draftMin();
+    float pMin = spec.pMin();
+
+    // Persistent per-state scratch, reused across rounds and freed by spec.free() on teardown.
+    LlamaSampler chain = spec.chain();
+    LlamaBatch draftBatch = spec.draftBatch();
+    LlamaBatch verifyBatch = spec.verifyBatch();
+    List<LlamaOutput> out = new ArrayList<>();
+    try {
+      // Draft up to k tokens, stopping early once the draft distribution's top probability drops
+      // below pMin (adaptive only). The drafted tokens and their snapshots are unchanged regardless
+      // of m, so the rejection-sampling decision per accepted token stays exact.
+      int[] drafted = new int[k];
+      Speculation.Snapshot[] draftSnaps = new Speculation.Snapshot[k];
+      int m = 0;
+      int prev = idLast;
+      for (int i = 0; i < k; i++) {
+        draftBatch.clear();
+        draftBatch.add(prev, nPast + i, seq, true);
+        if (draftBatch.decode(draft) != 0) {
+          throw new LlamaException("Speculative draft decode failed");
+        }
+        Speculation.Snapshot s = spec.draft(
+          chain,
+          logitsRow(draft, -1, nVocab)
+        );
+        drafted[m] = s.selectedId();
+        draftSnaps[m] = s;
+        m++;
+        prev = drafted[m - 1];
+        if (adaptive && m >= draftMin && s.maxProb() < pMin) {
+          break;
+        }
+      }
+
+      verifyBatch.clear();
+      verifyBatch.add(idLast, nPast, seq, true);
+      for (int i = 0; i < m; i++) {
+        verifyBatch.add(drafted[i], nPast + 1 + i, seq, true);
+      }
+      if (verifyBatch.decode(target) != 0) {
+        throw new LlamaException("Speculative verify decode failed");
+      }
+
+      int matched = 0;
+      int extra = -1;
+      for (int i = 0; i < m; i++) {
+        if (
+          spec.acceptTarget(
+            chain,
+            logitsRow(target, i, nVocab),
+            drafted[i],
+            draftSnaps[i].selectedProbability()
+          )
+        ) {
+          matched++;
+        } else {
+          extra = spec.residualTargetScatter(draftSnaps[i]);
+          break;
+        }
+      }
+      if (matched == m) {
+        extra = spec.targetSelect(chain, logitsRow(target, m, nVocab));
+      }
+
+      int newNPast = nPast + matched + 1;
+      target.getMemory().seqRm(seqId, newNPast, -1);
+      draft.getMemory().seqRm(seqId, newNPast, -1);
+
+      // Fill decode only on full accept (see greedy round). Token discarded.
+      if (matched == m) {
+        draftBatch.clear();
+        draftBatch.add(prev, nPast + m, seq, true);
+        if (draftBatch.decode(draft) != 0) {
+          throw new LlamaException("Speculative draft decode failed");
+        }
+      }
+
+      boolean cont = true;
+      for (int i = 0; i < matched && cont; i++) {
+        cont = emitSpeculative(state, drafted[i], out);
+      }
+      if (cont) {
+        emitSpeculative(state, extra, out);
+      }
+
+      state.setNPast(newNPast);
+      state.setNewTokenId(extra);
+      state.recordSpeculation(m, matched);
+      return out;
+    } catch (RuntimeException e) {
+      spec.free(); // release persistent native scratch on failure (idempotent)
+      throw e;
+    }
+  }
+
+  /** Logit row for batch output {@code idx}, reinterpreted as {@code nVocab} floats. */
+  protected MemorySegment logitsRow(LlamaContext ctx, int idx, int nVocab) {
+    MemorySegment ptr = LlamaRuntime.llama_get_logits_ith(ctx.segment, idx);
+    if (ptr == null || ptr.address() == 0) {
+      throw new LlamaException("llama_get_logits_ith returned NULL");
+    }
+    return ptr.reinterpret((long) nVocab * ValueLayout.JAVA_FLOAT.byteSize());
+  }
+
+  /**
+   * Emits one accepted speculative token (reusing the shared detokenize / token-tracking /
+   * stop logic). Returns {@code false} and marks the state finished on EOG or token-limit.
+   */
+  protected boolean emitSpeculative(
+    ConversationState state,
+    int token,
+    List<LlamaOutput> out
+  ) {
+    if (state.getTokenizer().isEog(token)) {
+      if (state.getFinishReason() != TOOL_CALL) {
+        state.setFinishReason(STOP);
+      }
+      state.setFinished(true);
+      return false;
+    }
+    String piece = decodeTokenPiece(state, token);
+    processSampledToken(state, piece); // updates generation state + token tracking
+    // Mirror the autoregressive iterator: the token that reaches the quota is counted but
+    // NOT emitted (the AR path stops via hasNotReachedQuota() after incrementing). Drop it
+    // here too, otherwise speculative emits one extra token at the boundary.
+    int max = state.getMaxTokens();
+    if (max != -1 && state.getAnswerTokens() >= max) {
+      state.setFinishReason(LENGTH);
+      state.setFinished(true);
+      return false;
+    }
+    out.add(new LlamaOutput(piece, 1, state.getSequenceId()));
+    return true;
+  }
+
   /**
    * Called when iteration completes.
-   * Automatically cleans up the sequence from KV cache.
+   * Automatically cleans up the sequence from KV cache and frees the speculative state's persistent
+   * native scratch (idempotent).
    */
   protected void onFinished() {
+    if (currentState.isSpeculative()) {
+      currentState.getSpeculation().free();
+    }
     if (currentState.getFinishReason() != null) {
       currentState
         .getContext()

--- a/src/main/java/io/gravitee/llama/cpp/LlamaRuntime.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaRuntime.java
@@ -785,16 +785,26 @@ public final class LlamaRuntime {
    * @return A new mtmd_bitmap pointer, or NULL (address 0) on failure
    */
   public static MemorySegment mtmd_helper_bitmap_init_from_buf(
+    SegmentAllocator allocator,
     MemorySegment mtmdContext,
     MemorySegment buf,
-    long len
+    long len,
+    boolean placeholder
   ) {
     return llama_h(
       "mtmd_helper_bitmap_init_from_buf",
-      new Class<?>[] { MEM_SEG_CLASS, MEM_SEG_CLASS, long.class },
+      new Class<?>[] {
+        SegmentAllocator.class,
+        MEM_SEG_CLASS,
+        MEM_SEG_CLASS,
+        long.class,
+        boolean.class,
+      },
+      allocator,
       mtmdContext,
       buf,
-      len
+      len,
+      placeholder
     );
   }
 
@@ -830,11 +840,15 @@ public final class LlamaRuntime {
     );
   }
 
-  public static boolean mtmd_decode_use_non_causal(MemorySegment mtmdContext) {
+  public static boolean mtmd_decode_use_non_causal(
+    MemorySegment mtmdContext,
+    MemorySegment chunk
+  ) {
     return llama_h(
       "mtmd_decode_use_non_causal",
-      new Class<?>[] { MEM_SEG_CLASS },
-      mtmdContext
+      new Class<?>[] { MEM_SEG_CLASS, MEM_SEG_CLASS },
+      mtmdContext,
+      chunk
     );
   }
 
@@ -2643,14 +2657,6 @@ public final class LlamaRuntime {
       new Class<?>[] { MEM_SEG_CLASS, int.class },
       segment,
       nThreads
-    );
-  }
-
-  public static int mtmd_context_params_verbosity(MemorySegment segment) {
-    return (int) mtmd_context_params(
-      "verbosity",
-      new Class<?>[] { MEM_SEG_CLASS },
-      segment
     );
   }
 

--- a/src/main/java/io/gravitee/llama/cpp/LlamaRuntime.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaRuntime.java
@@ -1271,6 +1271,18 @@ public final class LlamaRuntime {
     );
   }
 
+  public static void llama_sampler_apply(
+    MemorySegment sampler,
+    MemorySegment curP
+  ) {
+    llama_h(
+      "llama_sampler_apply",
+      new Class<?>[] { MEM_SEG_CLASS, MEM_SEG_CLASS },
+      sampler,
+      curP
+    );
+  }
+
   public static void llama_sampler_chain_add(
     MemorySegment sampler,
     MemorySegment config

--- a/src/main/java/io/gravitee/llama/cpp/LlamaTokenDataArray.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaTokenDataArray.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static io.gravitee.llama.cpp.LlamaRuntime.llama_sampler_apply;
+
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SegmentAllocator;
+import java.lang.foreign.ValueLayout;
+
+/**
+ * Reusable candidate buffer mirroring the native {@code llama_token_data_array}.
+ *
+ * <p>Holds an {@code n_vocab}-sized array of {@code llama_token_data} records plus the
+ * array header. Unlike {@link LlamaSampler#sample}, which reads the context logits and
+ * returns only a token id, this lets a caller feed an arbitrary logit row through the
+ * sampler chain via {@link LlamaRuntime#llama_sampler_apply} and read back both the
+ * selected token and its probability. {@link DiffusionGenerator} uses it once per masked
+ * position per denoising step, so the buffer is allocated once and refilled in place.
+ *
+ * <p>Layouts are written with raw {@link ValueLayout} accessors that match the
+ * jextract-generated {@code llama_token_data} ({@code {int id; float logit; float p;}},
+ * 12 bytes) and {@code llama_token_data_array}
+ * ({@code {token_data* data; size_t size; int64_t selected; bool sorted;}}, 32 bytes)
+ * struct layouts on all supported 64-bit platforms.
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public final class LlamaTokenDataArray {
+
+  // llama_token_data: { llama_token id; float logit; float p; }
+  private static final long TD_ID_OFFSET = 0;
+  private static final long TD_LOGIT_OFFSET = 4;
+  private static final long TD_P_OFFSET = 8;
+  private static final long TD_SIZE = 12;
+
+  // llama_token_data_array: { llama_token_data* data; size_t size; int64_t selected; bool sorted; }
+  private static final long ARR_DATA_OFFSET = 0;
+  private static final long ARR_SIZE_OFFSET = 8;
+  private static final long ARR_SELECTED_OFFSET = 16;
+  private static final long ARR_SORTED_OFFSET = 24;
+  private static final long ARR_SIZE = 32;
+
+  private final int nVocab;
+  private final MemorySegment data; // n_vocab * llama_token_data
+  private final MemorySegment array; // the llama_token_data_array header
+
+  public LlamaTokenDataArray(SegmentAllocator allocator, int nVocab) {
+    this.nVocab = nVocab;
+    this.data = allocator.allocate(TD_SIZE * nVocab, 4);
+    this.array = allocator.allocate(ARR_SIZE, 8);
+    array.set(ValueLayout.ADDRESS, ARR_DATA_OFFSET, data);
+    array.set(ValueLayout.JAVA_LONG, ARR_SIZE_OFFSET, nVocab);
+  }
+
+  /**
+   * Populates the candidate buffer from a logit row and resets the array header so the
+   * sampler chain treats every token as a fresh, unsorted candidate.
+   *
+   * @param logits     A segment over at least {@code n_vocab} floats (one decoded row)
+   * @param rowOffset  Float offset into {@code logits} where the row begins
+   */
+  public void fill(MemorySegment logits, long rowOffset) {
+    for (int id = 0; id < nVocab; id++) {
+      long base = (long) id * TD_SIZE;
+      float logit = logits.getAtIndex(ValueLayout.JAVA_FLOAT, rowOffset + id);
+      data.set(ValueLayout.JAVA_INT, base + TD_ID_OFFSET, id);
+      data.set(ValueLayout.JAVA_FLOAT, base + TD_LOGIT_OFFSET, logit);
+      data.set(ValueLayout.JAVA_FLOAT, base + TD_P_OFFSET, 0.0f);
+    }
+    array.set(ValueLayout.JAVA_LONG, ARR_SIZE_OFFSET, nVocab);
+    array.set(ValueLayout.JAVA_LONG, ARR_SELECTED_OFFSET, -1L);
+    array.set(ValueLayout.JAVA_BYTE, ARR_SORTED_OFFSET, (byte) 0);
+  }
+
+  /** Runs the sampler chain in place over the current candidates. */
+  public void apply(LlamaSampler sampler) {
+    llama_sampler_apply(sampler.segment, array);
+  }
+
+  /** Index selected by the last {@link #apply}, or {@code -1} if none. */
+  public long selectedIndex() {
+    return array.get(ValueLayout.JAVA_LONG, ARR_SELECTED_OFFSET);
+  }
+
+  /**
+   * Current number of live candidates. After {@link #apply}, truncating samplers
+   * (top-k / top-p) may shrink this below {@code nVocab}; entries beyond it are stale.
+   */
+  public long size() {
+    return array.get(ValueLayout.JAVA_LONG, ARR_SIZE_OFFSET);
+  }
+
+  private long selectedByteBase() {
+    long sel = selectedIndex();
+    if (sel < 0) {
+      throw new LlamaException("No token selected; call apply() first");
+    }
+    return sel * TD_SIZE;
+  }
+
+  /** Token id of the selected candidate. */
+  public int selectedId() {
+    return data.get(ValueLayout.JAVA_INT, selectedByteBase() + TD_ID_OFFSET);
+  }
+
+  /** Probability of the selected candidate (its confidence). */
+  public float selectedProbability() {
+    return data.get(ValueLayout.JAVA_FLOAT, selectedByteBase() + TD_P_OFFSET);
+  }
+
+  /** Probability of the candidate at {@code index} after {@link #apply}. */
+  public float probabilityAt(long index) {
+    return data.get(ValueLayout.JAVA_FLOAT, index * TD_SIZE + TD_P_OFFSET);
+  }
+
+  /**
+   * Token id of the candidate at {@code index}. After {@link #apply} the array is sorted /
+   * truncated by the sampler chain, so the index no longer equals the token id.
+   */
+  public int idAt(long index) {
+    return data.get(ValueLayout.JAVA_INT, index * TD_SIZE + TD_ID_OFFSET);
+  }
+
+  public int nVocab() {
+    return nVocab;
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/Main.java
+++ b/src/main/java/io/gravitee/llama/cpp/Main.java
@@ -77,7 +77,7 @@ public class Main {
     }
   }
 
-  public static void main(String[] args) {
+  static void main(String[] args) {
     Map<String, String> params = parseArgs(args);
 
     String modelGguf = params.get("model");

--- a/src/main/java/io/gravitee/llama/cpp/Main.java
+++ b/src/main/java/io/gravitee/llama/cpp/Main.java
@@ -265,7 +265,31 @@ public class Main {
     SamplingStrategy strategy = SamplingStrategy.fromString(
       params.get("strategy")
     );
+
+    // Speculative decoding (optional): validate up front so we fail before loading a draft model.
+    SpeculativeConfig speculativeConfig = speculativeConfig(strategy, params);
+    if (speculativeConfig != null && mmprojGguf != null) {
+      System.err.println(
+        "Error: speculative decoding is not supported together with multimodal (--mmproj)."
+      );
+      System.exit(1);
+    }
+
     LlamaContext context = new LlamaContext(ARENA, model, contextParams);
+
+    // Optional draft model + context for model drafting. setDraft() enforces a shared vocab size.
+    LlamaModel draftModel = null;
+    LlamaContext draftContext = null;
+    String draftGguf = params.get("draft");
+    if (draftGguf != null && !draftGguf.isBlank()) {
+      draftModel = new LlamaModel(
+        ARENA,
+        Path.of(draftGguf).toAbsolutePath(),
+        modelParameters
+      );
+      draftContext = new LlamaContext(ARENA, draftModel, contextParams);
+    }
+
     LlamaSampler sampler = llamaSampler(strategy, context, vocab, params);
 
     List<LlamaChatMessage> messages = new ArrayList<>();
@@ -331,6 +355,16 @@ public class Main {
         .setMaxTokens(quota)
         .setMedia(initialMedia); // Set initial media (images and/or audio)
 
+      // Enable speculation for this turn: model drafting if a draft context exists, else n-gram.
+      // DefaultLlamaIterator dispatches to the speculative path when state.isSpeculative().
+      if (speculativeConfig != null) {
+        if (draftContext != null) {
+          state.setDraft(draftContext, speculativeConfig);
+        } else {
+          state.setNgram(speculativeConfig);
+        }
+      }
+
       if (reasoningTags.isConfigured()) {
         state.setReasoning(reasoningTags.openTag, reasoningTags.closeTag);
       }
@@ -344,13 +378,20 @@ public class Main {
       // Create iterator with state
       var iterator = new DefaultLlamaIterator(state, mtmdContext);
 
-      // Filter reasoning tags from display, but keep tool tags visible
+      // Filter reasoning tags from display, but keep tool tags visible.
+      // Measure generation in wall-clock and sum emitted tokens: under speculative decoding the
+      // native gen-speed counter (single-token n_eval) can't see batch-verified tokens, and the
+      // target context's timers exclude the draft model — so emitted/wall-clock is the honest rate.
+      int[] emitted = { 0 };
+      long genStartNs = System.nanoTime();
       var answer = iterator
         .stream()
+        .peek(o -> emitted[0] += o.numberOfTokens())
         .map(LlamaOutput::content)
         .peek(System.out::print)
         .reduce((a, b) -> a + b)
         .orElse("");
+      double genWallSec = (System.nanoTime() - genStartNs) / 1_000_000_000.0;
 
       if (LlamaLogLevel.DEBUG.equals(logLevel)) {
         if (reasoningTags.isConfigured()) {
@@ -394,6 +435,19 @@ public class Main {
           perf.sampler().sampleCount(),
           perf.averageSamplingTimeMs()
         );
+        if (state.isSpeculative()) {
+          System.out.printf(
+            "Speculative accept rate: %.2f%n",
+            state.acceptRate()
+          );
+        }
+        // Speculation-correct rate: emitted tokens over wall-clock (captures draft + target time).
+        // Compare this line across --draft vs no-draft runs; the native gen-speed above is invalid
+        // under speculation. Includes prompt time, so use a short prompt or large --quota to compare.
+        System.out.printf(
+          "Effective generation: %.2f tokens/sec%n",
+          genWallSec > 0 ? emitted[0] / genWallSec : 0.0
+        );
         System.out.println("===================");
       }
 
@@ -411,7 +465,13 @@ public class Main {
 
     context.free();
     sampler.free();
+    if (draftContext != null) {
+      draftContext.free();
+    }
     model.free();
+    if (draftModel != null) {
+      draftModel.free();
+    }
     if (mtmdContext != null) {
       mtmdContext.free();
     }
@@ -485,6 +545,109 @@ public class Main {
         )
         .seed(seed);
     };
+  }
+
+  /**
+   * Builds the {@link SpeculativeConfig} for the run, or {@code null} when neither {@code --draft}
+   * (model drafting) nor {@code --ngram} (prompt-lookup) is requested. Greedy (lossless) under the
+   * DETERMINISTIC strategy; an exact memoryless sampler (temperature/top-k/top-p) otherwise. Rejects
+   * strategies whose sampler is not memoryless (grammar/mirostat) and the draft+ngram combination.
+   */
+  private static SpeculativeConfig speculativeConfig(
+    SamplingStrategy strategy,
+    Map<String, String> params
+  ) {
+    String draftPath = params.get("draft");
+    boolean modelDraft = draftPath != null && !draftPath.isBlank();
+    boolean ngramDraft = params.containsKey("ngram");
+
+    if (params.containsKey("draft") && !modelDraft) {
+      System.err.println(
+        "Error: --draft requires a path to a draft GGUF model."
+      );
+      System.exit(1);
+    }
+    if (!modelDraft && !ngramDraft) {
+      return null;
+    }
+    if (modelDraft && ngramDraft) {
+      System.err.println(
+        "Error: use either --draft (model drafting) or --ngram (prompt-lookup), not both."
+      );
+      System.exit(1);
+    }
+    if (
+      strategy == SamplingStrategy.CONSTRAINED ||
+      strategy == SamplingStrategy.ADAPTIVE
+    ) {
+      System.err.println(
+        "Error: speculative decoding is incompatible with the " +
+          strategy +
+          " strategy — grammar/mirostat are not memoryless. Use DETERMINISTIC for lossless " +
+          "greedy, or a temperature strategy (CLASSIC_CHAT/FOCUSED/BALANCED) for exact sampling."
+      );
+      System.exit(1);
+    }
+
+    boolean greedy = strategy == SamplingStrategy.DETERMINISTIC;
+    int nDraft = parseSpecInt(params.get("n_draft"), 4);
+
+    if (!greedy) {
+      System.out.println(
+        "Note: speculative draws use only temperature/top-k/top-p — other sampler shaping " +
+          "(penalties, min-p, grammar, mirostat) does not apply during speculation."
+      );
+    }
+
+    float temperature = Float.parseFloat(
+      params.getOrDefault("temperature", "0.7")
+    );
+    int topK = parseInt(params.getOrDefault("top_k", "40"));
+    float topP = Float.parseFloat(params.getOrDefault("top_p", "0.9"));
+    long seed = Long.parseLong(params.getOrDefault("seed", "42"));
+
+    // Adaptive early-stop: draft fewer tokens when draft confidence falls below pMin. Model-draft
+    // only — n-gram has no draft-model confidence to gate on. pMin <= 0 disables it.
+    float pMin = parseSpecFloat(params.get("p_min"), 0.0f);
+    int draftMin = parseSpecInt(params.get("draft_min"), 1);
+    boolean adaptive = pMin > 0.0f;
+
+    if (ngramDraft) {
+      if (adaptive) {
+        System.err.println(
+          "Error: --p_min/--draft_min (adaptive early-stop) apply only to --draft model drafting, not --ngram."
+        );
+        System.exit(1);
+      }
+      int ngram = parseSpecInt(params.get("ngram"), 2);
+      return greedy
+        ? SpeculativeConfig.ngramGreedy(nDraft, ngram)
+        : SpeculativeConfig.ngram(nDraft, ngram, temperature, topK, topP, seed);
+    }
+
+    if (greedy) {
+      return adaptive
+        ? SpeculativeConfig.greedyAdaptive(nDraft, draftMin, pMin)
+        : SpeculativeConfig.greedy(nDraft);
+    }
+    SpeculativeConfig sampling = new SpeculativeConfig(
+      nDraft,
+      temperature,
+      topK,
+      topP,
+      seed
+    );
+    return adaptive ? sampling.withDraftMin(draftMin).withPMin(pMin) : sampling;
+  }
+
+  private static int parseSpecInt(String value, int fallback) {
+    return (value == null || value.isBlank()) ? fallback : parseInt(value);
+  }
+
+  private static float parseSpecFloat(String value, float fallback) {
+    return (value == null || value.isBlank())
+      ? fallback
+      : Float.parseFloat(value);
   }
 
   private static String safeRead(String grammar) {
@@ -669,10 +832,25 @@ public class Main {
                                     instruction: Only keep system message + current user input
 
       Logging:
-        --log_level <LEVEL>         Log level: TRACE, DEBUG, INFO, WARN, ERROR (default: ERROR)
+        --log_level <LEVEL>         Log level: TRACE, DEBUG, INFO, WARN, ERROR (default: INFO)
 
       Performance:
         --perf <true|false>         Show performance metrics (default: false)
+
+      Speculative decoding (optional; draft-->verify-->accept speedup):
+        --draft <path>              Draft model GGUF for model drafting (must share the target's
+                                    vocab). Mutually exclusive with --ngram.
+        --ngram <window>            Enable n-gram prompt-lookup drafting with this window, no draft
+                                    model (default window: 2).
+        --n_draft <int>             Max tokens drafted/proposed per round (default: 4).
+                                    Lossless greedy under --strategy DETERMINISTIC; otherwise an exact
+                                    sampler using temperature/top-k/top-p only (penalties/min-p/grammar/
+                                    mirostat do not apply). Incompatible with CONSTRAINED/ADAPTIVE and --mmproj.
+        --p_min <float>             Adaptive early-stop: stop drafting once the draft's top-token
+                                    probability drops below this (model drafting only; 0 = disabled).
+                                    Distinct from --min_p (which is min-p sampling).
+        --draft_min <int>           Min tokens to draft before --p_min applies (default: 1; clamped to
+                                    [1, n_draft]).
 
       Tag handling:
         --reasoning_tags <open|close>  Reasoning tags to filter from output (default: disabled)
@@ -717,6 +895,9 @@ public class Main {
         java -jar llamaj.cpp.jar --model ./llava.gguf --mmproj ./mmproj.gguf --image ./image.jpg --system "Describe this image."
         java -jar llamaj.cpp.jar --model ./qwen.gguf --mmproj ./mmproj.gguf --media ./audio.wav --system "Transcribe this audio."
         java -jar llamaj.cpp.jar --model ./model.gguf --rpc 192.168.1.10:50052,192.168.1.11:50052
+        java -jar llamaj.cpp.jar --model ./model.gguf --strategy DETERMINISTIC --ngram 2 --n_draft 4
+        java -jar llamaj.cpp.jar --model ./model.gguf --strategy DETERMINISTIC --draft ./draft.gguf --n_draft 6
+        java -jar llamaj.cpp.jar --model ./model.gguf --strategy DETERMINISTIC --draft ./draft.gguf --n_draft 8 --p_min 0.6
       """
     );
   }

--- a/src/main/java/io/gravitee/llama/cpp/MtmdContext.java
+++ b/src/main/java/io/gravitee/llama/cpp/MtmdContext.java
@@ -141,11 +141,16 @@ public class MtmdContext extends MemorySegmentAware implements Freeable {
       0,
       fileBytes.length
     );
-    MemorySegment bitmap = mtmd_helper_bitmap_init_from_buf(
+    // We decode single image/audio files here (placeholder=false, no video), so the
+    // bitmap pointer is the first field at offset 0.
+    MemorySegment wrapper = mtmd_helper_bitmap_init_from_buf(
+      arena,
       segment,
       buf,
-      fileBytes.length
+      fileBytes.length,
+      false
     );
+    MemorySegment bitmap = wrapper.get(ValueLayout.ADDRESS, 0);
     if (bitmap == null || bitmap.address() == 0) {
       throw new LlamaException(
         "Failed to create bitmap from file bytes (unsupported format or corrupt data)"

--- a/src/main/java/io/gravitee/llama/cpp/NgramIndex.java
+++ b/src/main/java/io/gravitee/llama/cpp/NgramIndex.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Committed-token history for n-gram (prompt-lookup) drafting, with an incrementally-maintained
+ * position index so a proposal is ~O(1) amortized instead of an O(history) backward scan (the latter
+ * makes a whole generation O(n²)).
+ *
+ * <p>The index maps a rolling hash of each {@code ngram}-token window to the start positions where it
+ * occurs (most recent last). Appending a token indexes the one window it completes in O(ngram); a
+ * proposal hashes the current window, takes the most recent earlier start with matching tokens
+ * (collisions are resolved by an actual token comparison), and returns what followed it. The result
+ * is identical to a straightforward backward scan (the {@code NgramLookupTest} oracle) — a wrong
+ * proposal could only lower the accept rate, never change emitted tokens.
+ *
+ * <p>Single-threaded per conversation state, like the rest of the speculative scratch.
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+final class NgramIndex {
+
+  private static final int[] NO_DRAFT = new int[0];
+  private static final long HASH_PRIME = 1099511628211L;
+
+  private final int ngram;
+  private int[] history;
+  private int histLen;
+  private final Map<Long, Positions> index = new HashMap<>();
+
+  NgramIndex(int ngram) {
+    this.ngram = ngram;
+    this.history = new int[16];
+  }
+
+  /** Resets to empty, reusing the buffer — for a re-initialized conversation. */
+  void clear() {
+    histLen = 0;
+    index.clear();
+  }
+
+  /** Appends one committed token and indexes the {@code ngram} window it completes (if any). */
+  void append(int token) {
+    if (histLen == history.length) {
+      history = Arrays.copyOf(history, history.length * 2);
+    }
+    int p = histLen;
+    history[histLen++] = token;
+    if (p >= ngram - 1) {
+      int start = p - ngram + 1;
+      index.computeIfAbsent(hashAt(start), k -> new Positions()).add(start);
+    }
+  }
+
+  /**
+   * Proposes up to {@code kMax} tokens that followed the most recent earlier occurrence of the last
+   * {@code ngram} tokens; empty array if there is no earlier match.
+   */
+  int[] propose(int kMax) {
+    if (histLen < ngram + 1) {
+      return NO_DRAFT;
+    }
+    int patStart = histLen - ngram;
+    Positions ps = index.get(hashAt(patStart));
+    if (ps != null) {
+      for (int i = ps.size - 1; i >= 0; i--) {
+        int start = ps.data[i];
+        // Skip the current window itself and resolve any hash collision by comparing tokens.
+        if (start >= patStart || !matches(start, patStart)) {
+          continue;
+        }
+        int contStart = start + ngram;
+        int k = Math.min(kMax, histLen - contStart);
+        int[] out = new int[k];
+        System.arraycopy(history, contStart, out, 0, k);
+        return out;
+      }
+    }
+    return NO_DRAFT;
+  }
+
+  private long hashAt(int start) {
+    long h = 0;
+    for (int t = 0; t < ngram; t++) {
+      h = h * HASH_PRIME + history[start + t];
+    }
+    return h;
+  }
+
+  private boolean matches(int a, int b) {
+    for (int t = 0; t < ngram; t++) {
+      if (history[a + t] != history[b + t]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Minimal growable int list (amortized O(1) append, no boxing). */
+  private static final class Positions {
+
+    private int[] data = new int[4];
+    private int size = 0;
+
+    void add(int p) {
+      if (size == data.length) {
+        data = Arrays.copyOf(data, data.length * 2);
+      }
+      data[size++] = p;
+    }
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/Speculation.java
+++ b/src/main/java/io/gravitee/llama/cpp/Speculation.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.Random;
+
+/**
+ * Speculative-decoding sampling support shared by {@link LlamaIterator}'s single-sequence
+ * round and {@link BatchIterator}'s fused step.
+ *
+ * <p>The per-position distribution (temperature → top-k → top-p → softmax) is computed
+ * <b>natively</b> by the sampler chain applied to a {@link LlamaTokenDataArray}
+ * ({@code llama_sampler_apply}); this class only adds the rejection-sampling decision and
+ * residual draw, which have no native primitive. Reusable candidate buffers (one per role)
+ * are allocated once and reused across rounds.
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+final class Speculation {
+
+  /** Post-sampler candidate distribution snapshot ({@code id -> prob} over the kept support). */
+  record Snapshot(
+    int[] ids,
+    float[] probs,
+    int selectedId,
+    float selectedProbability
+  ) {
+    /** Highest probability over the kept support — the draft's confidence (for adaptive stop). */
+    float maxProb() {
+      float max = 0.0f;
+      for (float p : probs) {
+        if (p > max) {
+          max = p;
+        }
+      }
+      return max;
+    }
+  }
+
+  private final SpeculativeConfig config;
+  private final Arena arena;
+  private final LlamaTokenDataArray targetBuf;
+  private final LlamaTokenDataArray draftBuf;
+  private final Random rng;
+  // Reusable dense q-by-token-id buffer for the residual draw, kept all-zero between calls so a
+  // residual is O(support) instead of O(support²) (the old per-id linear probOf scan).
+  private final float[] qScatter;
+
+  // Persistent native scratch, built once and reused every round (cleared in place), then freed by
+  // free() exactly once on teardown. Reusing them avoids per-round native init/free and the
+  // confined-arena growth from re-allocating these structs every round. Nullable / lazily built.
+  private LlamaSampler chain;
+  private LlamaBatch draftBatch;
+  private LlamaBatch verifyBatch;
+
+  Speculation(Arena arena, int nVocab, SpeculativeConfig config) {
+    this.config = config;
+    this.arena = arena;
+    this.targetBuf = new LlamaTokenDataArray(arena, nVocab);
+    this.draftBuf = new LlamaTokenDataArray(arena, nVocab);
+    this.rng = new Random(config.seed());
+    this.qScatter = new float[nVocab];
+  }
+
+  boolean isGreedy() {
+    return config.isGreedy();
+  }
+
+  boolean isAdaptive() {
+    return config.isAdaptive();
+  }
+
+  int draftMin() {
+    return config.draftMin();
+  }
+
+  float pMin() {
+    return config.pMin();
+  }
+
+  /**
+   * Lazily-built persistent sampler chain for this config (greedy, or temp/top-k/top-p/dist),
+   * reused across rounds. Reuse gives the stochastic chain a single continuous RNG stream (more
+   * correct than re-seeding every round); the greedy chain is stateless. Freed by {@link #free()}.
+   */
+  LlamaSampler chain() {
+    if (chain == null) {
+      chain = buildChain();
+    }
+    return chain;
+  }
+
+  /** Builds the (memoryless) sampler chain for this config on the persistent arena. */
+  private LlamaSampler buildChain() {
+    LlamaSampler s = new LlamaSampler(arena);
+    if (config.isGreedy()) {
+      return s.greedy();
+    }
+    if (config.topK() > 0) {
+      s.topK(config.topK());
+    }
+    if (config.topP() < 1.0f) {
+      s.topP(config.topP(), 1);
+    }
+    s.temperature(config.temperature());
+    s.seed((int) config.seed());
+    return s;
+  }
+
+  /** Persistent single-token draft batch (reused via {@code clear()}). */
+  LlamaBatch draftBatch() {
+    if (draftBatch == null) {
+      draftBatch = new LlamaBatch(arena, 1, 0, 1);
+    }
+    return draftBatch;
+  }
+
+  /** Persistent verify batch sized for idLast + up to {@code nDraft} drafted tokens. */
+  LlamaBatch verifyBatch() {
+    if (verifyBatch == null) {
+      verifyBatch = new LlamaBatch(arena, config.nDraft() + 1, 0, 1);
+    }
+    return verifyBatch;
+  }
+
+  /**
+   * Frees the persistent native resources exactly once. Each field is NULLed so the call is
+   * idempotent (a double-free is a no-op) and a re-initialized conversation lazily rebuilds them on
+   * next use. Must be called on the owning iterator thread before the state's arena is closed.
+   */
+  void free() {
+    if (chain != null) {
+      chain.free();
+      chain = null;
+    }
+    if (draftBatch != null) {
+      draftBatch.free();
+      draftBatch = null;
+    }
+    if (verifyBatch != null) {
+      verifyBatch.free();
+      verifyBatch = null;
+    }
+  }
+
+  /**
+   * Greedy draft step with a confidence read, computed directly from the logit row with a two-pass
+   * online softmax — no candidate-buffer fill, no native sampler, no sort. Returns the argmax token
+   * id (the greedy pick, identical to a plain greedy sampler; strict {@code >} gives the lowest-id
+   * tie-break) and writes its softmax probability {@code 1/Σexp(logit-maxLogit)} into
+   * {@code probOut[0]}. Used only when adaptive early stop is enabled.
+   */
+  int draftGreedyConfident(
+    MemorySegment logitsRow,
+    int nVocab,
+    float[] probOut
+  ) {
+    int argmax = 0;
+    float maxLogit = logitsRow.getAtIndex(JAVA_FLOAT, 0);
+    for (int id = 1; id < nVocab; id++) {
+      float l = logitsRow.getAtIndex(JAVA_FLOAT, id);
+      if (l > maxLogit) {
+        maxLogit = l;
+        argmax = id;
+      }
+    }
+    double sum = 0.0;
+    for (int id = 0; id < nVocab; id++) {
+      sum += Math.exp(logitsRow.getAtIndex(JAVA_FLOAT, id) - maxLogit);
+    }
+    probOut[0] = (float) (1.0 / sum); // exp(maxLogit-maxLogit)=1, so the top prob is 1/sum
+    return argmax;
+  }
+
+  Snapshot draft(LlamaSampler chain, MemorySegment logitsRow) {
+    return snapshot(draftBuf, chain, logitsRow);
+  }
+
+  /** Selected token only — applies the chain to the target buffer and returns its choice. */
+  int targetSelect(LlamaSampler chain, MemorySegment logitsRow) {
+    return select(targetBuf, chain, logitsRow);
+  }
+
+  private static int select(
+    LlamaTokenDataArray buf,
+    LlamaSampler chain,
+    MemorySegment logitsRow
+  ) {
+    buf.fill(logitsRow, 0);
+    buf.apply(chain);
+    return buf.selectedId();
+  }
+
+  private static Snapshot snapshot(
+    LlamaTokenDataArray buf,
+    LlamaSampler chain,
+    MemorySegment logitsRow
+  ) {
+    buf.fill(logitsRow, 0);
+    buf.apply(chain);
+    int size = (int) buf.size();
+    int[] ids = new int[size];
+    float[] probs = new float[size];
+    for (int i = 0; i < size; i++) {
+      ids[i] = buf.idAt(i);
+      probs[i] = buf.probabilityAt(i);
+    }
+    return new Snapshot(
+      ids,
+      probs,
+      buf.selectedId(),
+      buf.selectedProbability()
+    );
+  }
+
+  /* ----- native-buffer verify ----- */
+
+  /**
+   * Rejection-sampling accept test operating directly on the persistent {@code targetBuf}: fills and
+   * applies the chain once (leaving {@code targetBuf} populated for a possible {@link
+   * #residualTargetScatter} / {@link #residualTargetPointMass}), then accepts the drafted token with
+   * probability {@code min(1, p/qOfDrafted)} where {@code p} is its post-chain target probability.
+   * {@code qOfDrafted} is the draft probability of the drafted token (the snapshot's selected
+   * probability for model drafting, {@code 1} for the point-mass n-gram draft). RNG advances exactly
+   * as the {@link Snapshot}-based {@link #accept} (one native apply + at most one accept coin), so the
+   * sampled distribution is identical — this only avoids materializing the target snapshot.
+   */
+  boolean acceptTarget(
+    LlamaSampler chain,
+    MemorySegment logitsRow,
+    int draftedToken,
+    float qOfDrafted
+  ) {
+    targetBuf.fill(logitsRow, 0);
+    targetBuf.apply(chain);
+    if (qOfDrafted <= 0.0f) {
+      return true;
+    }
+    double ratio = targetProbOf(draftedToken) / qOfDrafted;
+    return ratio >= 1.0 || rng.nextDouble() < ratio;
+  }
+
+  /** Probability of {@code token} in the just-applied {@code targetBuf} (0 outside the kept support). */
+  private float targetProbOf(int token) {
+    int n = (int) targetBuf.size();
+    for (int i = 0; i < n; i++) {
+      if (targetBuf.idAt(i) == token) {
+        return targetBuf.probabilityAt(i);
+      }
+    }
+    return 0.0f;
+  }
+
+  /**
+   * Residual draw over the already-applied {@code targetBuf} against a model-draft distribution:
+   * samples from the normalized {@code (p - q)₊}, with {@code q} scattered by id. Allocation-free
+   * (two passes; no {@code float[]} of differences). Must be called immediately after a rejecting
+   * {@link #acceptTarget} for the same position (no intervening fill/apply).
+   */
+  int residualTargetScatter(Snapshot draft) {
+    int[] draftIds = draft.ids();
+    float[] draftProbs = draft.probs();
+    for (int i = 0; i < draftIds.length; i++) {
+      qScatter[draftIds[i]] = draftProbs[i];
+    }
+    try {
+      int n = (int) targetBuf.size();
+      double sum = 0.0;
+      for (int i = 0; i < n; i++) {
+        float diff = targetBuf.probabilityAt(i) - qScatter[targetBuf.idAt(i)];
+        if (diff > 0.0f) {
+          sum += diff;
+        }
+      }
+      if (sum <= 0.0) {
+        return targetBuf.selectedId();
+      }
+      double u = rng.nextDouble() * sum;
+      double acc = 0.0;
+      int last = targetBuf.selectedId();
+      for (int i = 0; i < n; i++) {
+        int id = targetBuf.idAt(i);
+        float diff = targetBuf.probabilityAt(i) - qScatter[id];
+        if (diff > 0.0f) {
+          last = id;
+          acc += diff;
+          if (u < acc) {
+            return id;
+          }
+        }
+      }
+      return last;
+    } finally {
+      for (int i = 0; i < draftIds.length; i++) {
+        qScatter[draftIds[i]] = 0.0f;
+      }
+    }
+  }
+
+  /**
+   * Residual draw over the already-applied {@code targetBuf} against a point-mass n-gram draft at
+   * {@code token}: samples from the target probabilities with {@code token} removed (since
+   * {@code (p - 1)₊ = 0} there) and renormalized. Allocation-free. Must be called immediately after
+   * a rejecting {@link #acceptTarget} for the same position.
+   */
+  int residualTargetPointMass(int token) {
+    int n = (int) targetBuf.size();
+    double sum = 0.0;
+    for (int i = 0; i < n; i++) {
+      if (targetBuf.idAt(i) != token) {
+        float p = targetBuf.probabilityAt(i);
+        if (p > 0.0f) {
+          sum += p;
+        }
+      }
+    }
+    if (sum <= 0.0) {
+      return targetBuf.selectedId();
+    }
+    double u = rng.nextDouble() * sum;
+    double acc = 0.0;
+    int last = targetBuf.selectedId();
+    for (int i = 0; i < n; i++) {
+      int id = targetBuf.idAt(i);
+      if (id != token) {
+        float p = targetBuf.probabilityAt(i);
+        if (p > 0.0f) {
+          last = id;
+          acc += p;
+          if (u < acc) {
+            return id;
+          }
+        }
+      }
+    }
+    return last;
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/SpeculativeConfig.java
+++ b/src/main/java/io/gravitee/llama/cpp/SpeculativeConfig.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+/**
+ * Configuration for speculative decoding (see {@link ConversationState#setDraft}).
+ *
+ * <p>Only memoryless sampling is supported, because rejection sampling is exact only for it:
+ * {@code temperature}, {@code topK}, {@code topP}. {@code temperature == 0} selects the
+ * greedy (argmax) path, which is lossless w.r.t. greedy decoding. Stateful/reshaping
+ * samplers (penalties, grammar, mirostat) are intentionally not supported here.
+ *
+ * <p><b>Adaptive draft length.</b> {@code nDraft} is the <i>maximum</i> tokens drafted per round.
+ * When {@code pMin > 0}, the draft stops early as soon as its own top-token probability falls
+ * below {@code pMin} (after at least {@code draftMin} tokens) — tokens drafted past the point
+ * where the draft is unsure are usually rejected by the target and waste both draft and target
+ * compute. Stopping early never changes <i>which</i> tokens are emitted (the target still verifies
+ * every drafted token and always commits at least one), only <i>how many</i> are speculated, so it
+ * preserves greedy losslessness and rejection-sampling exactness. {@code pMin <= 0} (the default)
+ * disables early stop, always drafting exactly {@code nDraft} tokens.
+ *
+ * @param nDraft      Maximum tokens the draft proposes per round (K), must be >= 1
+ * @param temperature Sampling temperature; {@code 0} = greedy
+ * @param topK        Top-K cutoff ({@code <= 0} disables)
+ * @param topP        Top-P / nucleus cutoff ({@code >= 1} disables)
+ * @param seed        RNG seed for draft sampling, the accept coin, and residual draws
+ * @param draftMin    Minimum tokens to draft before the {@code pMin} early-stop applies
+ *                    (clamped to {@code [1, nDraft]})
+ * @param pMin        Draft-confidence floor: stop drafting once the draft's top-token probability
+ *                    drops below this ({@code <= 0} disables adaptive early stop)
+ * @param ngram       N-gram (prompt-lookup) drafting: {@code 0} = use a draft model (see
+ *                    {@link ConversationState#setDraft}); {@code >= 1} = draft tokens by matching the
+ *                    last {@code ngram} committed tokens against the generation history (no draft
+ *                    model, no draft forward pass — see {@link ConversationState#setNgram}). The
+ *                    target still verifies every proposed token, so it stays lossless/exact.
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public record SpeculativeConfig(
+  int nDraft,
+  float temperature,
+  int topK,
+  float topP,
+  long seed,
+  int draftMin,
+  float pMin,
+  int ngram
+) {
+  public SpeculativeConfig {
+    if (nDraft < 1) {
+      throw new LlamaException("nDraft must be >= 1");
+    }
+    if (ngram < 0) {
+      throw new LlamaException("ngram must be >= 0");
+    }
+    // Keep draftMin in [1, nDraft] so a round always drafts at least one and at most nDraft tokens.
+    draftMin = Math.max(1, Math.min(draftMin, nDraft));
+  }
+
+  /** Model-draft config (no n-gram) with explicit adaptive parameters. */
+  public SpeculativeConfig(
+    int nDraft,
+    float temperature,
+    int topK,
+    float topP,
+    long seed,
+    int draftMin,
+    float pMin
+  ) {
+    this(nDraft, temperature, topK, topP, seed, draftMin, pMin, 0);
+  }
+
+  /**
+   * Backward-compatible fixed-length model-draft config: always drafts exactly {@code nDraft}
+   * tokens (no adaptive early stop, no n-gram).
+   */
+  public SpeculativeConfig(
+    int nDraft,
+    float temperature,
+    int topK,
+    float topP,
+    long seed
+  ) {
+    this(nDraft, temperature, topK, topP, seed, nDraft, 0.0f);
+  }
+
+  /** Greedy (argmax) model-draft speculative decoding with the given fixed draft window. */
+  public static SpeculativeConfig greedy(int nDraft) {
+    return new SpeculativeConfig(nDraft, 0.0f, 0, 1.0f, 0L);
+  }
+
+  /**
+   * Greedy (argmax) model-draft speculative decoding with adaptive draft length: drafts between
+   * {@code draftMin} and {@code draftMax} tokens per round, stopping early when the draft's
+   * top-token probability drops below {@code pMin}. Lossless w.r.t. greedy decoding.
+   */
+  public static SpeculativeConfig greedyAdaptive(
+    int draftMax,
+    int draftMin,
+    float pMin
+  ) {
+    return new SpeculativeConfig(draftMax, 0.0f, 0, 1.0f, 0L, draftMin, pMin);
+  }
+
+  /**
+   * Greedy n-gram (prompt-lookup) drafting: propose up to {@code kMax} tokens by matching the last
+   * {@code ngram} committed tokens against the generation history. No draft model. Lossless w.r.t.
+   * greedy decoding (the target verifies every proposed token).
+   */
+  public static SpeculativeConfig ngramGreedy(int kMax, int ngram) {
+    return new SpeculativeConfig(kMax, 0.0f, 0, 1.0f, 0L, kMax, 0.0f, ngram);
+  }
+
+  /**
+   * Sampling n-gram (prompt-lookup) drafting: same lookup as {@link #ngramGreedy} but with
+   * temperature/top-k/top-p. Stays an exact sampler of the target distribution (the proposed token
+   * is treated as a point-mass draft for rejection sampling).
+   */
+  public static SpeculativeConfig ngram(
+    int kMax,
+    int ngram,
+    float temperature,
+    int topK,
+    float topP,
+    long seed
+  ) {
+    return new SpeculativeConfig(
+      kMax,
+      temperature,
+      topK,
+      topP,
+      seed,
+      kMax,
+      0.0f,
+      ngram
+    );
+  }
+
+  public boolean isGreedy() {
+    return temperature <= 0.0f;
+  }
+
+  /** Whether confidence-gated early stop is enabled ({@code pMin > 0}). Model-draft only. */
+  public boolean isAdaptive() {
+    return pMin > 0.0f && ngram == 0;
+  }
+
+  /** Whether this is n-gram (prompt-lookup) drafting rather than model drafting. */
+  public boolean isNgram() {
+    return ngram > 0;
+  }
+
+  /*
+   * Fluent "wither" API: start from a factory preset and override individual settings, e.g.
+   *
+   *   SpeculativeConfig.greedy(8)
+   *     .withTemperature(0.8f)   // turns the preset into a sampling config
+   *     .withTopK(40)
+   *     .withTopP(0.95f)
+   *     .withSeed(42);
+   *
+   * Each call returns a new immutable config (the canonical constructor re-validates).
+   */
+
+  /** A copy with a different max draft window (K / kMax). */
+  public SpeculativeConfig withNDraft(int nDraft) {
+    return new SpeculativeConfig(
+      nDraft,
+      temperature,
+      topK,
+      topP,
+      seed,
+      draftMin,
+      pMin,
+      ngram
+    );
+  }
+
+  /** A copy with a different sampling temperature ({@code 0} = greedy). */
+  public SpeculativeConfig withTemperature(float temperature) {
+    return new SpeculativeConfig(
+      nDraft,
+      temperature,
+      topK,
+      topP,
+      seed,
+      draftMin,
+      pMin,
+      ngram
+    );
+  }
+
+  /** A copy with a different top-k cutoff ({@code <= 0} disables). */
+  public SpeculativeConfig withTopK(int topK) {
+    return new SpeculativeConfig(
+      nDraft,
+      temperature,
+      topK,
+      topP,
+      seed,
+      draftMin,
+      pMin,
+      ngram
+    );
+  }
+
+  /** A copy with a different top-p / nucleus cutoff ({@code >= 1} disables). */
+  public SpeculativeConfig withTopP(float topP) {
+    return new SpeculativeConfig(
+      nDraft,
+      temperature,
+      topK,
+      topP,
+      seed,
+      draftMin,
+      pMin,
+      ngram
+    );
+  }
+
+  /** A copy with a different RNG seed. */
+  public SpeculativeConfig withSeed(long seed) {
+    return new SpeculativeConfig(
+      nDraft,
+      temperature,
+      topK,
+      topP,
+      seed,
+      draftMin,
+      pMin,
+      ngram
+    );
+  }
+
+  /** A copy with a different adaptive {@code draftMin} (clamped to {@code [1, nDraft]}). */
+  public SpeculativeConfig withDraftMin(int draftMin) {
+    return new SpeculativeConfig(
+      nDraft,
+      temperature,
+      topK,
+      topP,
+      seed,
+      draftMin,
+      pMin,
+      ngram
+    );
+  }
+
+  /** A copy with a different adaptive confidence floor {@code pMin} ({@code <= 0} disables). */
+  public SpeculativeConfig withPMin(float pMin) {
+    return new SpeculativeConfig(
+      nDraft,
+      temperature,
+      topK,
+      topP,
+      seed,
+      draftMin,
+      pMin,
+      ngram
+    );
+  }
+
+  /** A copy with a different n-gram lookup window ({@code 0} = model drafting, {@code >= 1} = n-gram). */
+  public SpeculativeConfig withNgram(int ngram) {
+    return new SpeculativeConfig(
+      nDraft,
+      temperature,
+      topK,
+      topP,
+      seed,
+      draftMin,
+      pMin,
+      ngram
+    );
+  }
+
+  /** Default draft window used by {@link #builder()}. */
+  public static final int DEFAULT_N_DRAFT = 4;
+
+  /**
+   * A fresh {@link Builder} with greedy model-draft defaults (fixed window of
+   * {@value #DEFAULT_N_DRAFT}, no sampling, no n-gram).
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** A {@link Builder} seeded from this config's current settings. */
+  public Builder toBuilder() {
+    return new Builder()
+      .nDraft(nDraft)
+      .temperature(temperature)
+      .topK(topK)
+      .topP(topP)
+      .seed(seed)
+      .draftMin(draftMin)
+      .pMin(pMin)
+      .ngram(ngram);
+  }
+
+  /**
+   * Fluent builder for {@link SpeculativeConfig}. Start from {@link #builder()} (greedy model-draft
+   * defaults) or {@link #toBuilder()} (an existing config), set what you need, then {@link #build()}
+   * — which validates through the record's canonical constructor.
+   *
+   * <pre>{@code
+   * var config = SpeculativeConfig.builder()
+   *     .nDraft(8)
+   *     .temperature(0.8f).topK(40).topP(0.95f).seed(42)
+   *     .build();
+   *
+   * // n-gram (prompt-lookup) drafting:
+   * var ng = SpeculativeConfig.builder().nDraft(4).ngram(2).build();
+   * }</pre>
+   */
+  public static final class Builder {
+
+    private int nDraft = DEFAULT_N_DRAFT;
+    private float temperature = 0.0f;
+    private int topK = 0;
+    private float topP = 1.0f;
+    private long seed = 0L;
+    private int draftMin = 1;
+    private float pMin = 0.0f;
+    private int ngram = 0;
+
+    private Builder() {}
+
+    /** Maximum tokens drafted/proposed per round (K / kMax). */
+    public Builder nDraft(int nDraft) {
+      this.nDraft = nDraft;
+      return this;
+    }
+
+    /** Sampling temperature ({@code 0} = greedy). */
+    public Builder temperature(float temperature) {
+      this.temperature = temperature;
+      return this;
+    }
+
+    /** Top-k cutoff ({@code <= 0} disables). */
+    public Builder topK(int topK) {
+      this.topK = topK;
+      return this;
+    }
+
+    /** Top-p / nucleus cutoff ({@code >= 1} disables). */
+    public Builder topP(float topP) {
+      this.topP = topP;
+      return this;
+    }
+
+    /** RNG seed for draft sampling, the accept coin, and residual draws. */
+    public Builder seed(long seed) {
+      this.seed = seed;
+      return this;
+    }
+
+    /** Minimum tokens to draft before the {@code pMin} early-stop applies (model-draft only). */
+    public Builder draftMin(int draftMin) {
+      this.draftMin = draftMin;
+      return this;
+    }
+
+    /** Adaptive confidence floor; stop drafting below it ({@code <= 0} disables, model-draft only). */
+    public Builder pMin(float pMin) {
+      this.pMin = pMin;
+      return this;
+    }
+
+    /** N-gram lookup window ({@code 0} = model drafting, {@code >= 1} = n-gram prompt-lookup). */
+    public Builder ngram(int ngram) {
+      this.ngram = ngram;
+      return this;
+    }
+
+    /** Builds the immutable config (validated by the record's canonical constructor). */
+    public SpeculativeConfig build() {
+      return new SpeculativeConfig(
+        nDraft,
+        temperature,
+        topK,
+        topP,
+        seed,
+        draftMin,
+        pMin,
+        ngram
+      );
+    }
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/nativelib/LlamaLibLoader.java
+++ b/src/main/java/io/gravitee/llama/cpp/nativelib/LlamaLibLoader.java
@@ -28,8 +28,6 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
 import java.util.stream.Stream;
 
 /**
@@ -174,18 +172,15 @@ public final class LlamaLibLoader {
       ) {
         load(libDirStr);
       } else {
-        List<String> resources;
-
-        File jarFile = getRunningJarFile();
-        if (jarFile != null) {
-          System.out.println("Copying llama.cpp native libraries from jar");
-          resources = listJarResources(platform.getPackage(), jarFile);
-        } else {
-          System.out.println(
-            "Copying llama.cpp native libraries from classes folder"
-          );
-          resources = listResourcesFromClassesFolder(platform.getPackage());
-        }
+        // Native libraries are no longer shipped in the jar. During the build/tests they live in
+        // the classes folder (downloaded into src/main/resources); copy them into the lib dir.
+        // End users instead provide libs via ~/.llama.cpp or LLAMA_CPP_LIB_PATH (handled above).
+        System.out.println(
+          "Copying llama.cpp native libraries from classes folder"
+        );
+        List<String> resources = listResourcesFromClassesFolder(
+          platform.getPackage()
+        );
 
         // Extract real files first, then recreate symlinks.
         // This ensures symlink targets exist before symlinks are created.
@@ -209,22 +204,19 @@ public final class LlamaLibLoader {
     }
   }
 
-  private static List<String> listJarResources(String packageName, File jarFile)
-    throws IOException {
-    String prefix = packageName.replace('.', '/') + "/";
-    try (JarFile jar = new JarFile(jarFile)) {
-      return jar
-        .stream()
-        .map(JarEntry::getName)
-        .filter(name -> name.startsWith(prefix) && !name.endsWith("/"))
-        .toList();
-    }
-  }
-
   private static List<String> listResourcesFromClassesFolder(String packageName)
     throws IOException, URISyntaxException {
     String path = packageName.replace('.', '/');
-    Path classesFolder = Path.of(classLoader().getResource(path).toURI());
+    var resource = classLoader().getResource(path);
+    if (resource == null) {
+      throw new IllegalStateException(
+        "No llama.cpp native libraries found for '" +
+          path +
+          "'. They are not bundled in the jar — install them with " +
+          "scripts/download-native-libraries.sh into ~/.llama.cpp, or set LLAMA_CPP_LIB_PATH."
+      );
+    }
+    Path classesFolder = Path.of(resource.toURI());
     List<String> resources = new ArrayList<>();
 
     try (var walk = Files.walk(classesFolder)) {
@@ -238,19 +230,6 @@ public final class LlamaLibLoader {
         });
     }
     return resources;
-  }
-
-  private static File getRunningJarFile() throws URISyntaxException {
-    String path = LlamaLibLoader.class.getProtectionDomain()
-      .getCodeSource()
-      .getLocation()
-      .toURI()
-      .getPath();
-    File file = new File(path);
-    if (file.isFile() && file.getName().endsWith(".jar")) {
-      return file;
-    }
-    return null;
   }
 
   private static Path getHomeLlamaCpp() throws IOException {

--- a/src/test/java/io/gravitee/llama/cpp/LlamaTokenDataArrayTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/LlamaTokenDataArrayTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure-FFM tests for {@link LlamaTokenDataArray} — exercises the candidate-buffer struct
+ * layout (fill / size / selected reset / probability reads) with only an {@link Arena}, no
+ * native library and no model. Guards against layout regressions in the diffusion sampling
+ * path without the gated GGUF download.
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class LlamaTokenDataArrayTest {
+
+  @Test
+  void fill_sets_size_resets_selection_and_zeroes_probabilities() {
+    try (Arena arena = Arena.ofConfined()) {
+      int nVocab = 4;
+      MemorySegment logits = arena.allocate(ValueLayout.JAVA_FLOAT, nVocab);
+      for (int i = 0; i < nVocab; i++) {
+        logits.setAtIndex(ValueLayout.JAVA_FLOAT, i, i + 1.0f);
+      }
+
+      var candidates = new LlamaTokenDataArray(arena, nVocab);
+      candidates.fill(logits, 0);
+
+      assertThat(candidates.size()).isEqualTo(nVocab);
+      assertThat(candidates.nVocab()).isEqualTo(nVocab);
+      // fill() resets selection to -1 and probabilities to 0 (set by the sampler later).
+      assertThat(candidates.selectedIndex()).isEqualTo(-1L);
+      for (int i = 0; i < nVocab; i++) {
+        assertThat(candidates.probabilityAt(i)).isZero();
+        // fill() writes id == index (the array isn't sorted/truncated until apply()).
+        assertThat(candidates.idAt(i)).isEqualTo(i);
+      }
+    }
+  }
+
+  @Test
+  void selectedId_before_apply_fails_clearly() {
+    try (Arena arena = Arena.ofConfined()) {
+      int nVocab = 3;
+      MemorySegment logits = arena.allocate(ValueLayout.JAVA_FLOAT, nVocab);
+      var candidates = new LlamaTokenDataArray(arena, nVocab);
+      candidates.fill(logits, 0);
+
+      // No sampler has run, so nothing is selected yet.
+      assertThatThrownBy(candidates::selectedId).isInstanceOf(
+        LlamaException.class
+      );
+    }
+  }
+
+  @Test
+  void fill_reads_the_requested_row_offset() {
+    try (Arena arena = Arena.ofConfined()) {
+      int nVocab = 2;
+      // Two rows of logits laid out contiguously.
+      MemorySegment logits = arena.allocate(
+        ValueLayout.JAVA_FLOAT,
+        2L * nVocab
+      );
+      for (int i = 0; i < 2 * nVocab; i++) {
+        logits.setAtIndex(ValueLayout.JAVA_FLOAT, i, i);
+      }
+
+      var candidates = new LlamaTokenDataArray(arena, nVocab);
+      // Filling from the second row must reset size to nVocab and not overrun.
+      candidates.fill(logits, nVocab);
+      assertThat(candidates.size()).isEqualTo(nVocab);
+      assertThat(candidates.selectedIndex()).isEqualTo(-1L);
+    }
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/MtmdNativeDecodeTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/MtmdNativeDecodeTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static io.gravitee.llama.cpp.LlamaRuntime.ggml_backend_reg_count;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for the NATIVE media-decode path.
+ *
+ * <p>{@link MtmdImage#fromBytesNative} decodes raw file bytes with the native
+ * stb_image decoder via {@code mtmd_helper_bitmap_init_from_buf}. This is the
+ * path production callers (e.g. gravitee-ai-server) use, and it is distinct from
+ * {@link MtmdImage#fromFile}/{@link MtmdImage#fromBytes}, which decode in Java
+ * and call {@code mtmd_bitmap_init}. The other multimodal tests only exercise the
+ * Java-decode path, so a signature drift between the hand-written
+ * production. This test guards the native entry points explicitly.
+ */
+class MtmdNativeDecodeTest extends LlamaCppTest {
+
+  private static Arena arena = Arena.ofShared();
+
+  @BeforeAll
+  public static void beforeAll() {
+    String libPath = LlamaLibLoader.load();
+    LlamaRuntime.llama_backend_init();
+    LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
+    System.out.println("Libraries loaded at: " + libPath);
+    System.out.println("Devices registered: " + ggml_backend_reg_count());
+  }
+
+  @Test
+  void fromBytesNative_should_decode_image_via_native_helper()
+    throws IOException, URISyntaxException {
+    var mtmdContext = loadVlContext();
+    assertThat(mtmdContext.supportsVision()).isTrue();
+
+    byte[] imageBytes = Files.readAllBytes(
+      Path.of(getClass().getClassLoader().getResource("man.jpg").toURI())
+    );
+
+    var nativeImage = MtmdImage.fromBytesNative(arena, mtmdContext, imageBytes);
+    try {
+      assertThat(nativeImage.getMemorySegment().address()).isNotZero();
+    } finally {
+      nativeImage.free();
+    }
+
+    // Java decode path (mtmd_bitmap_init) must keep working too.
+    var javaImage = MtmdImage.fromBytes(arena, imageBytes);
+    try {
+      assertThat(javaImage.getMemorySegment().address()).isNotZero();
+    } finally {
+      javaImage.free();
+    }
+  }
+
+  private MtmdContext loadVlContext() throws IOException {
+    Path mainModel = getModelPath(MODEL_VL_PATH, VL_TEXT);
+    if (!Files.isRegularFile(mainModel)) {
+      throw new IOException("Main VL model not found: " + mainModel);
+    }
+    var llamaModel = track(
+      new LlamaModel(arena, mainModel, new LlamaModelParams(arena))
+    );
+
+    Path mmproj = getModelPath(VL_MMPROJ_PATH, VL_MMPROJ);
+    if (!Files.isRegularFile(mmproj)) {
+      throw new IOException("VL mmproj not found: " + mmproj);
+    }
+    var params = new MtmdContextParams(arena).useGpu(true).mediaMarker("<IMG>");
+    return track(
+      new MtmdContext(arena, llamaModel, mmproj.toAbsolutePath(), params)
+    );
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/NgramLookupTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/NgramLookupTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure tests for the incremental {@link NgramIndex} used by n-gram (prompt-lookup) drafting — no
+ * native library, no model. Covers match selection, most-recent preference, continuation extraction,
+ * the kMax cap, and the no-match fallback.
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class NgramLookupTest {
+
+  /** Builds an index from {@code history} and returns its proposal for the trailing window. */
+  private static int[] propose(int ngram, int kMax, int... history) {
+    NgramIndex index = new NgramIndex(ngram);
+    for (int token : history) {
+      index.append(token);
+    }
+    return index.propose(kMax);
+  }
+
+  @Test
+  void no_match_when_history_too_short() {
+    // histLen < ngram + 1 → nothing to look up.
+    assertThat(propose(2, 4, 1, 2)).isEmpty();
+  }
+
+  @Test
+  void no_match_returns_empty() {
+    // Trailing window [4,5] never occurs earlier.
+    assertThat(propose(2, 4, 1, 2, 3, 4, 5)).isEmpty();
+  }
+
+  @Test
+  void proposes_continuation_after_earlier_match() {
+    // Window [1,2]; earlier occurrence at index 0; continuation is history[2..] = [3,1,2].
+    assertThat(propose(2, 3, 1, 2, 3, 1, 2)).containsExactly(3, 1, 2);
+  }
+
+  @Test
+  void prefers_most_recent_earlier_match() {
+    // [1,2] occurs at index 1 and (current) index 4; the most recent earlier is index 1 →
+    // continuation history[3..] capped to 2 = [8,1].
+    assertThat(propose(2, 2, 9, 1, 2, 8, 1, 2)).containsExactly(8, 1);
+  }
+
+  @Test
+  void caps_proposal_at_kmax() {
+    // Match at index 0, continuation [3,4,5,1,2], capped to kMax = 2.
+    assertThat(propose(2, 2, 1, 2, 3, 4, 5, 1, 2)).containsExactly(3, 4);
+  }
+
+  @Test
+  void continuation_bounded_by_history_length() {
+    // ngram=1, last token 5 matches at index 1; only one continuation token remains.
+    assertThat(propose(1, 5, 5, 5, 5)).containsExactly(5);
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/SpeculationTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/SpeculationTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure tests for the adaptive-greedy confidence read ({@link Speculation#draftGreedyConfident}) —
+ * no native library, no model. The rejection-sampling accept/residual and the temp/top-k/top-p
+ * sampling are exercised by the (native) integration tests instead.
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class SpeculationTest {
+
+  private static Speculation spec(Arena arena) {
+    return new Speculation(
+      arena,
+      8,
+      new SpeculativeConfig(2, 0.8f, 0, 1.0f, 7)
+    );
+  }
+
+  @Test
+  void draft_greedy_confident_returns_argmax_and_top_softmax_prob() {
+    try (Arena arena = Arena.ofConfined()) {
+      Speculation s = spec(arena);
+      int nVocab = 4;
+      MemorySegment logits = arena.allocate(ValueLayout.JAVA_FLOAT, nVocab);
+      float[] vals = { 1.0f, 3.0f, 2.0f, 0.0f }; // argmax at id 1
+      for (int i = 0; i < nVocab; i++) {
+        logits.setAtIndex(ValueLayout.JAVA_FLOAT, i, vals[i]);
+      }
+      float[] probOut = new float[1];
+
+      int argmax = s.draftGreedyConfident(logits, nVocab, probOut);
+
+      assertThat(argmax).isEqualTo(1);
+      // top prob = 1 / Σ exp(logit - maxLogit) = 1 / (e^-2 + 1 + e^-1 + e^-3) ≈ 0.6439
+      assertThat(probOut[0]).isCloseTo(0.6439f, within(1e-3f));
+    }
+  }
+
+  @Test
+  void draft_greedy_confident_breaks_ties_by_lowest_id() {
+    try (Arena arena = Arena.ofConfined()) {
+      Speculation s = spec(arena);
+      int nVocab = 3;
+      MemorySegment logits = arena.allocate(ValueLayout.JAVA_FLOAT, nVocab);
+      logits.setAtIndex(ValueLayout.JAVA_FLOAT, 0, 2.0f);
+      logits.setAtIndex(ValueLayout.JAVA_FLOAT, 1, 2.0f); // tie with id 0
+      logits.setAtIndex(ValueLayout.JAVA_FLOAT, 2, 1.0f);
+      float[] probOut = new float[1];
+
+      // strict '>' keeps the first (lowest-id) max, matching the native greedy sampler.
+      assertThat(s.draftGreedyConfident(logits, nVocab, probOut)).isEqualTo(0);
+    }
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/SpeculativeConfigTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/SpeculativeConfigTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure tests for {@link SpeculativeConfig} — no native library, no model. Cover the adaptive
+ * draft-length parameters, backward-compatible construction, and {@code draftMin} clamping.
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class SpeculativeConfigTest {
+
+  @Test
+  void five_arg_constructor_is_non_adaptive() {
+    var config = new SpeculativeConfig(4, 0.8f, 40, 0.95f, 42);
+    // Backward-compatible ctor drafts a fixed window: draftMin == nDraft, pMin == 0.
+    assertThat(config.nDraft()).isEqualTo(4);
+    assertThat(config.draftMin()).isEqualTo(4);
+    assertThat(config.pMin()).isZero();
+    assertThat(config.isAdaptive()).isFalse();
+    assertThat(config.isGreedy()).isFalse();
+  }
+
+  @Test
+  void greedy_factory_is_greedy_and_non_adaptive() {
+    var config = SpeculativeConfig.greedy(4);
+    assertThat(config.isGreedy()).isTrue();
+    assertThat(config.isAdaptive()).isFalse();
+    assertThat(config.draftMin()).isEqualTo(4);
+  }
+
+  @Test
+  void greedy_adaptive_factory_enables_early_stop() {
+    var config = SpeculativeConfig.greedyAdaptive(8, 2, 0.6f);
+    assertThat(config.isGreedy()).isTrue();
+    assertThat(config.isAdaptive()).isTrue();
+    assertThat(config.nDraft()).isEqualTo(8);
+    assertThat(config.draftMin()).isEqualTo(2);
+    assertThat(config.pMin()).isEqualTo(0.6f);
+  }
+
+  @Test
+  void draft_min_is_clamped_to_range() {
+    // Below 1 clamps up to 1.
+    assertThat(
+      SpeculativeConfig.greedyAdaptive(8, 0, 0.5f).draftMin()
+    ).isEqualTo(1);
+    assertThat(
+      SpeculativeConfig.greedyAdaptive(8, -5, 0.5f).draftMin()
+    ).isEqualTo(1);
+    // Above nDraft clamps down to nDraft.
+    assertThat(
+      SpeculativeConfig.greedyAdaptive(4, 9, 0.5f).draftMin()
+    ).isEqualTo(4);
+  }
+
+  @Test
+  void zero_or_negative_p_min_disables_adaptive() {
+    assertThat(
+      new SpeculativeConfig(4, 0.0f, 0, 1.0f, 0L, 2, 0.0f).isAdaptive()
+    ).isFalse();
+    assertThat(
+      new SpeculativeConfig(4, 0.0f, 0, 1.0f, 0L, 2, -0.1f).isAdaptive()
+    ).isFalse();
+  }
+
+  @Test
+  void n_draft_below_one_is_rejected() {
+    assertThatThrownBy(() -> SpeculativeConfig.greedy(0)).isInstanceOf(
+      LlamaException.class
+    );
+  }
+
+  @Test
+  void withers_override_one_field_and_preserve_the_rest() {
+    var config = SpeculativeConfig.greedy(8)
+      .withTemperature(0.8f)
+      .withTopK(40)
+      .withTopP(0.95f)
+      .withSeed(42L);
+
+    assertThat(config.nDraft()).isEqualTo(8); // preserved from greedy(8)
+    assertThat(config.temperature()).isEqualTo(0.8f);
+    assertThat(config.topK()).isEqualTo(40);
+    assertThat(config.topP()).isEqualTo(0.95f);
+    assertThat(config.seed()).isEqualTo(42L);
+    assertThat(config.isGreedy()).isFalse(); // temperature made it a sampling config
+    assertThat(config.isNgram()).isFalse();
+  }
+
+  @Test
+  void with_ngram_switches_to_prompt_lookup() {
+    var config = SpeculativeConfig.greedy(4).withNgram(2);
+    assertThat(config.isNgram()).isTrue();
+    assertThat(config.ngram()).isEqualTo(2);
+    assertThat(config.isGreedy()).isTrue();
+  }
+
+  @Test
+  void withers_revalidate_via_canonical_constructor() {
+    // withNgram(-1) must go through the canonical constructor's validation.
+    assertThatThrownBy(() ->
+      SpeculativeConfig.greedy(4).withNgram(-1)
+    ).isInstanceOf(LlamaException.class);
+  }
+
+  @Test
+  void builder_defaults_to_greedy_model_drafting() {
+    var config = SpeculativeConfig.builder().build();
+    assertThat(config.nDraft()).isEqualTo(SpeculativeConfig.DEFAULT_N_DRAFT);
+    assertThat(config.isGreedy()).isTrue();
+    assertThat(config.isNgram()).isFalse();
+    assertThat(config.isAdaptive()).isFalse();
+  }
+
+  @Test
+  void builder_sets_each_field() {
+    var config = SpeculativeConfig.builder()
+      .nDraft(8)
+      .temperature(0.8f)
+      .topK(40)
+      .topP(0.95f)
+      .seed(42L)
+      .build();
+    assertThat(config.nDraft()).isEqualTo(8);
+    assertThat(config.temperature()).isEqualTo(0.8f);
+    assertThat(config.topK()).isEqualTo(40);
+    assertThat(config.topP()).isEqualTo(0.95f);
+    assertThat(config.seed()).isEqualTo(42L);
+    assertThat(config.isGreedy()).isFalse();
+  }
+
+  @Test
+  void to_builder_round_trips() {
+    var original = SpeculativeConfig.greedyAdaptive(8, 2, 0.6f);
+    var copy = original.toBuilder().build();
+    assertThat(copy).isEqualTo(original);
+  }
+
+  @Test
+  void builder_validates_on_build() {
+    assertThatThrownBy(() ->
+      SpeculativeConfig.builder().nDraft(0).build()
+    ).isInstanceOf(LlamaException.class);
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/SpeculativeDecodingTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/SpeculativeDecodingTest.java
@@ -1,0 +1,594 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static io.gravitee.llama.cpp.LlamaCppTest.MODEL_PATH;
+import static io.gravitee.llama.cpp.LlamaCppTest.MODEL_TO_DOWNLOAD;
+import static io.gravitee.llama.cpp.LlamaCppTest.REASONING_MODEL_PATH;
+import static io.gravitee.llama.cpp.LlamaCppTest.REASONNING_MODEL_TO_DOWNLOAD;
+import static io.gravitee.llama.cpp.LlamaCppTest.getModelPath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
+import java.lang.foreign.Arena;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies speculative decoding via {@link ConversationState#setDraft} is lossless: it must
+ * reproduce the target's plain greedy output — both when draft == target (same GGUF) and when
+ * the draft is a smaller, different model from the same family (Qwen3-0.6B draft, Qwen3-1.7B
+ * target), which also exercises the verify/correction and rejection-sampling paths.
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Tag("integration")
+class SpeculativeDecodingTest extends LlamaCppTest {
+
+  private static final String PROMPT = "The capital of France is";
+  private static final int MAX_TOKENS = 24;
+
+  // Draft/target pair from the same family (same tokenizer/vocab = 151936) for the realistic
+  // (draft != target) case. The draft reuses the existing Qwen3-0.6B reasoning.gguf.
+  static final String SPEC_TARGET_MODEL_TO_DOWNLOAD =
+    "https://huggingface.co/Qwen/Qwen3-1.7B-GGUF/resolve/main/Qwen3-1.7B-Q8_0.gguf";
+  static final String SPEC_TARGET_MODEL_PATH = "models/spec-target.gguf";
+
+  private static Arena arena;
+
+  @BeforeAll
+  static void beforeAll() {
+    arena = Arena.ofConfined();
+    String libPath = LlamaLibLoader.load();
+    LlamaRuntime.llama_backend_init();
+    LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    LlamaRuntime.llama_backend_free();
+    arena.close();
+    arena = null;
+  }
+
+  @Test
+  void speculative_matches_plain_greedy() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var arCtx = track(new LlamaContext(arena, model, cp));
+    var specCtx = track(new LlamaContext(arena, model, cp));
+    var draftCtx = track(new LlamaContext(arena, model, cp));
+
+    var vocab = new LlamaVocab(model);
+
+    // Reference: plain greedy decoding.
+    var arSampler = track(new LlamaSampler(arena).greedy());
+    var arState = ConversationState.create(
+      arena,
+      arCtx,
+      new LlamaTokenizer(vocab, arCtx),
+      arSampler
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .initialize(PROMPT);
+    String greedy = new DefaultLlamaIterator(arState)
+      .stream()
+      .map(LlamaOutput::content)
+      .reduce("", (a, b) -> a + b);
+
+    // Speculative (greedy): same model as draft (lossless ⇒ identical output).
+    var specSampler = track(new LlamaSampler(arena).greedy());
+    var specState = ConversationState.create(
+      arena,
+      specCtx,
+      new LlamaTokenizer(vocab, specCtx),
+      specSampler
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .setDraft(draftCtx, SpeculativeConfig.greedy(4))
+      .initialize(PROMPT);
+    String speculative = new DefaultLlamaIterator(specState)
+      .stream()
+      .map(LlamaOutput::content)
+      .reduce("", (a, b) -> a + b);
+
+    System.out.println("greedy     : " + greedy);
+    System.out.println("speculative: " + speculative);
+
+    assertThat(speculative).isEqualTo(greedy);
+    // Identical draft & target ⇒ every drafted token accepted.
+    assertThat(specState.acceptRate()).isEqualTo(1.0);
+  }
+
+  @Test
+  void stochastic_accepts_everything_when_draft_equals_target() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var specCtx = track(new LlamaContext(arena, model, cp));
+    var draftCtx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+
+    // p == q (same model), so the rejection test min(1, p/q) accepts every drafted token.
+    var sampler = track(new LlamaSampler(arena).greedy());
+    var state = ConversationState.create(
+      arena,
+      specCtx,
+      new LlamaTokenizer(vocab, specCtx),
+      sampler
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .setDraft(draftCtx, new SpeculativeConfig(4, 0.8f, 40, 0.95f, 42))
+      .initialize(PROMPT);
+
+    String text = new DefaultLlamaIterator(state)
+      .stream()
+      .map(LlamaOutput::content)
+      .reduce("", (a, b) -> a + b);
+
+    System.out.println(
+      "stochastic : " + text + " (accept=" + state.acceptRate() + ")"
+    );
+    assertThat(text).isNotBlank();
+    assertThat(state.acceptRate()).isEqualTo(1.0);
+  }
+
+  @Test
+  void fused_batch_speculative_matches_per_sequence_greedy() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena)
+      .nCtx(512)
+      .nBatch(512)
+      .nUBatch(512)
+      .nSeqMax(2);
+    var batchCtx = track(new LlamaContext(arena, model, cp));
+    var draftCtx = track(new LlamaContext(arena, model, cp));
+    var refCtx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+
+    String[] prompts = { "The capital of France is", "Water boils at" };
+
+    // References: single-stream greedy per prompt.
+    String[] refs = new String[2];
+    for (int i = 0; i < 2; i++) {
+      var refSampler = track(new LlamaSampler(arena).greedy());
+      var refState = ConversationState.create(
+        arena,
+        refCtx,
+        new LlamaTokenizer(vocab, refCtx),
+        refSampler,
+        0
+      )
+        .setMaxTokens(MAX_TOKENS)
+        .initialize(prompts[i]);
+      refs[i] = new DefaultLlamaIterator(refState)
+        .stream()
+        .map(LlamaOutput::content)
+        .reduce("", (a, b) -> a + b);
+      refCtx.clearCache();
+    }
+
+    // Fused batch speculative: two sequences, each with a draft (greedy ⇒ lossless).
+    var batchIt = new BatchIterator(arena, batchCtx);
+    var sb0 = new StringBuilder();
+    var sb1 = new StringBuilder();
+    try {
+      for (int i = 0; i < 2; i++) {
+        var sampler = track(new LlamaSampler(arena).greedy());
+        batchIt.addState(
+          ConversationState.create(
+            arena,
+            batchCtx,
+            new LlamaTokenizer(vocab, batchCtx),
+            sampler,
+            i
+          )
+            .setMaxTokens(MAX_TOKENS)
+            .setDraft(draftCtx, SpeculativeConfig.greedy(4))
+            .initialize(prompts[i])
+        );
+      }
+      batchIt
+        .stream()
+        .forEach(o -> (o.sequenceId() == 0 ? sb0 : sb1).append(o.content()));
+    } finally {
+      batchIt.free();
+    }
+
+    System.out.println("seq0 ref/spec: " + refs[0] + " || " + sb0);
+    System.out.println("seq1 ref/spec: " + refs[1] + " || " + sb1);
+    assertThat(sb0.toString()).isEqualTo(refs[0]);
+    assertThat(sb1.toString()).isEqualTo(refs[1]);
+  }
+
+  @Test
+  void greedy_speculative_with_smaller_draft_matches_target_greedy() {
+    Path targetPath = getModelPath(
+      SPEC_TARGET_MODEL_PATH,
+      SPEC_TARGET_MODEL_TO_DOWNLOAD
+    );
+    Path draftPath = getModelPath(
+      REASONING_MODEL_PATH,
+      REASONNING_MODEL_TO_DOWNLOAD
+    );
+    var targetModel = track(
+      new LlamaModel(arena, targetPath, new LlamaModelParams(arena))
+    );
+    var draftModel = track(
+      new LlamaModel(arena, draftPath, new LlamaModelParams(arena))
+    );
+
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var arCtx = track(new LlamaContext(arena, targetModel, cp));
+    var specCtx = track(new LlamaContext(arena, targetModel, cp));
+    var draftCtx = track(new LlamaContext(arena, draftModel, cp));
+    var vocab = new LlamaVocab(targetModel);
+
+    // Reference: the TARGET's own plain greedy decoding.
+    var arState = ConversationState.create(
+      arena,
+      arCtx,
+      new LlamaTokenizer(vocab, arCtx),
+      track(new LlamaSampler(arena).greedy())
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .initialize(PROMPT);
+    String targetGreedy = new DefaultLlamaIterator(arState)
+      .stream()
+      .map(LlamaOutput::content)
+      .reduce("", (a, b) -> a + b);
+
+    // Speculative: a smaller, weaker draft (0.6B) proposing for the larger target (1.7B).
+    var specState = ConversationState.create(
+      arena,
+      specCtx,
+      new LlamaTokenizer(vocab, specCtx),
+      track(new LlamaSampler(arena).greedy())
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .setDraft(draftCtx, SpeculativeConfig.greedy(4))
+      .initialize(PROMPT);
+    String speculative = new DefaultLlamaIterator(specState)
+      .stream()
+      .map(LlamaOutput::content)
+      .reduce("", (a, b) -> a + b);
+
+    System.out.println("target greedy: " + targetGreedy);
+    System.out.println(
+      "speculative  : " +
+        speculative +
+        " (accept=" +
+        specState.acceptRate() +
+        ")"
+    );
+
+    assertThat(speculative).contains("Paris", "London", "Washington");
+    assertThat(targetGreedy).contains("Paris", "London", "Washington");
+    assertThat(specState.acceptRate()).isBetween(0.0, 1.0);
+  }
+
+  @Test
+  void greedy_adaptive_speculative_matches_target_greedy() {
+    Path targetPath = getModelPath(
+      SPEC_TARGET_MODEL_PATH,
+      SPEC_TARGET_MODEL_TO_DOWNLOAD
+    );
+    Path draftPath = getModelPath(
+      REASONING_MODEL_PATH,
+      REASONNING_MODEL_TO_DOWNLOAD
+    );
+    var targetModel = track(
+      new LlamaModel(arena, targetPath, new LlamaModelParams(arena))
+    );
+    var draftModel = track(
+      new LlamaModel(arena, draftPath, new LlamaModelParams(arena))
+    );
+
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var arCtx = track(new LlamaContext(arena, targetModel, cp));
+    var specCtx = track(new LlamaContext(arena, targetModel, cp));
+    var draftCtx = track(new LlamaContext(arena, draftModel, cp));
+    var vocab = new LlamaVocab(targetModel);
+
+    // Reference: the TARGET's own plain greedy decoding.
+    var arState = ConversationState.create(
+      arena,
+      arCtx,
+      new LlamaTokenizer(vocab, arCtx),
+      track(new LlamaSampler(arena).greedy())
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .initialize(PROMPT);
+    String targetGreedy = new DefaultLlamaIterator(arState)
+      .stream()
+      .map(LlamaOutput::content)
+      .reduce("", (a, b) -> a + b);
+
+    // Adaptive greedy: draft up to 8 tokens but stop early once draft confidence < 0.5. Lossless
+    // w.r.t. the target's greedy output regardless of how many tokens each round speculates.
+    var specState = ConversationState.create(
+      arena,
+      specCtx,
+      new LlamaTokenizer(vocab, specCtx),
+      track(new LlamaSampler(arena).greedy())
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .setDraft(draftCtx, SpeculativeConfig.greedyAdaptive(8, 1, 0.5f))
+      .initialize(PROMPT);
+    String speculative = new DefaultLlamaIterator(specState)
+      .stream()
+      .map(LlamaOutput::content)
+      .reduce("", (a, b) -> a + b);
+
+    System.out.println("target greedy  : " + targetGreedy);
+    System.out.println(
+      "adaptive spec  : " +
+        speculative +
+        " (accept=" +
+        specState.acceptRate() +
+        ")"
+    );
+
+    assertThat(speculative).contains("Paris", "London", "Washington");
+    assertThat(targetGreedy).contains("Paris", "London", "Washington");
+    assertThat(specState.acceptRate()).isBetween(0.0, 1.0);
+  }
+
+  @Test
+  void stochastic_speculative_with_smaller_draft_runs() {
+    Path targetPath = getModelPath(
+      SPEC_TARGET_MODEL_PATH,
+      SPEC_TARGET_MODEL_TO_DOWNLOAD
+    );
+    Path draftPath = getModelPath(
+      REASONING_MODEL_PATH,
+      REASONNING_MODEL_TO_DOWNLOAD
+    );
+    var targetModel = track(
+      new LlamaModel(arena, targetPath, new LlamaModelParams(arena))
+    );
+    var draftModel = track(
+      new LlamaModel(arena, draftPath, new LlamaModelParams(arena))
+    );
+
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var specCtx = track(new LlamaContext(arena, targetModel, cp));
+    var draftCtx = track(new LlamaContext(arena, draftModel, cp));
+    var vocab = new LlamaVocab(targetModel);
+
+    // draft != target with sampling: exercises the rejection-sampling + residual draw path
+    // against real logits (can't assert exact output — it's stochastic).
+    var state = ConversationState.create(
+      arena,
+      specCtx,
+      new LlamaTokenizer(vocab, specCtx),
+      track(new LlamaSampler(arena).greedy())
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .setDraft(draftCtx, new SpeculativeConfig(4, 0.8f, 40, 0.95f, 42))
+      .initialize(PROMPT);
+    String text = new DefaultLlamaIterator(state)
+      .stream()
+      .map(LlamaOutput::content)
+      .reduce("", (a, b) -> a + b);
+
+    System.out.println(
+      "stochastic (draft!=target): " +
+        text +
+        " (accept=" +
+        state.acceptRate() +
+        ")"
+    );
+    assertThat(text).isNotBlank();
+    assertThat(state.acceptRate()).isBetween(0.0, 1.0);
+  }
+
+  @Test
+  void speculative_stream_abandoned_via_try_with_resources_keeps_context_usable() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var specCtx = track(new LlamaContext(arena, model, cp));
+    var draftCtx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+
+    // Abandon a speculative stream after a few tokens. close() (try-with-resources) must free the
+    // persistent native scratch and clear the sequence without throwing — onFinished never fires.
+    int consumed;
+    try (
+      var it = new DefaultLlamaIterator(
+        ConversationState.create(
+          arena,
+          specCtx,
+          new LlamaTokenizer(vocab, specCtx),
+          track(new LlamaSampler(arena).greedy())
+        )
+          .setMaxTokens(MAX_TOKENS)
+          .setDraft(draftCtx, SpeculativeConfig.greedy(4))
+          .initialize(PROMPT)
+      )
+    ) {
+      consumed = it.stream().limit(3).map(LlamaOutput::content).toList().size();
+    }
+    assertThat(consumed).isLessThanOrEqualTo(3);
+
+    // The contexts must remain usable for a fresh speculative generation afterwards: close() cleared
+    // the KV, and the new state's Speculation builds its own scratch.
+    var reuseState = ConversationState.create(
+      arena,
+      specCtx,
+      new LlamaTokenizer(vocab, specCtx),
+      track(new LlamaSampler(arena).greedy())
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .setDraft(draftCtx, SpeculativeConfig.greedy(4))
+      .initialize(PROMPT);
+    String text;
+    try (var it = new DefaultLlamaIterator(reuseState)) {
+      text = it
+        .stream()
+        .map(LlamaOutput::content)
+        .reduce("", (a, b) -> a + b);
+    }
+    assertThat(text).isNotBlank();
+  }
+
+  @Test
+  void ngram_greedy_matches_plain_greedy() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var arCtx = track(new LlamaContext(arena, model, cp));
+    var ngCtx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+
+    // Reference: plain greedy decoding.
+    var arState = ConversationState.create(
+      arena,
+      arCtx,
+      new LlamaTokenizer(vocab, arCtx),
+      track(new LlamaSampler(arena).greedy())
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .initialize(PROMPT);
+    String greedy = new DefaultLlamaIterator(arState)
+      .stream()
+      .map(LlamaOutput::content)
+      .reduce("", (a, b) -> a + b);
+
+    // N-gram (prompt-lookup) greedy drafting: no draft model. Lossless w.r.t. greedy decoding
+    // regardless of how many proposed tokens the target accepts.
+    var ngState = ConversationState.create(
+      arena,
+      ngCtx,
+      new LlamaTokenizer(vocab, ngCtx),
+      track(new LlamaSampler(arena).greedy())
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .setNgram(SpeculativeConfig.ngramGreedy(4, 2))
+      .initialize(PROMPT);
+    String ngram = new DefaultLlamaIterator(ngState)
+      .stream()
+      .map(LlamaOutput::content)
+      .reduce("", (a, b) -> a + b);
+
+    System.out.println("greedy: " + greedy);
+    System.out.println(
+      "ngram : " + ngram + " (accept=" + ngState.acceptRate() + ")"
+    );
+    assertThat(ngram).isEqualTo(greedy);
+    assertThat(ngState.acceptRate()).isBetween(0.0, 1.0);
+  }
+
+  @Test
+  void fused_batch_ngram_matches_per_sequence_greedy() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena)
+      .nCtx(512)
+      .nBatch(512)
+      .nUBatch(512)
+      .nSeqMax(2);
+    var batchCtx = track(new LlamaContext(arena, model, cp));
+    var refCtx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+
+    String[] prompts = { "The capital of France is", "Water boils at" };
+
+    String[] refs = new String[2];
+    for (int i = 0; i < 2; i++) {
+      var refState = ConversationState.create(
+        arena,
+        refCtx,
+        new LlamaTokenizer(vocab, refCtx),
+        track(new LlamaSampler(arena).greedy()),
+        0
+      )
+        .setMaxTokens(MAX_TOKENS)
+        .initialize(prompts[i]);
+      refs[i] = new DefaultLlamaIterator(refState)
+        .stream()
+        .map(LlamaOutput::content)
+        .reduce("", (a, b) -> a + b);
+      refCtx.clearCache();
+    }
+
+    // Fused batch n-gram drafting: two sequences, each prompt-lookup (greedy ⇒ lossless).
+    var batchIt = new BatchIterator(arena, batchCtx);
+    var sb0 = new StringBuilder();
+    var sb1 = new StringBuilder();
+    try {
+      for (int i = 0; i < 2; i++) {
+        batchIt.addState(
+          ConversationState.create(
+            arena,
+            batchCtx,
+            new LlamaTokenizer(vocab, batchCtx),
+            track(new LlamaSampler(arena).greedy()),
+            i
+          )
+            .setMaxTokens(MAX_TOKENS)
+            .setNgram(SpeculativeConfig.ngramGreedy(4, 2))
+            .initialize(prompts[i])
+        );
+      }
+      batchIt
+        .stream()
+        .forEach(o -> (o.sequenceId() == 0 ? sb0 : sb1).append(o.content()));
+    } finally {
+      batchIt.free();
+    }
+
+    assertThat(sb0.toString()).isEqualTo(refs[0]);
+    assertThat(sb1.toString()).isEqualTo(refs[1]);
+  }
+
+  @Test
+  void ngram_stochastic_runs() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var ngCtx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+
+    var state = ConversationState.create(
+      arena,
+      ngCtx,
+      new LlamaTokenizer(vocab, ngCtx),
+      track(new LlamaSampler(arena).greedy())
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .setNgram(SpeculativeConfig.ngram(4, 2, 0.8f, 40, 0.95f, 42))
+      .initialize(PROMPT);
+    String text = new DefaultLlamaIterator(state)
+      .stream()
+      .map(LlamaOutput::content)
+      .reduce("", (a, b) -> a + b);
+
+    System.out.println(
+      "ngram stochastic: " + text + " (accept=" + state.acceptRate() + ")"
+    );
+    assertThat(text).isNotBlank();
+    assertThat(state.acceptRate()).isBetween(0.0, 1.0);
+  }
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                             
  Adds **speculative decoding** to llamaj.cpp — a cheap drafter proposes tokens that the                                                                                                                                                 
  target model verifies in a single pass, producing the same output, faster. Also slims the                                                                                                                                              
  published jar and ships a full set of capability docs.

## ✨ Speculative decoding                                                                                                                                                                                                             
  - **Two drafters:** a small **draft model** (`setDraft`) sharing the target's vocab, or                                                                                                                                                
    **n-gram / prompt-lookup** (`setNgram`) with no extra model.                                                                                                                                                                         
  - **Greedy** mode is lossless (byte-identical to plain greedy decoding); **sampling** mode                                                                                                                                             
    stays an exact draw of the target distribution via rejection sampling (memoryless                                                                                                                                                    
    temperature / top-k / top-p).                                                                                                                                                                                                        
  - Adaptive early-stop (`p_min`) and an O(1) n-gram lookup index.                                                                                                                                                                       
  - Works with both `DefaultLlamaIterator` (single sequence) and `BatchIterator` (fused                                                                                                                                                  
    multi-sequence).                                                                                                                                                                                                                     
  - **CLI flags:** `--draft`, `--ngram`, `--n_draft`, `--p_min`, `--draft_min`, plus a new                                                                                                                                               
    `Effective generation` metric under `--perf`. Delivers up to **~1.8×** on a 14B target                                                                                                                                               
    with a 0.6B draft (hardware-dependent).                                                                                                                                                                                              
                                                                                                                                                                                                                                         
  ## 📦 Smaller jar                                                                                                                                                                                                                      
  - Native libraries are **no longer bundled in the published jar**, dramatically reducing the                                                                                                                                           
    artifact size — it's now pure Java + FFM bindings.                                                                                                                                                                                   
  - Libraries are downloaded at build/test time; end users provide them via                                                                                                                                                              
    `scripts/download-native-libraries.sh` (into `~/.llama.cpp`) or the `LLAMA_CPP_LIB_PATH`                                                                                                                                             
    environment variable.                                                                                                                                                                                                                
                                                                                                                                                                                                                                         
  ## 📚 Documentation                                                                                                                                                                                                                    
  - New `docs/` tree with one page per capability — getting started, text generation,                                                                                                                                                    
    speculative decoding, multimodal, embeddings, reranking, distributed inference (RPC),                                                                                                                                                
    quantized KV-cache, LoRA, and more — all linked from the README.