### PR TITLE
feat: MTP + EAGLE3 speculative decoding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,24 +156,26 @@ commands:
 
   download_models:
     parameters:
-      repo:
+      os:
         type: string
-      files:
-        type: string
-      destinations:
+      models-dir:
         type: string
     steps:
+      # Bump the version suffix (also CACHE_KEY_VERSION note in the script) when
+      # scripts/ci-models.txt changes so the cache is invalidated.
+      - restore_cache:
+          keys:
+            - models-v1-<< parameters.os >>
       - run:
-          name: Download Models from << parameters.repo >>
+          name: Download models (parallel, cache-filling)
           command: |
-            mkdir -p $HOME_DIR/llamaj.cpp/models/
-            IFS=',' read -ra FILES \<<< "<< parameters.files >>"
-            IFS=',' read -ra DESTS \<<< "<< parameters.destinations >>"
-            for i in "${!FILES[@]}"; do
-              echo "Downloading ${FILES[$i]} -> ${DESTS[$i]}"
-              curl -L -o "$HOME_DIR/llamaj.cpp/${DESTS[$i]}" \
-                "https://huggingface.co/<< parameters.repo >>/resolve/main/${FILES[$i]}"
-            done
+            MODELS_ROOT="$HOME_DIR/llamaj.cpp" \
+              bash "$HOME_DIR/llamaj.cpp/scripts/download_ci_models.sh"
+      - save_cache:
+          # No-op when the key already exists (warm cache).
+          key: models-v1-<< parameters.os >>
+          paths:
+            - << parameters.models-dir >>
 
   run-tests:
     parameters:
@@ -367,44 +369,8 @@ jobs:
       - checkout:
           path: "/Users/distiller/llamaj.cpp"
       - download_models:
-          repo: "Qwen/Qwen3-0.6B-GGUF"
-          files: "Qwen3-0.6B-Q8_0.gguf"
-          destinations: "models/model.gguf"
-      - run:
-          name: Copy model for reasoning
-          command: cp $HOME_DIR/llamaj.cpp/models/model.gguf $HOME_DIR/llamaj.cpp/models/reasoning.gguf
-      - download_models:
-          repo: "phh/Qwen3-0.6B-TLDR-Lora"
-          files: "Qwen3-0.6B-tldr-lora-f16.gguf"
-          destinations: "models/lora-adapter.gguf"
-      - download_models:
-          repo: "Qwen/Qwen3-VL-2B-Instruct-GGUF"
-          files: "Qwen3VL-2B-Instruct-Q8_0.gguf,mmproj-Qwen3VL-2B-Instruct-Q8_0.gguf"
-          destinations: "models/model_vl.gguf,models/mmproj.gguf"
-      - download_models:
-          repo: "ggml-org/ultravox-v0_5-llama-3_2-1b-GGUF"
-          files: "Llama-3.2-1B-Instruct-Q8_0.gguf,mmproj-ultravox-v0_5-llama-3_2-1b-f16.gguf"
-          destinations: "models/model_audio.gguf,models/mmproj_audio.gguf"
-      - download_models:
-          repo: "Qwen/Qwen3-Embedding-0.6B-GGUF"
-          files: "Qwen3-Embedding-0.6B-Q8_0.gguf"
-          destinations: "models/embedding.gguf"
-      - download_models:
-          repo: "ggml-org/bge-m3-Q8_0-GGUF"
-          files: "bge-m3-q8_0.gguf"
-          destinations: "models/bge-m3.gguf"
-      - download_models:
-          repo: "n24q02m/Qwen3-Reranker-0.6B-GGUF"
-          files: "qwen3-reranker-0.6b-q4-k-m.gguf"
-          destinations: "models/reranker.gguf"
-      - download_models:
-          repo: "gpustack/jina-reranker-v1-tiny-en-GGUF"
-          files: "jina-reranker-v1-tiny-en-Q4_K_M.gguf"
-          destinations: "models/jina-reranker.gguf"
-      - download_models:
-          repo: "Qwen/Qwen3-1.7B-GGUF"
-          files: "Qwen3-1.7B-Q8_0.gguf"
-          destinations: "models/spec-target.gguf"
+          os: "macosx"
+          models-dir: "/Users/distiller/llamaj.cpp/models"
       - run-tests:
           os: "macosx"
           platform: "aarch64"
@@ -423,44 +389,8 @@ jobs:
       - checkout:
           path: "/home/circleci/llamaj.cpp"
       - download_models:
-          repo: "Qwen/Qwen3-0.6B-GGUF"
-          files: "Qwen3-0.6B-Q8_0.gguf"
-          destinations: "models/model.gguf"
-      - run:
-          name: Copy model for reasoning
-          command: cp $HOME_DIR/llamaj.cpp/models/model.gguf $HOME_DIR/llamaj.cpp/models/reasoning.gguf
-      - download_models:
-          repo: "phh/Qwen3-0.6B-TLDR-Lora"
-          files: "Qwen3-0.6B-tldr-lora-f16.gguf"
-          destinations: "models/lora-adapter.gguf"
-      - download_models:
-          repo: "Qwen/Qwen3-VL-2B-Instruct-GGUF"
-          files: "Qwen3VL-2B-Instruct-Q8_0.gguf,mmproj-Qwen3VL-2B-Instruct-Q8_0.gguf"
-          destinations: "models/model_vl.gguf,models/mmproj.gguf"
-      - download_models:
-          repo: "ggml-org/ultravox-v0_5-llama-3_2-1b-GGUF"
-          files: "Llama-3.2-1B-Instruct-Q8_0.gguf,mmproj-ultravox-v0_5-llama-3_2-1b-f16.gguf"
-          destinations: "models/model_audio.gguf,models/mmproj_audio.gguf"
-      - download_models:
-          repo: "Qwen/Qwen3-Embedding-0.6B-GGUF"
-          files: "Qwen3-Embedding-0.6B-Q8_0.gguf"
-          destinations: "models/embedding.gguf"
-      - download_models:
-          repo: "ggml-org/bge-m3-Q8_0-GGUF"
-          files: "bge-m3-q8_0.gguf"
-          destinations: "models/bge-m3.gguf"
-      - download_models:
-          repo: "n24q02m/Qwen3-Reranker-0.6B-GGUF"
-          files: "qwen3-reranker-0.6b-q4-k-m.gguf"
-          destinations: "models/reranker.gguf"
-      - download_models:
-          repo: "gpustack/jina-reranker-v1-tiny-en-GGUF"
-          files: "jina-reranker-v1-tiny-en-Q4_K_M.gguf"
-          destinations: "models/jina-reranker.gguf"
-      - download_models:
-          repo: "Qwen/Qwen3-1.7B-GGUF"
-          files: "Qwen3-1.7B-Q8_0.gguf"
-          destinations: "models/spec-target.gguf"
+          os: "linux"
+          models-dir: "/home/circleci/llamaj.cpp/models"
       - run-tests:
           os: "linux"
           platform: "x86_64"

--- a/docs/speculative-decoding/README.md
+++ b/docs/speculative-decoding/README.md
@@ -3,13 +3,22 @@
 > Speed up generation by having a cheap drafter propose several tokens that the target model verifies in a single pass, with byte-for-byte identical output.
 
 ## Overview
-Speculative decoding accelerates token generation without changing the result: a cheap *drafter* proposes up to `nDraft` tokens per round and the target model verifies them all in one decode, committing the run of tokens it agrees with. The drafter is either a small **draft model** (`setDraft`) sharing the target's vocab, or **n-gram / prompt-lookup** matching against the generation history with no extra model (`setNgram`). Greedy configs are *lossless* (identical to plain greedy decoding); sampling configs use rejection sampling and stay an *exact* draw of the target distribution. Use it when you have spare compute and want lower latency — especially with repetitive output (code, JSON, RAG) for the n-gram path.
+Speculative decoding accelerates token generation without changing the result: a cheap *drafter* proposes up to `nDraft` tokens per round and the target model verifies them all in one decode, committing the run of tokens it agrees with. Four drafter flavours are available:
+
+| Flavour | Setter | Drafter | Needs |
+| --- | --- | --- | --- |
+| **Model drafting** | `setDraft` | a small separate model sharing the target's vocab | a compatible draft GGUF |
+| **N-gram / prompt-lookup** | `setNgram` | the generation history itself (no model, no forward pass) | nothing |
+| **MTP self-speculation** | `setMtp` | the target model's own multi-token-prediction head | a model with `n_layer_nextn > 0` (e.g. Qwen3.6-MoE) |
+| **EAGLE3** | `setEagle3` | a tiny trained head consuming the target's intermediate hidden states | a target-specific `eagle3`-arch head GGUF |
+
+Greedy configs are *lossless* (identical to plain greedy decoding); sampling configs use rejection sampling and stay an *exact* draw of the target distribution. Use it when you have spare compute and want lower latency — especially with repetitive output (code, JSON, RAG) for the n-gram path. MTP/EAGLE3 bind llama.cpp's *staging* nextn API (C++-mangled symbols, capability-probed at runtime via `LlamaExt`).
 
 ## Key types
 - `SpeculativeConfig` — immutable record holding the draft window, sampling knobs, adaptive early-stop, and n-gram window; built via factories, withers, or a builder.
 - `ConversationState` — per-conversation state; `setDraft(...)` / `setNgram(...)` enable speculation, `isSpeculative()` / `isNgram()` query it, `acceptRate()` reports accepted/drafted.
-- `Speculation` (internal) — drives the draft→verify→accept cycle; the per-position distribution is computed natively, the accept test / residual draw / n-gram lookup are Java.
-- `NgramIndex` (internal) — committed-token history with a position index for ~O(1) prompt-lookup proposals.
+- `io.gravitee.llama.cpp.speculative` (internal) — `SpeculativeDecoding`, the abstract flavour base (verify/accept/emit mechanics) with one subclass per flavour (`ModelDraftSpeculativeDecoding`, `NgramSpeculativeDecoding`, `MtpSpeculativeDecoding`, `Eagle3SpeculativeDecoding`), attached to the state by its setter; and `Speculation`, the sampling math (draft snapshots, rejection-sampling accept test, residual draws — the per-position distribution is computed natively).
+- `io.gravitee.llama.cpp.draft` (internal) — the draft sources: `NgramIndex`, `MtpDraft`, `Eagle3Draft` (the latter two behind `HiddenStateDraft`).
 
 ## Usage
 ```java
@@ -58,16 +67,54 @@ state.setNgram(SpeculativeConfig.ngramGreedy(4, 2));                // greedy: k
 state.setNgram(SpeculativeConfig.ngram(4, 2, 0.8f, 40, 0.95f, 42)); // sampling
 ```
 
+### MTP self-speculation and EAGLE3
+MTP drives the target model's own **nextn head** — no separate draft model. The MTP context is a
+second context over the *target's* model with `ctx_type=MTP`, linked to the target via `ctx_other`:
+
+```java
+// Target model must carry a nextn head: LlamaRuntime.llama_model_n_layer_nextn(model.segment) > 0
+var mtpParams = new LlamaContextParams(arena)
+    .nCtx(512).nBatch(512)
+    .poolingType(PoolingType.NONE)
+    .nRsSeq(nDraft + 1)      // recurrent-state rollback snapshots (hybrid SSM targets)
+    .nSeqMax(nSeqMax)        // match the target's for fused BatchIterator use
+    .nOutputsMax(nSeqMax)    // one output row per concurrent sequence
+    .ctxOther(targetCtx)     // borrows the target's tensors
+    .ctxTypeMtp();
+var mtpCtx = new LlamaContext(arena, model, mtpParams);
+state.setMtp(mtpCtx, SpeculativeConfig.greedy(2)); // K=2 is the measured optimum on Metal
+```
+
+Hybrid attention+SSM targets (the Qwen3.6-MoE family) also need `nRsSeq(nDraft + 1)` on the
+**target** context — rejecting drafts rewinds recurrent state, which only works from snapshots.
+
+EAGLE3 uses a separate ~1B trained head (GGUF arch `eagle3`, converted against your exact target)
+and works with dense targets that have no nextn head:
+
+```java
+var headModel = new LlamaModel(arena, Path.of("eagle3-head.gguf"), new LlamaModelParams(arena));
+var headCtx = new LlamaContext(arena, headModel, cp);
+state.setEagle3(headCtx, headModel, SpeculativeConfig.greedy(2));
+```
+
+Both setters validate capability up front (staging symbols present, head declares 3 extract
+layers, shared vocab) and throw `LlamaException` with a per-symbol report otherwise. The prompt
+must fit in one target batch for EAGLE3 (layer capture covers only the last decode).
+
 ## From the CLI
 `Main` (the bundled CLI) exposes speculation through flags — no code required:
 
 | Flag | Meaning |
 | --- | --- |
-| `--draft <path>` | Draft model GGUF (model drafting); must share the target's vocab. Mutually exclusive with `--ngram`. |
+| `--draft <path>` | Draft model GGUF (model drafting); must share the target's vocab. |
 | `--ngram <window>` | N-gram prompt-lookup drafting with this window; no draft model (default window 2). |
+| `--mtp` | MTP (nextn) self-speculation using the target model's own MTP head; requires `n_layer_nextn > 0`. |
+| `--eagle3 <path>` | EAGLE3 head GGUF (arch `eagle3`, trained for this target). |
 | `--n_draft <k>` | Max tokens drafted/proposed per round (default 4). |
-| `--p_min <p>` | Adaptive early-stop: stop drafting once the draft's top-token probability drops below `p` (model drafting only; `0` = disabled). Distinct from `--min_p` (min-p sampling). |
+| `--p_min <p>` | Adaptive early-stop: stop drafting once the draft's top-token probability drops below `p` (not `--ngram`; `0` = disabled). Distinct from `--min_p` (min-p sampling). |
 | `--draft_min <n>` | Min tokens to draft before `--p_min` applies (default 1; clamped to `[1, n_draft]`). |
+
+The four flavours are mutually exclusive — pick exactly one.
 
 `--strategy DETERMINISTIC` selects the lossless greedy path; any temperature strategy (`CLASSIC_CHAT`/`FOCUSED`/`BALANCED`) makes speculation an exact memoryless sampler (temperature/top-k/top-p only). `CONSTRAINED`/`ADAPTIVE` and `--mmproj` are rejected up front (grammar/mirostat aren't memoryless; multimodal is unsupported).
 
@@ -103,7 +150,10 @@ Helpers: `isGreedy()` (`temperature <= 0`), `isAdaptive()` (`pMin > 0` and model
 - `setNgram` requires an n-gram config (`config.isNgram()`, i.e. `ngram >= 1`); calling it with a model-draft config throws. A missing n-gram match simply degrades the round to a single target decode — never wrong output.
 - **Lossless / exact regardless of draft quality:** the target verifies every proposed token and always commits at least one. A weaker draft only lowers `acceptRate()`, it never changes which tokens are emitted. `acceptRate()` is `0.0` until something is drafted.
 - **Adaptive early stop** (`pMin > 0`) changes only *how many* tokens are speculated per round, not *which* are emitted, so it preserves greedy losslessness and sampling exactness.
-- Works with both `DefaultLlamaIterator` (single sequence) and `BatchIterator` (fused multi-sequence). For the fused path, size the target context so `nBatch >= sum(nDraft + 1)` across sequences.
+- All four flavours work with both `DefaultLlamaIterator` (single sequence) and `BatchIterator` (fused multi-sequence). For the fused path, size the target context so `nBatch >= sum(nDraft + 1)` across sequences.
+- **Fused MTP/EAGLE3**: sequences sharing a head context draft in lockstep — each chain step is one batched dual *(token, hidden)* decode across sequences (this also amortizes the per-draft dispatch cost that dominates small-graph decodes), they verify in the shared fused target decode, and each sequence then advances its own seed (MTP: the target's hidden at its last accepted verify row) or boundary (EAGLE3: per-sequence slice of the layer capture, encoded and re-synced) from its slice of the verify buffers. Size the **head context** for the batch: `nSeqMax` matching the target's and `nOutputsMax >= nSeqMax` (the bundled CLI does this; if you build the MTP context yourself, see the usage snippet above).
+- EAGLE3 tip: keep `nDraft` small (2–3) and benchmark with chat-shaped prompts — community heads are instruct-trained, raw completions understate them. MTP/EAGLE3 pay off most where no compatible small draft model exists (MTP: the head ships inside the GGUF; EAGLE3: dense targets with a published head).
+- **Staging-API dependency:** MTP/EAGLE3 resolve C++-mangled symbols from the bundled llama.cpp at runtime (`LlamaExt.available()` / `eagle3Available()`). A llama.cpp version bump can invalidate them; the setters then fail fast with a per-symbol resolution report rather than mis-calling a changed ABI.
 - **Resources/lifecycle:** the `Speculation` allocates persistent native scratch (sampler chain + draft/verify batches) on the state's `Arena`, freed once on teardown. Close the iterator (try-with-resources) when abandoning a stream so the scratch is freed and the sequence cleared; the contexts stay reusable afterward.
 
 ## See also

--- a/pom.xml
+++ b/pom.xml
@@ -406,6 +406,7 @@
                                 <exclude>SECURITY.md</exclude>
                                 <exclude>.gravitee.settings.xml</exclude>
                                 <exclude>.jextract/**</exclude>
+                                <exclude>scripts/ci-models.txt</exclude>
                             </excludes>
                         </licenseSet>
                     </licenseSets>

--- a/scripts/ci-models.txt
+++ b/scripts/ci-models.txt
@@ -1,0 +1,16 @@
+# CI model manifest: one entry per line as `repo file dest` (space-separated).
+# Consumed by scripts/download_ci_models.sh, which downloads every entry in
+# parallel from https://huggingface.co/<repo>/resolve/main/<file> into <dest>.
+# NOTE: bump CACHE_KEY_VERSION in that script whenever this list changes so the
+# CircleCI cache is invalidated.
+Qwen/Qwen3-0.6B-GGUF Qwen3-0.6B-Q8_0.gguf models/model.gguf
+phh/Qwen3-0.6B-TLDR-Lora Qwen3-0.6B-tldr-lora-f16.gguf models/lora-adapter.gguf
+Qwen/Qwen3-VL-2B-Instruct-GGUF Qwen3VL-2B-Instruct-Q8_0.gguf models/model_vl.gguf
+Qwen/Qwen3-VL-2B-Instruct-GGUF mmproj-Qwen3VL-2B-Instruct-Q8_0.gguf models/mmproj.gguf
+ggml-org/ultravox-v0_5-llama-3_2-1b-GGUF Llama-3.2-1B-Instruct-Q8_0.gguf models/model_audio.gguf
+ggml-org/ultravox-v0_5-llama-3_2-1b-GGUF mmproj-ultravox-v0_5-llama-3_2-1b-f16.gguf models/mmproj_audio.gguf
+Qwen/Qwen3-Embedding-0.6B-GGUF Qwen3-Embedding-0.6B-Q8_0.gguf models/embedding.gguf
+ggml-org/bge-m3-Q8_0-GGUF bge-m3-q8_0.gguf models/bge-m3.gguf
+n24q02m/Qwen3-Reranker-0.6B-GGUF qwen3-reranker-0.6b-q4-k-m.gguf models/reranker.gguf
+gpustack/jina-reranker-v1-tiny-en-GGUF jina-reranker-v1-tiny-en-Q4_K_M.gguf models/jina-reranker.gguf
+Qwen/Qwen3-1.7B-GGUF Qwen3-1.7B-Q8_0.gguf models/spec-target.gguf

--- a/scripts/download_ci_models.sh
+++ b/scripts/download_ci_models.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Copyright © 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Download every model listed in scripts/ci-models.txt in parallel.
+#
+# Files that already exist (e.g. restored from the CircleCI cache) are skipped,
+# so this doubles as the cache-fill step: on a cold cache it fetches everything
+# concurrently; on a warm cache it only fills gaps and re-derives reasoning.gguf.
+#
+# Env:
+#   MODELS_ROOT  Base dir; destinations from the manifest are resolved under it
+#                (required, e.g. "$HOME_DIR/llamaj.cpp").
+#
+set -euo pipefail
+
+ROOT="${MODELS_ROOT:?MODELS_ROOT must be set}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST="$HERE/ci-models.txt"
+
+download_one() {
+  local repo="$1" file="$2" dest="$3"
+  local out="$ROOT/$dest"
+  if [[ -s "$out" ]]; then
+    echo "cache hit, skipping: $dest"
+    return 0
+  fi
+  mkdir -p "$(dirname "$out")"
+  echo "downloading $repo/$file -> $dest"
+  curl -fSL --retry 5 --retry-delay 3 --retry-connrefused \
+    -o "$out.part" \
+    "https://huggingface.co/$repo/resolve/main/$file"
+  mv "$out.part" "$out" # atomic: a half-written file never looks like a cache hit
+}
+
+pids=()
+while read -r repo file dest _; do
+  [[ -z "${repo:-}" || "$repo" == \#* ]] && continue
+  download_one "$repo" "$file" "$dest" &
+  pids+=("$!")
+done < "$MANIFEST"
+
+status=0
+for pid in "${pids[@]}"; do
+  wait "$pid" || status=1
+done
+if [[ $status -ne 0 ]]; then
+  echo "ERROR: one or more model downloads failed" >&2
+  exit 1
+fi
+
+# reasoning.gguf is just a copy of the base model (kept out of the manifest so it
+# is not fetched twice).
+cp "$ROOT/models/model.gguf" "$ROOT/models/reasoning.gguf"
+
+echo "all models ready under $ROOT/models"

--- a/src/main/java/io/gravitee/llama/cpp/BatchIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/BatchIterator.java
@@ -15,7 +15,10 @@
  */
 package io.gravitee.llama.cpp;
 
+import io.gravitee.llama.cpp.draft.HiddenStateDraft;
+import io.gravitee.llama.cpp.speculative.Speculation;
 import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
 import java.util.*;
 
 /**
@@ -26,12 +29,17 @@ public final class BatchIterator
   extends LlamaIterator<LlamaOutput>
   implements AutoCloseable {
 
+  private final Arena arena;
   private final LlamaContext context;
   private final LlamaBatch batch;
   private final Map<Integer, ConversationState> seqIdToState;
   private final Map<Integer, Boolean> firstTokenEmitted;
   private final Map<Integer, Integer> seqIdToBatchPos;
   private final List<LlamaOutput> currentOutputs = new ArrayList<>();
+  // Per-head-context dual token+embd scratch for fused MTP/EAGLE3 draft chains (lazily built,
+  // freed with the iterator).
+  private final Map<LlamaContext, FusedDualBatch> dualScratch =
+    new LinkedHashMap<>();
   private int currentOutputIndex = 0;
   private volatile boolean stopped = false;
   private boolean freed = false;
@@ -49,6 +57,7 @@ public final class BatchIterator
     MtmdContext mtmdContext
   ) {
     super(null, mtmdContext); // No initial state - states are added via addState()
+    this.arena = arena;
     this.context = context;
     this.batch = new LlamaBatch(arena, context.nBatch(), 0, context.nSeqMax());
     this.seqIdToState = new HashMap<>();
@@ -226,11 +235,17 @@ public final class BatchIterator
       }
     }
     Map<LlamaContext, List<Integer>> byDraftContext = new LinkedHashMap<>();
+    Map<LlamaContext, List<Integer>> byHiddenContext = new LinkedHashMap<>();
     for (int c = 0; c < n; c++) {
       ConversationState s = states.get(c);
       if (s.hasDraft()) {
         byDraftContext
           .computeIfAbsent(s.getDraftContext(), key -> new ArrayList<>())
+          .add(c);
+      } else if (s.isMtp() || s.isEagle3()) {
+        // MTP/EAGLE3: fused per shared head context (dual token+embd chain steps).
+        byHiddenContext
+          .computeIfAbsent(hiddenDraft(s).context(), key -> new ArrayList<>())
           .add(c);
       } else {
         // n-gram: propose up to nDraft tokens from the committed history (no draft decode).
@@ -250,12 +265,26 @@ public final class BatchIterator
         nDrafted
       );
     }
+    for (var entry : byHiddenContext.entrySet()) {
+      draftHiddenGroupFused(
+        states,
+        entry.getKey(),
+        entry.getValue(),
+        chains,
+        drafted,
+        snaps,
+        nDrafted
+      );
+    }
 
-    // Phase B — one fused target decode over all sequences' drafts.
+    // Phase B — one fused target decode over all sequences' drafts. Each sequence's pre-verify
+    // idLast is captured for the hidden-state advance (acceptSequence overwrites newTokenId).
+    int[] idLast = new int[n];
     batch.clear();
     for (int c = 0; c < n; c++) {
       ConversationState s = states.get(c);
       base[c] = batch.nTokens();
+      idLast[c] = s.getNewTokenId();
       var seq = List.of(s.getSequenceId());
       batch.add(s.getNewTokenId(), s.getNPast(), seq, true);
       for (int i = 0; i < nDrafted[c]; i++) {
@@ -282,6 +311,24 @@ public final class BatchIterator
         snaps[c],
         nVocab
       );
+    }
+
+    // Phase C' — advance MTP seeds / EAGLE3 boundaries from the verify decode's capture buffers.
+    // Must run before any further TARGET decode (the captures cover only the last target decode);
+    // Phase D only decodes draft contexts, so ordering here is safe.
+    for (int c = 0; c < n; c++) {
+      ConversationState s = states.get(c);
+      if (s.isMtp() || s.isEagle3()) {
+        advanceHiddenState(
+          s,
+          base[c],
+          idLast[c],
+          oldNPast[c],
+          matched[c],
+          nDrafted[c],
+          drafted[c]
+        );
+      }
     }
 
     // Phase D — fused gap-fill, only for full-accept (still-running) sequences. On partial accept
@@ -408,6 +455,235 @@ public final class BatchIterator
           active[j] = false;
         }
       }
+    }
+  }
+
+  /**
+   * Fused draft chain for a group of MTP/EAGLE3 sequences sharing one head context: each chain
+   * step decodes one dual (token, hidden) row per still-drafting sequence in a single batched
+   * head decode, then samples per row and chains each sequence on its own row's hidden output
+   * ({@link HiddenStateDraft#chainHidden(int)}). Semantics per sequence are identical to the
+   * single-sequence rounds (greedy/confident/snapshot sampling, adaptive early-stop).
+   */
+  private void draftHiddenGroupFused(
+    List<ConversationState> states,
+    LlamaContext headContext,
+    List<Integer> group,
+    LlamaSampler[] chains,
+    int[][] drafted,
+    Speculation.Snapshot[][] snaps,
+    int[] nDrafted
+  ) {
+    int g = group.size();
+    FusedDualBatch dual = dualScratch.computeIfAbsent(headContext, ctx ->
+      new FusedDualBatch(
+        ctx,
+        hiddenDraft(states.get(group.get(0))).hiddenSize()
+      )
+    );
+    if (g > dual.capacity) {
+      throw new LlamaException(
+        "Fused MTP/EAGLE3 draft needs head n_seq_max >= " +
+          g +
+          " (sequences sharing a head context); got " +
+          dual.capacity
+      );
+    }
+    int nVocab = context.nVocab();
+    int[] prev = new int[g];
+    int[] basePos = new int[g];
+    float[][] hidden = new float[g][];
+    boolean[] active = new boolean[g];
+    float[] probOut = new float[1];
+    int maxK = 0;
+    for (int j = 0; j < g; j++) {
+      ConversationState s = states.get(group.get(j));
+      HiddenStateDraft drafter = hiddenDraft(s);
+      prev[j] = s.getNewTokenId();
+      // MTP pairs (token @ P, hidden @ P-1) starting at nPast; the EAGLE3 decoder pairs
+      // (token @ P+1, g @ P) starting at the pending boundary nPast-1.
+      basePos[j] = s.isMtp() ? s.getNPast() : s.getNPast() - 1;
+      hidden[j] = s.isMtp()
+        ? s.getMtpDraft().seed()
+        : s.getEagle3Draft().boundary();
+      active[j] = true;
+      nDrafted[group.get(j)] = 0;
+      maxK = Math.max(maxK, s.getNDraft());
+      // Wipe stale head cells in this round's write window (previous round's chain overrun).
+      headContext.getMemory().seqRm(s.getSequenceId(), basePos[j], -1);
+    }
+
+    int[] row = new int[g];
+    for (int step = 0; step < maxK; step++) {
+      dual.clear();
+      int packed = 0;
+      for (int j = 0; j < g; j++) {
+        if (!active[j]) {
+          continue;
+        }
+        ConversationState s = states.get(group.get(j));
+        row[j] = dual.addRow(
+          prev[j],
+          basePos[j] + step,
+          s.getSequenceId(),
+          hidden[j]
+        );
+        packed++;
+      }
+      if (packed == 0) {
+        break;
+      }
+      if (dual.decode() != 0) {
+        throw new LlamaException("Fused MTP/EAGLE3 draft decode failed");
+      }
+      for (int j = 0; j < g; j++) {
+        if (!active[j]) {
+          continue;
+        }
+        int c = group.get(j);
+        ConversationState s = states.get(c);
+        Speculation spec = s.getSpeculation();
+        int sampled;
+        float topProb;
+        if (spec.isGreedy()) {
+          if (spec.isAdaptive()) {
+            sampled = spec.draftGreedyConfident(
+              logitsRow(headContext, row[j], nVocab),
+              nVocab,
+              probOut
+            );
+            topProb = probOut[0];
+          } else {
+            sampled = chains[c].sample(headContext, row[j]);
+            topProb = 1.0f; // unused without adaptive stop
+          }
+        } else {
+          Speculation.Snapshot ds = spec.draft(
+            chains[c],
+            logitsRow(headContext, row[j], nVocab)
+          );
+          sampled = ds.selectedId();
+          snaps[c][nDrafted[c]] = ds;
+          topProb = ds.maxProb();
+        }
+        drafted[c][nDrafted[c]] = sampled;
+        nDrafted[c]++;
+        prev[j] = sampled;
+        if (nDrafted[c] >= s.getNDraft()) {
+          active[j] = false;
+        } else if (
+          spec.isAdaptive() &&
+          nDrafted[c] >= spec.draftMin() &&
+          topProb < spec.pMin()
+        ) {
+          active[j] = false;
+        } else {
+          // The head's own hidden for this row seeds this sequence's next chained draft.
+          hidden[j] = hiddenDraft(s).chainHidden(row[j]);
+        }
+      }
+    }
+  }
+
+  /**
+   * Post-accept advance of a hidden-state sequence from its slice of the fused verify decode:
+   * MTP re-seeds from the target's hidden at the last accepted row; EAGLE3 encodes its verify
+   * rows' captured features, re-syncs the head decoder with only the accepted shifted pairs,
+   * and moves the pending boundary. Must run before the next TARGET decode (the capture buffers
+   * cover only the last one).
+   */
+  private void advanceHiddenState(
+    ConversationState s,
+    int base,
+    int idLast,
+    int oldNPast,
+    int matched,
+    int m,
+    int[] drafted
+  ) {
+    int seqId = s.getSequenceId();
+    int newNPast = oldNPast + matched + 1;
+    if (s.isMtp()) {
+      var mtp = s.getMtpDraft();
+      mtp.setSeed(context.getEmbeddingsIth(base + matched));
+      mtp.context().getMemory().seqRm(seqId, newNPast, -1);
+      return;
+    }
+    var e3 = s.getEagle3Draft();
+    int boundaryPos = oldNPast - 1;
+    // gv[r] = g at target pos oldNPast + r, from this sequence's verify-row slice.
+    float[][] gv = e3.encodeCaptured(context, base, m + 1);
+    // Head resync: wipe from the boundary, re-decode only the accepted shifted pairs.
+    e3.context().getMemory().seqRm(seqId, boundaryPos, -1);
+    int[] toks = new int[matched + 1];
+    int[] poss = new int[matched + 1];
+    float[][] rows = new float[matched + 1][];
+    toks[0] = idLast;
+    poss[0] = boundaryPos;
+    rows[0] = e3.boundary();
+    for (int k = 0; k < matched; k++) {
+      toks[k + 1] = drafted[k];
+      poss[k + 1] = boundaryPos + 1 + k;
+      rows[k + 1] = gv[k];
+    }
+    e3.syncPairs(toks, poss, rows, List.of(seqId));
+    e3.setBoundary(gv[matched]);
+  }
+
+  /** The state's hidden-state draft source (MTP head or EAGLE3 head). */
+  private static HiddenStateDraft hiddenDraft(ConversationState s) {
+    return s.isMtp() ? s.getMtpDraft() : s.getEagle3Draft();
+  }
+
+  /**
+   * Persistent dual token+embd batch for fused MTP/EAGLE3 chain steps on one head context:
+   * up to {@code n_seq_max} rows, each carrying a token plus that sequence's hidden-state row.
+   * The embd buffer is arena-owned and injected into the batch (nulled before free — see
+   * {@code LlamaExt.setBatchEmbd}).
+   */
+  private final class FusedDualBatch {
+
+    final LlamaContext head;
+    final LlamaBatch batch;
+    final MemorySegment embd;
+    final int nEmbd;
+    final int capacity;
+
+    FusedDualBatch(LlamaContext headContext, int nEmbd) {
+      this.head = headContext;
+      this.nEmbd = nEmbd;
+      this.capacity = Math.max(1, context.nSeqMax());
+      this.embd = arena.allocate((long) capacity * nEmbd * Float.BYTES);
+      this.batch = new LlamaBatch(arena, capacity, 0, 1);
+      LlamaExt.setBatchEmbd(batch, embd);
+    }
+
+    void clear() {
+      batch.clear();
+    }
+
+    /** Adds one (token, hidden) row; returns its batch row index (== logits row). */
+    int addRow(int token, int pos, int seqId, float[] hidden) {
+      int r = batch.nTokens();
+      batch.add(token, pos, List.of(seqId), true);
+      MemorySegment.copy(
+        hidden,
+        0,
+        embd,
+        java.lang.foreign.ValueLayout.JAVA_FLOAT,
+        (long) r * nEmbd * Float.BYTES,
+        nEmbd
+      );
+      return r;
+    }
+
+    int decode() {
+      return batch.decode(head);
+    }
+
+    void free() {
+      LlamaExt.setBatchEmbd(batch, MemorySegment.NULL);
+      batch.free();
     }
   }
 
@@ -805,6 +1081,10 @@ public final class BatchIterator
     }
     freed = true;
     stop();
+    for (FusedDualBatch dual : dualScratch.values()) {
+      dual.free();
+    }
+    dualScratch.clear();
     batch.free();
   }
 
@@ -820,7 +1100,7 @@ public final class BatchIterator
     // Free the speculative state's persistent native scratch (idempotent: null-on-free, so the
     // common path of removal-then-stop never double-frees). Non-speculative states have none.
     if (state.isSpeculative()) {
-      state.getSpeculation().free();
+      state.freeSpeculativeScratch();
     }
     firstTokenEmitted.remove(sequenceId);
     seqIdToBatchPos.remove(sequenceId);

--- a/src/main/java/io/gravitee/llama/cpp/ConversationState.java
+++ b/src/main/java/io/gravitee/llama/cpp/ConversationState.java
@@ -19,10 +19,14 @@ import static io.gravitee.llama.cpp.GenerationState.ANSWER;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
 import io.gravitee.llama.cpp.LlamaTokenizer.TokenizerResponse;
+import io.gravitee.llama.cpp.draft.Eagle3Draft;
+import io.gravitee.llama.cpp.draft.MtpDraft;
+import io.gravitee.llama.cpp.draft.NgramIndex;
 import io.gravitee.llama.cpp.modules.PromptMemory;
 import io.gravitee.llama.cpp.modules.StateEvaluation;
 import io.gravitee.llama.cpp.modules.StopString;
 import io.gravitee.llama.cpp.modules.TokenTracking;
+import io.gravitee.llama.cpp.speculative.*;
 import io.gravitee.llama.cpp.utils.Utf8Decoder;
 import java.lang.foreign.Arena;
 import java.util.ArrayList;
@@ -77,6 +81,13 @@ public class ConversationState {
   // N-gram (prompt-lookup) drafting history + position index (the committed token stream
   // prompt+generated, on the heap, NOT the confined arena). Built lazily by setNgram().
   private NgramIndex ngramIndex;
+
+  // MTP self-speculation (setMtp) / EAGLE3 head drafting (setEagle3) proposal state.
+  private MtpDraft mtpDraft;
+  private Eagle3Draft eagle3Draft;
+
+  // The speculative flavour attached by setDraft/setNgram/setMtp/setEagle3 (stateless singleton).
+  private SpeculativeDecoding speculativeDecoding;
   private final List<StateBounds> stateBounds = new ArrayList<>();
   private List<MtmdMedia> media = new ArrayList<>();
 
@@ -207,6 +218,7 @@ public class ConversationState {
     this.draftContext = draftContext;
     this.speculativeConfig = config;
     this.speculation = new Speculation(arena, context.nVocab(), config);
+    this.speculativeDecoding = ModelDraftSpeculativeDecoding.INSTANCE;
     return this;
   }
 
@@ -226,6 +238,128 @@ public class ConversationState {
     this.speculativeConfig = config;
     this.speculation = new Speculation(arena, context.nVocab(), config);
     this.ngramIndex = new NgramIndex(config.ngram());
+    this.speculativeDecoding = NgramSpeculativeDecoding.INSTANCE;
+    return this;
+  }
+
+  /**
+   * Enables MTP (nextn) self-speculative decoding: the target model's own multi-token-prediction
+   * head proposes tokens — no separate draft model. Requires a model with {@code n_layer_nextn > 0},
+   * the staging nextn API in the loaded llama.cpp
+   * ({@link LlamaExt#available()}), and {@code mtpContext} built from the <b>same model</b> as this
+   * state's target with {@code LlamaContextParams.ctxTypeMtp().ctxOther(target).nRsSeq(>0)}.
+   *
+   * <p>Enables embeddings output on the target context (the MTP head is seeded with the target's
+   * post-norm hidden states). Greedy config is lossless; sampling configs use rejection sampling.
+   * N-gram configs are rejected.
+   *
+   * @param mtpContext An MTP draft context over the target's model (caller-owned, like a draft ctx)
+   * @param config     Speculative decoding configuration ({@code ngram} must be 0)
+   */
+  public ConversationState setMtp(
+    LlamaContext mtpContext,
+    SpeculativeConfig config
+  ) {
+    if (config.isNgram()) {
+      throw new LlamaException(
+        "setMtp requires a model-draft config (ngram == 0)"
+      );
+    }
+    if (!LlamaExt.available()) {
+      throw new LlamaException(
+        "MTP requires the staging nextn API in the loaded libllama:\n" +
+          LlamaExt.resolutionReport()
+      );
+    }
+    // The MTP context must share the target's vocab (it is the same model).
+    if (mtpContext.nVocab() != context.nVocab()) {
+      throw new LlamaException(
+        "MTP context vocab (" +
+          mtpContext.nVocab() +
+          ") differs from target (" +
+          context.nVocab() +
+          ") — the MTP context must be built from the target's model"
+      );
+    }
+    // Seed extraction reads the target's post-norm hidden rows.
+    LlamaRuntime.llama_set_embeddings(context.segment, true);
+    // The MTP graph stores its own nextn hidden per output row for nDraft>1 chaining.
+    LlamaExt.setEmbeddingsNextn(mtpContext, true, false);
+    this.speculativeConfig = config;
+    this.speculation = new Speculation(arena, context.nVocab(), config);
+    this.mtpDraft = new MtpDraft(
+      arena,
+      mtpContext,
+      context.getModel().nEmbdOut()
+    );
+    this.speculativeDecoding = MtpSpeculativeDecoding.INSTANCE;
+    return this;
+  }
+
+  /**
+   * Enables EAGLE3 speculative decoding: a separate tiny trained head model (GGUF arch
+   * {@code eagle3}) proposes tokens from the target's intermediate hidden states. Works with
+   * targets that carry no nextn head (dense models). Requires the staging layer-input API
+   * ({@link LlamaExt#eagle3Available()}), a head model declaring exactly 3 target extract layers,
+   * and a shared vocab.
+   *
+   * <p>Enables capture of the declared target layers' input hiddens on the target context and
+   * nextn (pre-norm) capture on the head context. Greedy config is lossless; sampling configs use
+   * rejection sampling. N-gram configs are rejected.
+   *
+   * @param eagle3Context A context over the EAGLE3 head model (caller-owned)
+   * @param eagle3Model   The EAGLE3 head model (for its target-layer ids and hidden size)
+   * @param config        Speculative decoding configuration ({@code ngram} must be 0)
+   */
+  public ConversationState setEagle3(
+    LlamaContext eagle3Context,
+    LlamaModel eagle3Model,
+    SpeculativeConfig config
+  ) {
+    if (config.isNgram()) {
+      throw new LlamaException(
+        "setEagle3 requires a model-draft config (ngram == 0)"
+      );
+    }
+    if (!LlamaExt.eagle3Available()) {
+      throw new LlamaException(
+        "EAGLE3 requires the staging layer-input API in the loaded libllama:\n" +
+          LlamaExt.eagle3ResolutionReport()
+      );
+    }
+    int[] layerIds = LlamaExt.targetLayerIds(eagle3Model);
+    if (layerIds.length != 3) {
+      throw new LlamaException(
+        "Not an EAGLE3 head model: expected 3 target extract layers, got " +
+          layerIds.length
+      );
+    }
+    if (eagle3Context.nVocab() != context.nVocab()) {
+      throw new LlamaException(
+        "EAGLE3 head vocab (" +
+          eagle3Context.nVocab() +
+          ") differs from target (" +
+          context.nVocab() +
+          ") — the head must be converted against this target model"
+      );
+    }
+    // Capture the declared target layers' input hiddens on every target decode.
+    for (int id : layerIds) {
+      LlamaExt.setEmbeddingsLayerInp(context, id, true);
+    }
+    // Head pre-norm hidden capture: encoder g_embd rows + decoder chain seeds.
+    LlamaExt.setEmbeddingsNextn(eagle3Context, true, true);
+    this.speculativeConfig = config;
+    this.speculation = new Speculation(arena, context.nVocab(), config);
+    this.eagle3Draft = new Eagle3Draft(
+      arena,
+      eagle3Context,
+      layerIds,
+      context.getModel().nEmbdOut(),
+      eagle3Model.nEmbdOut(),
+      config.nDraft()
+    );
+    this.speculativeDecoding = Eagle3SpeculativeDecoding.INSTANCE;
     return this;
   }
 
@@ -243,6 +377,37 @@ public class ConversationState {
     return speculativeConfig != null && speculativeConfig.isNgram();
   }
 
+  /** Whether MTP (nextn) self-speculation is enabled. */
+  public boolean isMtp() {
+    return mtpDraft != null;
+  }
+
+  /** Whether EAGLE3 head drafting is enabled. */
+  public boolean isEagle3() {
+    return eagle3Draft != null;
+  }
+
+  public MtpDraft getMtpDraft() {
+    return mtpDraft;
+  }
+
+  public Eagle3Draft getEagle3Draft() {
+    return eagle3Draft;
+  }
+
+  /** Frees all speculative persistent native scratch (idempotent; safe when none is set). */
+  public void freeSpeculativeScratch() {
+    if (speculation != null) {
+      speculation.free();
+    }
+    if (mtpDraft != null) {
+      mtpDraft.free();
+    }
+    if (eagle3Draft != null) {
+      eagle3Draft.free();
+    }
+  }
+
   public LlamaContext getDraftContext() {
     return draftContext;
   }
@@ -251,8 +416,13 @@ public class ConversationState {
     return speculativeConfig.nDraft();
   }
 
-  Speculation getSpeculation() {
+  public Speculation getSpeculation() {
     return speculation;
+  }
+
+  /** The speculative flavour enabled on this state (null when not speculative). */
+  public SpeculativeDecoding getSpeculativeDecoding() {
+    return speculativeDecoding;
   }
 
   /**
@@ -270,7 +440,7 @@ public class ConversationState {
   }
 
   /** Appends one committed token to the n-gram history (and its index). */
-  void appendHistory(int token) {
+  public void appendHistory(int token) {
     ngramIndex.append(token);
   }
 
@@ -281,7 +451,7 @@ public class ConversationState {
    * target decode). Pure heap/CPU work — no native calls, no draft KV. A wrong proposal only lowers
    * the accept rate; the target verify is the sole arbiter of emitted tokens.
    */
-  int[] proposeNgram(int kMax) {
+  public int[] proposeNgram(int kMax) {
     return ngramIndex.propose(kMax);
   }
 

--- a/src/main/java/io/gravitee/llama/cpp/DefaultLlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/DefaultLlamaIterator.java
@@ -180,7 +180,7 @@ public final class DefaultLlamaIterator
   @Override
   public void close() {
     if (currentState.isSpeculative()) {
-      currentState.getSpeculation().free();
+      currentState.freeSpeculativeScratch();
     }
     currentState
       .getContext()

--- a/src/main/java/io/gravitee/llama/cpp/LlamaBatch.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaBatch.java
@@ -231,6 +231,16 @@ public final class LlamaBatch extends MemorySegmentAware implements Freeable {
   }
 
   /**
+   * Runs this batch through the context's <b>encoder</b> graph ({@code llama_encode}) —
+   * used by encoder-bearing architectures (e.g. EAGLE3 draft heads).
+   *
+   * @return 0 on success, non-zero on error
+   */
+  public int encode(LlamaContext context) {
+    return LlamaRuntime.llama_encode(context.segment, this.segment);
+  }
+
+  /**
    * Returns the number of tokens currently in this batch.
    */
   public int nTokens() {

--- a/src/main/java/io/gravitee/llama/cpp/LlamaContext.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaContext.java
@@ -94,6 +94,11 @@ public final class LlamaContext extends MemorySegmentAware implements Freeable {
     return nBatch;
   }
 
+  /** The micro-batch size ({@code n_ubatch}) this context was created with. */
+  public int nUbatch() {
+    return LlamaRuntime.llama_n_ubatch(segment);
+  }
+
   public int nUBatch() {
     return nUBatch;
   }

--- a/src/main/java/io/gravitee/llama/cpp/LlamaContextParams.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaContextParams.java
@@ -18,6 +18,7 @@ package io.gravitee.llama.cpp;
 import static io.gravitee.llama.cpp.LlamaRuntime.*;
 
 import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
 
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
@@ -161,6 +162,46 @@ public final class LlamaContextParams extends MemorySegmentAware {
 
   public LlamaContextParams noPerf(boolean noPerf) {
     no_perf(this.segment, noPerf);
+    return this;
+  }
+
+  /* ----- MTP self-speculation (nextn) context fields (public llama.h) ----- */
+
+  private static final Class<?>[] SEG_INT = new Class<?>[] {
+    MemorySegment.class,
+    int.class,
+  };
+
+  /**
+   * Sets {@code ctx_type = LLAMA_CONTEXT_TYPE_MTP (1)} — build this context as an MTP
+   * self-speculation draft. The context must be created from a model that carries a nextn head
+   * ({@code n_layer_nextn > 0}), with {@link #ctxOther(LlamaContext)} pointing at the target.
+   */
+  public LlamaContextParams ctxTypeMtp() {
+    llama_context_params("ctx_type", SEG_INT, this.segment, 1);
+    return this;
+  }
+
+  /** Links this (draft) context to a source/target context — borrows tensors / shares memory. */
+  public LlamaContextParams ctxOther(LlamaContext other) {
+    llama_context_params(
+      "ctx_other",
+      new Class<?>[] { MemorySegment.class, MemorySegment.class },
+      this.segment,
+      other.segment
+    );
+    return this;
+  }
+
+  /** Recurrent-state rollback snapshots per sequence — must be {@code > 0} for MTP. */
+  public LlamaContextParams nRsSeq(int nRsSeq) {
+    llama_context_params("n_rs_seq", SEG_INT, this.segment, nRsSeq);
+    return this;
+  }
+
+  /** Max outputs per decode (set to the parallelism for MTP). */
+  public LlamaContextParams nOutputsMax(int nOutputsMax) {
+    llama_context_params("n_outputs_max", SEG_INT, this.segment, nOutputsMax);
     return this;
   }
 }

--- a/src/main/java/io/gravitee/llama/cpp/LlamaExt.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaExt.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static io.gravitee.llama.cpp.cxx.CxxParam.BOOL;
+import static io.gravitee.llama.cpp.cxx.CxxParam.CONST_MODEL;
+import static io.gravitee.llama.cpp.cxx.CxxParam.CTX;
+import static io.gravitee.llama.cpp.cxx.CxxParam.INT32;
+import static io.gravitee.llama.cpp.cxx.CxxParam.UINT32;
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+
+import io.gravitee.llama.cpp.cxx.CxxFunction;
+import io.gravitee.llama.cpp.cxx.CxxFunctions;
+import io.gravitee.llama.cpp.platform.PlatformResolver;
+import java.lang.foreign.MemorySegment;
+import java.util.List;
+
+/**
+ * Binding for llama.cpp's <b>staging</b> API ({@code src/llama-ext.h}): MTP "nextn"
+ * self-speculation and EAGLE3 layer-input extraction.
+ *
+ * <p>The staging header is not inside an {@code extern "C"} block, so these functions are
+ * exported from {@code libllama} under <b>C++-mangled</b> names (Itanium ABI — identical on
+ * macOS-arm64 and Linux-x86_64) and jextract cannot bind them. Each function is declared as a
+ * {@link CxxFunction} data record; derivation of the mangled symbol, resolution, and
+ * dispatch live in {@link io.gravitee.llama.cpp.cxx}. Adding a staging function is one
+ * declaration line.
+ *
+ * <p><b>Fragility:</b> the mangled name encodes the full signature. If upstream renames a
+ * function or changes a parameter type, the symbol vanishes and the group's {@code available()}
+ * returns {@code false} — fail-fast, never a silent wrong-ABI call.
+ * {@code MtpEagle3SpeculativeTest} asserts resolution in CI, so a llama.cpp version bump that
+ * breaks the ABI fails with a per-symbol report; {@code LlamaExtSymbolsTest} locks the derived
+ * manglings against the observed exports.
+ *
+ * @author GraviteeSource Team
+ */
+public final class LlamaExt {
+
+  private LlamaExt() {}
+
+  // MTP (nextn) self-speculation group.
+  static final CxxFunction SET_EMBEDDINGS_NEXTN = CxxFunction.of(
+    "llama_set_embeddings_nextn",
+    null,
+    CTX,
+    BOOL,
+    BOOL
+  );
+  static final CxxFunction GET_EMBEDDINGS_NEXTN_ITH = CxxFunction.of(
+    "llama_get_embeddings_nextn_ith",
+    ADDRESS,
+    CTX,
+    INT32
+  );
+  static final CxxFunction GET_CTX_OTHER = CxxFunction.of(
+    "llama_get_ctx_other",
+    ADDRESS,
+    CTX
+  );
+
+  // EAGLE3 layer-input extraction group.
+  static final CxxFunction SET_EMBEDDINGS_LAYER_INP = CxxFunction.of(
+    "llama_set_embeddings_layer_inp",
+    null,
+    CTX,
+    UINT32,
+    BOOL
+  );
+  static final CxxFunction GET_EMBEDDINGS_LAYER_INP = CxxFunction.of(
+    "llama_get_embeddings_layer_inp",
+    ADDRESS,
+    CTX,
+    UINT32
+  );
+  static final CxxFunction GET_EMBEDDINGS_NEXTN = CxxFunction.of(
+    "llama_get_embeddings_nextn",
+    ADDRESS,
+    CTX
+  );
+  static final CxxFunction MODEL_TARGET_LAYER_IDS = CxxFunction.of(
+    "llama_model_target_layer_ids",
+    ADDRESS,
+    CONST_MODEL
+  );
+  static final CxxFunction MODEL_TARGET_LAYER_IDS_N = CxxFunction.of(
+    "llama_model_target_layer_ids_n",
+    JAVA_INT,
+    CONST_MODEL
+  );
+
+  static final List<CxxFunction> MTP_GROUP = List.of(
+    SET_EMBEDDINGS_NEXTN,
+    GET_EMBEDDINGS_NEXTN_ITH,
+    GET_CTX_OTHER
+  );
+  static final List<CxxFunction> EAGLE3_GROUP = List.of(
+    SET_EMBEDDINGS_LAYER_INP,
+    GET_EMBEDDINGS_LAYER_INP,
+    GET_EMBEDDINGS_NEXTN,
+    MODEL_TARGET_LAYER_IDS,
+    MODEL_TARGET_LAYER_IDS_N
+  );
+
+  /* ---------------------------------- public API ---------------------------------- */
+
+  /**
+   * True if all MTP (nextn) staging symbols resolved against the loaded {@code libllama}. When
+   * false, the loaded llama.cpp build either predates the nextn API or changed its signatures
+   * (which changes the mangled names) — do not attempt MTP against it.
+   */
+  public static boolean available() {
+    return CxxFunctions.allResolve(MTP_GROUP);
+  }
+
+  /** Per-symbol resolution report for the MTP staging group. */
+  public static String resolutionReport() {
+    return CxxFunctions.report(MTP_GROUP);
+  }
+
+  /** True if all EAGLE3 staging symbols resolved against the loaded {@code libllama}. */
+  public static boolean eagle3Available() {
+    return CxxFunctions.allResolve(EAGLE3_GROUP);
+  }
+
+  /** Per-symbol resolution report for the EAGLE3 staging group. */
+  public static String eagle3ResolutionReport() {
+    return CxxFunctions.report(EAGLE3_GROUP);
+  }
+
+  /**
+   * Turn on extraction of a context's pre-final-norm "nextn" hidden state (the MTP seed / the
+   * EAGLE3 encoder output). {@code masked=false} stores rows densely by token position.
+   */
+  public static void setEmbeddingsNextn(
+    LlamaContext ctx,
+    boolean value,
+    boolean masked
+  ) {
+    CxxFunctions.call(SET_EMBEDDINGS_NEXTN, ctx.segment, value, masked);
+  }
+
+  /**
+   * Read the nextn hidden state for output row {@code i} as {@code nEmbd} floats. On a draft
+   * (MTP/EAGLE3) context this is the seed for chaining the next draft token.
+   */
+  public static float[] getEmbeddingsNextnIth(
+    LlamaContext ctx,
+    int i,
+    int nEmbd
+  ) {
+    MemorySegment ptr = (MemorySegment) CxxFunctions.call(
+      GET_EMBEDDINGS_NEXTN_ITH,
+      ctx.segment,
+      i
+    );
+    if (ptr == null || ptr.equals(MemorySegment.NULL)) {
+      throw new LlamaException("no nextn embeddings at row " + i);
+    }
+    return ptr.reinterpret((long) nEmbd * Float.BYTES).toArray(JAVA_FLOAT);
+  }
+
+  /** The context this one was linked to via {@code ctx_other} (target for an MTP/EAGLE3 draft). */
+  public static MemorySegment getCtxOther(LlamaContext ctx) {
+    return (MemorySegment) CxxFunctions.call(GET_CTX_OTHER, ctx.segment);
+  }
+
+  /** Enable/disable capture of a target layer's input hidden state (EAGLE3 feature source). */
+  public static void setEmbeddingsLayerInp(
+    LlamaContext ctx,
+    int layer,
+    boolean value
+  ) {
+    CxxFunctions.call(SET_EMBEDDINGS_LAYER_INP, ctx.segment, layer, value);
+  }
+
+  /**
+   * Raw pointer to the captured input hidden states of {@code layer} for the last decode —
+   * {@code [n_tokens, n_embd]} floats. Caller reinterprets with the right size.
+   */
+  public static MemorySegment getEmbeddingsLayerInp(
+    LlamaContext ctx,
+    int layer
+  ) {
+    MemorySegment ptr = (MemorySegment) CxxFunctions.call(
+      GET_EMBEDDINGS_LAYER_INP,
+      ctx.segment,
+      layer
+    );
+    if (ptr == null || ptr.equals(MemorySegment.NULL)) {
+      throw new LlamaException("layer " + layer + " input not extracted");
+    }
+    return ptr;
+  }
+
+  /**
+   * Raw pointer to the full nextn (pre-norm) embeddings buffer of the last encode/decode —
+   * one {@code n_embd} row per output. EAGLE3 reads the encoder's g_embd rows from here.
+   */
+  public static MemorySegment getEmbeddingsNextnAll(LlamaContext ctx) {
+    MemorySegment ptr = (MemorySegment) CxxFunctions.call(
+      GET_EMBEDDINGS_NEXTN,
+      ctx.segment
+    );
+    if (ptr == null || ptr.equals(MemorySegment.NULL)) {
+      throw new LlamaException("no nextn embeddings buffer");
+    }
+    return ptr;
+  }
+
+  /**
+   * The target-layer indices an EAGLE3/DFlash draft model was trained to consume
+   * (empty for non-draft models).
+   */
+  public static int[] targetLayerIds(LlamaModel model) {
+    int n = (int) CxxFunctions.call(MODEL_TARGET_LAYER_IDS_N, model.segment);
+    if (n <= 0) {
+      return new int[0];
+    }
+    MemorySegment ptr = (MemorySegment) CxxFunctions.call(
+      MODEL_TARGET_LAYER_IDS,
+      model.segment
+    );
+    return ptr.reinterpret((long) n * Integer.BYTES).toArray(JAVA_INT);
+  }
+
+  /* ---------------- jextract-struct helper (not a staging symbol) ---------------- */
+
+  private static final String BASE_PKG =
+    "io.gravitee.llama.cpp." + PlatformResolver.platform().getPackage() + ".";
+
+  // Cached once as a MethodHandle so the JIT can inline the invocation (near-zero overhead in the
+  // hot path); a per-call reflective lookup would otherwise dominate a 1-layer MTP decode.
+  private static final java.lang.invoke.MethodHandle BATCH_EMBD_SETTER =
+    resolveBatchEmbdSetter();
+
+  private static java.lang.invoke.MethodHandle resolveBatchEmbdSetter() {
+    try {
+      Class<?> clazz = Class.forName(BASE_PKG + "llama_batch");
+      return java.lang.invoke.MethodHandles.publicLookup().findStatic(
+        clazz,
+        "embd",
+        java.lang.invoke.MethodType.methodType(
+          void.class,
+          MemorySegment.class,
+          MemorySegment.class
+        )
+      );
+    } catch (ReflectiveOperationException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Set a batch's {@code embd} field pointer without clearing its {@code token} field — producing
+   * the dual token+embd batch MTP/EAGLE3 need (native {@code llama_batch_init} allocates only one
+   * of the two arrays). Uses the jextract-generated {@code llama_batch} struct accessor
+   * (resolved once, cached).
+   */
+  public static void setBatchEmbd(LlamaBatch batch, MemorySegment embd) {
+    if (BATCH_EMBD_SETTER == null) {
+      throw new LlamaException("llama_batch.embd accessor not resolvable");
+    }
+    try {
+      BATCH_EMBD_SETTER.invokeExact(batch.segment, embd);
+    } catch (Throwable t) {
+      throw new LlamaException("failed to set llama_batch.embd", t);
+    }
+  }
+
+  /**
+   * Set a pointer field of a {@code llama_batch} struct by name ({@code token}, {@code pos},
+   * {@code n_seq_id}, {@code seq_id}, {@code logits}, {@code embd}) — used to build the raw
+   * embd-only encoder batches EAGLE3 needs (all other arrays NULL so the native side
+   * auto-fills them).
+   */
+  public static void setBatchPointer(
+    LlamaBatch batch,
+    String field,
+    MemorySegment value
+  ) {
+    LlamaRuntime.invoke(
+      "llama_batch",
+      field,
+      new Class<?>[] { MemorySegment.class, MemorySegment.class },
+      batch.segment,
+      value
+    );
+  }
+
+  /** Set a {@code llama_batch}'s {@code n_tokens} field directly (raw encoder batches). */
+  public static void setBatchNTokens(LlamaBatch batch, int nTokens) {
+    LlamaRuntime.invoke(
+      "llama_batch",
+      "n_tokens",
+      new Class<?>[] { MemorySegment.class, int.class },
+      batch.segment,
+      nTokens
+    );
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
@@ -18,9 +18,9 @@ package io.gravitee.llama.cpp;
 import static io.gravitee.llama.cpp.FinishReason.*;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 
+import io.gravitee.llama.cpp.speculative.SpeculativeDecoding;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Spliterator;
@@ -380,387 +380,32 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
       );
   }
 
-  /* ----- speculative decoding (greedy / lossless) ----- */
+  /* ----- speculative decoding (see SpeculativeDecoding) ----- */
 
   /**
-   * Prefills the state's draft context with the same prompt tokens so its KV cache matches
-   * the target after {@link #processPrompt}. Text-only (speculative + multimodal is
-   * unsupported). No-op when the state has no draft.
+   * Brings the state's draft-side speculation state in line with the freshly-processed prompt
+   * (model-draft KV replay, MTP hidden seed, or EAGLE3 prompt encode). No-op for n-gram and
+   * non-speculative states. Text-only (speculative + multimodal is unsupported).
    */
   protected void prefillDraft(ConversationState state) {
-    if (!state.hasDraft()) {
-      return;
-    }
-    var draft = state.getDraftContext();
-    var tokenized = state.getTokenized();
-    int total = tokenized.size();
-    int nBatch = Math.max(1, draft.nBatch());
-    int seqId = state.getSequenceId();
-    // Start from a clean draft KV for this seqId: with a shared draft context, a reused seqId
-    // would otherwise inherit stale cells from a previous sequence (degrades accept rate; can't
-    // corrupt output since the target still verifies every token).
-    draft.getMemory().seqRm(seqId, -1, -1);
-    int offset = 0;
-    while (offset < total) {
-      int chunk = Math.min(nBatch, total - offset);
-      LlamaBatch batch = new LlamaBatch(state.getArena(), chunk, 0, 1);
-      try {
-        for (int i = 0; i < chunk; i++) {
-          int tok = tokenized.data().getAtIndex(JAVA_INT, offset + i);
-          batch.add(tok, offset + i, java.util.List.of(seqId), false);
-        }
-        if (batch.decode(draft) != 0) {
-          throw new LlamaException("Draft prefill decode failed");
-        }
-      } finally {
-        batch.free();
-      }
-      offset += chunk;
+    if (state.isSpeculative()) {
+      state.getSpeculativeDecoding().prefill(state);
     }
   }
 
   /**
-   * Runs one greedy draft → verify → accept cycle for a speculative state and returns the
-   * accepted tokens as outputs. The draft proposes {@code nDraft} tokens; the target verifies
-   * them in a single decode; the longest matching prefix (plus one correction/bonus token the
-   * target picks) is committed and both KV caches are rolled back to the accepted boundary.
-   * Output is identical to greedy decoding on the target.
-   *
-   * <p>Requires {@code state.getNewTokenId()} to be set (the last token, not yet in either KV).
-   * Updates the state's {@code nPast} and {@code newTokenId}; sets the finish reason on EOG or
-   * token-limit.
+   * Runs one speculative draft → verify → accept round for the state's flavour (model draft,
+   * n-gram, MTP, or EAGLE3) and returns the committed tokens as outputs — see
+   * {@link SpeculativeDecoding}. Requires {@code state.getNewTokenId()} to be set (the last
+   * token, not yet in any KV); updates the state's {@code nPast} and {@code newTokenId}, and
+   * sets the finish reason on EOG or token-limit.
    */
   protected List<LlamaOutput> speculativeRound(ConversationState state) {
-    if (state.isNgram()) {
-      return speculativeNgramRound(state);
-    }
-    return state.getSpeculation().isGreedy()
-      ? speculativeGreedyRound(state)
-      : speculativeStochasticRound(state);
-  }
-
-  /**
-   * One n-gram (prompt-lookup) speculative round: propose tokens from the committed history, verify
-   * them in a single target decode, accept the longest matching prefix (greedy) or via rejection
-   * sampling against a point-mass draft (stochastic), then roll back ONLY the target cache — there
-   * is no draft model and no draft KV. Output is identical to plain greedy / an exact target sample.
-   */
-  private List<LlamaOutput> speculativeNgramRound(ConversationState state) {
-    LlamaContext target = state.getContext();
-    Speculation spec = state.getSpeculation();
-    int seqId = state.getSequenceId();
-    int kMax = state.getNDraft();
-    int nPast = state.getNPast();
-    int idLast = state.getNewTokenId();
-    int nVocab = target.nVocab();
-    boolean greedy = spec.isGreedy();
-    var seq = java.util.List.of(seqId);
-
-    int[] drafted = state.proposeNgram(kMax);
-    int m = drafted.length;
-
-    LlamaSampler chain = spec.chain();
-    LlamaBatch verifyBatch = spec.verifyBatch();
-    List<LlamaOutput> out = new ArrayList<>();
-    try {
-      verifyBatch.clear();
-      verifyBatch.add(idLast, nPast, seq, true);
-      for (int i = 0; i < m; i++) {
-        verifyBatch.add(drafted[i], nPast + 1 + i, seq, true);
-      }
-      if (verifyBatch.decode(target) != 0) {
-        throw new LlamaException("Speculative verify decode failed");
-      }
-
-      int matched = 0;
-      int extra = -1;
-      if (greedy) {
-        int correction = -1;
-        for (int i = 0; i < m; i++) {
-          int t = chain.sample(target, i);
-          if (t == drafted[i]) {
-            matched++;
-          } else {
-            correction = t;
-            break;
-          }
-        }
-        extra = matched == m ? chain.sample(target, m) : correction;
-      } else {
-        for (int i = 0; i < m; i++) {
-          // n-gram proposes a single certain token per position → a point-mass draft (q = 1).
-          if (
-            spec.acceptTarget(
-              chain,
-              logitsRow(target, i, nVocab),
-              drafted[i],
-              1.0f
-            )
-          ) {
-            matched++;
-          } else {
-            extra = spec.residualTargetPointMass(drafted[i]);
-            break;
-          }
-        }
-        if (matched == m) {
-          extra = spec.targetSelect(chain, logitsRow(target, m, nVocab));
-        }
-      }
-
-      // Roll back ONLY the target cache (no draft cache exists).
-      int newNPast = nPast + matched + 1;
-      target.getMemory().seqRm(seqId, newNPast, -1);
-
-      boolean cont = true;
-      for (int i = 0; i < matched && cont; i++) {
-        cont = emitSpeculative(state, drafted[i], out);
-      }
-      if (cont) {
-        emitSpeculative(state, extra, out);
-      }
-
-      // Append the committed tokens (matched drafts + the extra) to history so the next round can
-      // look them up; keeps histLen == newNPast + 1 regardless of EOG/quota early stop.
-      for (int i = 0; i < matched; i++) {
-        state.appendHistory(drafted[i]);
-      }
-      state.appendHistory(extra);
-
-      state.setNPast(newNPast);
-      state.setNewTokenId(extra);
-      state.recordSpeculation(m, matched);
-      return out;
-    } catch (RuntimeException e) {
-      spec.free(); // release persistent native scratch on failure (idempotent)
-      throw e;
-    }
-  }
-
-  private List<LlamaOutput> speculativeGreedyRound(ConversationState state) {
-    LlamaContext target = state.getContext();
-    LlamaContext draft = state.getDraftContext();
-    Speculation spec = state.getSpeculation();
-    int seqId = state.getSequenceId();
-    int draftMax = state.getNDraft();
-    int nPast = state.getNPast();
-    int idLast = state.getNewTokenId();
-    int nVocab = target.nVocab();
-    boolean adaptive = spec.isAdaptive();
-    int draftMin = spec.draftMin();
-    float pMin = spec.pMin();
-    var seq = java.util.List.of(seqId);
-
-    // Persistent per-state scratch, reused across rounds and freed by spec.free() on teardown.
-    LlamaSampler greedy = spec.chain(); // greedy config => greedy sampler
-    LlamaBatch draftBatch = spec.draftBatch();
-    LlamaBatch verifyBatch = spec.verifyBatch();
-    List<LlamaOutput> out = new ArrayList<>();
-    float[] probOut = new float[1];
-    try {
-      // Draft up to draftMax tokens (positions nPast..nPast+m-1), stopping early once the draft's
-      // top-token probability drops below pMin (adaptive only) — those tokens would likely be
-      // rejected anyway, so drafting them wastes draft and target compute. The drafted token is
-      // always the argmax, so output stays identical to plain greedy.
-      int[] drafted = new int[draftMax];
-      int m = 0;
-      int prev = idLast;
-      for (int i = 0; i < draftMax; i++) {
-        draftBatch.clear();
-        draftBatch.add(prev, nPast + i, seq, true);
-        if (draftBatch.decode(draft) != 0) {
-          throw new LlamaException("Speculative draft decode failed");
-        }
-        int sampled = adaptive
-          ? spec.draftGreedyConfident(
-            logitsRow(draft, -1, nVocab),
-            nVocab,
-            probOut
-          )
-          : greedy.sample(draft);
-        drafted[m++] = sampled;
-        prev = sampled;
-        if (adaptive && m >= draftMin && probOut[0] < pMin) {
-          break;
-        }
-      }
-
-      // Verify all drafts in one target decode.
-      verifyBatch.clear();
-      verifyBatch.add(idLast, nPast, seq, true);
-      for (int i = 0; i < m; i++) {
-        verifyBatch.add(drafted[i], nPast + 1 + i, seq, true);
-      }
-      if (verifyBatch.decode(target) != 0) {
-        throw new LlamaException("Speculative verify decode failed");
-      }
-
-      // Accept the longest matching prefix; batch index i predicts slot drafted[i].
-      int matched = 0;
-      int correction = -1;
-      for (int i = 0; i < m; i++) {
-        int t = greedy.sample(target, i);
-        if (t == drafted[i]) {
-          matched++;
-        } else {
-          correction = t;
-          break;
-        }
-      }
-      int extra = matched == m ? greedy.sample(target, m) : correction;
-
-      // Roll back both caches to the accepted boundary.
-      int newNPast = nPast + matched + 1;
-      target.getMemory().seqRm(seqId, newNPast, -1);
-      draft.getMemory().seqRm(seqId, newNPast, -1);
-
-      // Fill decode, only on full accept: advance the draft KV by one so it covers position nPast+m
-      // for next round (no gap). On partial accept the seqRm above already trimmed the draft past
-      // nPast+matched, so a fill would be discarded — skipping it saves a draft forward pass. The
-      // sampled token is discarded.
-      if (matched == m) {
-        draftBatch.clear();
-        draftBatch.add(prev, nPast + m, seq, true);
-        if (draftBatch.decode(draft) != 0) {
-          throw new LlamaException("Speculative draft decode failed");
-        }
-      }
-
-      boolean cont = true;
-      for (int i = 0; i < matched && cont; i++) {
-        cont = emitSpeculative(state, drafted[i], out);
-      }
-      if (cont) {
-        emitSpeculative(state, extra, out);
-      }
-
-      state.setNPast(newNPast);
-      state.setNewTokenId(extra);
-      state.recordSpeculation(m, matched);
-      return out;
-    } catch (RuntimeException e) {
-      spec.free(); // release persistent native scratch on failure (idempotent)
-      throw e;
-    }
-  }
-
-  /**
-   * Rejection-sampling speculative round (temp/top-k/top-p). The native sampler chain produces
-   * the per-position distributions ({@link Speculation}); accept each drafted token with
-   * probability {@code min(1, p/q)}, else take a draw from the normalized residual.
-   */
-  private List<LlamaOutput> speculativeStochasticRound(
-    ConversationState state
-  ) {
-    LlamaContext target = state.getContext();
-    LlamaContext draft = state.getDraftContext();
-    Speculation spec = state.getSpeculation();
-    int seqId = state.getSequenceId();
-    int k = state.getNDraft();
-    int nPast = state.getNPast();
-    int idLast = state.getNewTokenId();
-    int nVocab = target.nVocab();
-    var seq = java.util.List.of(seqId);
-
-    boolean adaptive = spec.isAdaptive();
-    int draftMin = spec.draftMin();
-    float pMin = spec.pMin();
-
-    // Persistent per-state scratch, reused across rounds and freed by spec.free() on teardown.
-    LlamaSampler chain = spec.chain();
-    LlamaBatch draftBatch = spec.draftBatch();
-    LlamaBatch verifyBatch = spec.verifyBatch();
-    List<LlamaOutput> out = new ArrayList<>();
-    try {
-      // Draft up to k tokens, stopping early once the draft distribution's top probability drops
-      // below pMin (adaptive only). The drafted tokens and their snapshots are unchanged regardless
-      // of m, so the rejection-sampling decision per accepted token stays exact.
-      int[] drafted = new int[k];
-      Speculation.Snapshot[] draftSnaps = new Speculation.Snapshot[k];
-      int m = 0;
-      int prev = idLast;
-      for (int i = 0; i < k; i++) {
-        draftBatch.clear();
-        draftBatch.add(prev, nPast + i, seq, true);
-        if (draftBatch.decode(draft) != 0) {
-          throw new LlamaException("Speculative draft decode failed");
-        }
-        Speculation.Snapshot s = spec.draft(
-          chain,
-          logitsRow(draft, -1, nVocab)
-        );
-        drafted[m] = s.selectedId();
-        draftSnaps[m] = s;
-        m++;
-        prev = drafted[m - 1];
-        if (adaptive && m >= draftMin && s.maxProb() < pMin) {
-          break;
-        }
-      }
-
-      verifyBatch.clear();
-      verifyBatch.add(idLast, nPast, seq, true);
-      for (int i = 0; i < m; i++) {
-        verifyBatch.add(drafted[i], nPast + 1 + i, seq, true);
-      }
-      if (verifyBatch.decode(target) != 0) {
-        throw new LlamaException("Speculative verify decode failed");
-      }
-
-      int matched = 0;
-      int extra = -1;
-      for (int i = 0; i < m; i++) {
-        if (
-          spec.acceptTarget(
-            chain,
-            logitsRow(target, i, nVocab),
-            drafted[i],
-            draftSnaps[i].selectedProbability()
-          )
-        ) {
-          matched++;
-        } else {
-          extra = spec.residualTargetScatter(draftSnaps[i]);
-          break;
-        }
-      }
-      if (matched == m) {
-        extra = spec.targetSelect(chain, logitsRow(target, m, nVocab));
-      }
-
-      int newNPast = nPast + matched + 1;
-      target.getMemory().seqRm(seqId, newNPast, -1);
-      draft.getMemory().seqRm(seqId, newNPast, -1);
-
-      // Fill decode only on full accept (see greedy round). Token discarded.
-      if (matched == m) {
-        draftBatch.clear();
-        draftBatch.add(prev, nPast + m, seq, true);
-        if (draftBatch.decode(draft) != 0) {
-          throw new LlamaException("Speculative draft decode failed");
-        }
-      }
-
-      boolean cont = true;
-      for (int i = 0; i < matched && cont; i++) {
-        cont = emitSpeculative(state, drafted[i], out);
-      }
-      if (cont) {
-        emitSpeculative(state, extra, out);
-      }
-
-      state.setNPast(newNPast);
-      state.setNewTokenId(extra);
-      state.recordSpeculation(m, matched);
-      return out;
-    } catch (RuntimeException e) {
-      spec.free(); // release persistent native scratch on failure (idempotent)
-      throw e;
-    }
+    return state.getSpeculativeDecoding().round(this, state);
   }
 
   /** Logit row for batch output {@code idx}, reinterpreted as {@code nVocab} floats. */
-  protected MemorySegment logitsRow(LlamaContext ctx, int idx, int nVocab) {
+  public MemorySegment logitsRow(LlamaContext ctx, int idx, int nVocab) {
     MemorySegment ptr = LlamaRuntime.llama_get_logits_ith(ctx.segment, idx);
     if (ptr == null || ptr.address() == 0) {
       throw new LlamaException("llama_get_logits_ith returned NULL");
@@ -772,7 +417,7 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
    * Emits one accepted speculative token (reusing the shared detokenize / token-tracking /
    * stop logic). Returns {@code false} and marks the state finished on EOG or token-limit.
    */
-  protected boolean emitSpeculative(
+  public boolean emitSpeculative(
     ConversationState state,
     int token,
     List<LlamaOutput> out
@@ -806,7 +451,7 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
    */
   protected void onFinished() {
     if (currentState.isSpeculative()) {
-      currentState.getSpeculation().free();
+      currentState.freeSpeculativeScratch();
     }
     if (currentState.getFinishReason() != null) {
       currentState

--- a/src/main/java/io/gravitee/llama/cpp/LlamaRuntime.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaRuntime.java
@@ -942,6 +942,18 @@ public final class LlamaRuntime {
   }
 
   /**
+   * Returns the number of MTP "nextn" prediction layers the model carries
+   * ({@code 0} for models without a multi-token-prediction head).
+   */
+  public static int llama_model_n_layer_nextn(MemorySegment model) {
+    return llama_h(
+      "llama_model_n_layer_nextn",
+      new Class<?>[] { MEM_SEG_CLASS },
+      model
+    );
+  }
+
+  /**
    * Returns the number of classifier output classes for classifier / reranker models.
    * When {@link PoolingType#RANK} is active and this returns {@code 1}, the model is
    * a reranker (single relevance score). When it returns {@code > 1}, the model exposes
@@ -2320,6 +2332,15 @@ public final class LlamaRuntime {
     );
   }
 
+  public static int llama_encode(MemorySegment context, MemorySegment batch) {
+    return llama_h(
+      "llama_encode",
+      new Class[] { MEM_SEG_CLASS, MEM_SEG_CLASS },
+      context,
+      batch
+    );
+  }
+
   /* Free Memory */
   public static void llama_batch_free(LlamaBatch batch) {
     llama_h("llama_batch_free", new Class[] { MEM_SEG_CLASS }, batch.segment);
@@ -2641,7 +2662,7 @@ public final class LlamaRuntime {
   }
 
   public static int mtmd_context_params_n_threads(MemorySegment segment) {
-    return (int) mtmd_context_params(
+    return mtmd_context_params(
       "n_threads",
       new Class<?>[] { MEM_SEG_CLASS },
       segment
@@ -2663,7 +2684,7 @@ public final class LlamaRuntime {
   public static MemorySegment mtmd_context_params_media_marker(
     MemorySegment segment
   ) {
-    return (MemorySegment) mtmd_context_params(
+    return mtmd_context_params(
       "media_marker",
       new Class<?>[] { MEM_SEG_CLASS },
       segment
@@ -2727,7 +2748,7 @@ public final class LlamaRuntime {
   public static int mtmd_context_params_image_max_tokens(
     MemorySegment segment
   ) {
-    return (int) mtmd_context_params(
+    return mtmd_context_params(
       "image_max_tokens",
       new Class<?>[] { MEM_SEG_CLASS },
       segment
@@ -2805,7 +2826,6 @@ public final class LlamaRuntime {
    * @param targetMethodName The name of the method on the targetObject to be invoked by the native callback.
    * @param arena            The Arena to allocate the MemorySegment in.
    * @return A MemorySegment representing the native function pointer for the callback.
-   * @throws Exception if any reflective operation fails.
    */
   public static MemorySegment instantiateCallbackSegment(
     String callbackInterfaceName,
@@ -2813,7 +2833,7 @@ public final class LlamaRuntime {
     Object targetObject,
     String targetMethodName,
     Arena arena
-  ) throws Exception {
+  ) {
     String fullInterfaceName = basePackage + callbackInterfaceName;
 
     // --- 1. Load the interface class ---

--- a/src/main/java/io/gravitee/llama/cpp/Main.java
+++ b/src/main/java/io/gravitee/llama/cpp/Main.java
@@ -275,6 +275,13 @@ public class Main {
       System.exit(1);
     }
 
+    // MTP self-speculation: rejecting draft tokens rewinds the target, and hybrid
+    // attention+SSM models can only rewind recurrent state from rollback snapshots —
+    // allocate them on the target context (harmless for pure-attention models).
+    if (speculativeConfig != null && params.containsKey("mtp")) {
+      contextParams.nRsSeq(speculativeConfig.nDraft() + 1);
+    }
+
     LlamaContext context = new LlamaContext(ARENA, model, contextParams);
 
     // Optional draft model + context for model drafting. setDraft() enforces a shared vocab size.
@@ -288,6 +295,46 @@ public class Main {
         modelParameters
       );
       draftContext = new LlamaContext(ARENA, draftModel, contextParams);
+    }
+
+    // Optional MTP self-speculation: a second context over the TARGET model driving its nextn
+    // head (no separate draft model). Requires a model with a multi-token-prediction head.
+    LlamaContext mtpContext = null;
+    if (speculativeConfig != null && params.containsKey("mtp")) {
+      if (LlamaRuntime.llama_model_n_layer_nextn(model.segment) <= 0) {
+        System.err.println(
+          "Error: --mtp requires a model with an MTP head (n_layer_nextn > 0)."
+        );
+        System.exit(1);
+      }
+      var mtpParams = new LlamaContextParams(ARENA)
+        .nCtx(context.nCtx())
+        .nBatch(context.nBatch())
+        .poolingType(PoolingType.NONE)
+        .nRsSeq(speculativeConfig.nDraft() + 1)
+        // Sized for the fused BatchIterator path: one KV stream + one output row per
+        // concurrent sequence (a single-sequence run just uses fewer).
+        .nSeqMax(context.nSeqMax())
+        .nOutputsMax(Math.max(1, context.nSeqMax()))
+        .ctxOther(context)
+        .ctxTypeMtp()
+        .noPerf(true);
+      mtpContext = new LlamaContext(ARENA, model, mtpParams);
+    }
+
+    // Optional EAGLE3 head model + context (separate tiny trained speculator).
+    LlamaModel eagle3Model = null;
+    LlamaContext eagle3Context = null;
+    String eagle3Gguf = params.get("eagle3");
+    if (
+      speculativeConfig != null && eagle3Gguf != null && !eagle3Gguf.isBlank()
+    ) {
+      eagle3Model = new LlamaModel(
+        ARENA,
+        Path.of(eagle3Gguf).toAbsolutePath(),
+        modelParameters
+      );
+      eagle3Context = new LlamaContext(ARENA, eagle3Model, contextParams);
     }
 
     LlamaSampler sampler = llamaSampler(strategy, context, vocab, params);
@@ -355,11 +402,15 @@ public class Main {
         .setMaxTokens(quota)
         .setMedia(initialMedia); // Set initial media (images and/or audio)
 
-      // Enable speculation for this turn: model drafting if a draft context exists, else n-gram.
-      // DefaultLlamaIterator dispatches to the speculative path when state.isSpeculative().
+      // Enable speculation for this turn: model drafting, MTP self-speculation, EAGLE3 head
+      // drafting, or n-gram. DefaultLlamaIterator dispatches when state.isSpeculative().
       if (speculativeConfig != null) {
         if (draftContext != null) {
           state.setDraft(draftContext, speculativeConfig);
+        } else if (mtpContext != null) {
+          state.setMtp(mtpContext, speculativeConfig);
+        } else if (eagle3Context != null) {
+          state.setEagle3(eagle3Context, eagle3Model, speculativeConfig);
         } else {
           state.setNgram(speculativeConfig);
         }
@@ -463,6 +514,14 @@ public class Main {
       System.out.println();
     }
 
+    // Free contexts before their models; the MTP context borrows the target's tensors
+    // (ctx_other), so it must go before the target context.
+    if (mtpContext != null) {
+      mtpContext.free();
+    }
+    if (eagle3Context != null) {
+      eagle3Context.free();
+    }
     context.free();
     sampler.free();
     if (draftContext != null) {
@@ -471,6 +530,9 @@ public class Main {
     model.free();
     if (draftModel != null) {
       draftModel.free();
+    }
+    if (eagle3Model != null) {
+      eagle3Model.free();
     }
     if (mtmdContext != null) {
       mtmdContext.free();
@@ -560,6 +622,9 @@ public class Main {
     String draftPath = params.get("draft");
     boolean modelDraft = draftPath != null && !draftPath.isBlank();
     boolean ngramDraft = params.containsKey("ngram");
+    boolean mtpDraft = params.containsKey("mtp");
+    String eagle3Path = params.get("eagle3");
+    boolean eagle3Draft = eagle3Path != null && !eagle3Path.isBlank();
 
     if (params.containsKey("draft") && !modelDraft) {
       System.err.println(
@@ -567,12 +632,24 @@ public class Main {
       );
       System.exit(1);
     }
-    if (!modelDraft && !ngramDraft) {
+    if (params.containsKey("eagle3") && !eagle3Draft) {
+      System.err.println(
+        "Error: --eagle3 requires a path to an EAGLE3 head GGUF model."
+      );
+      System.exit(1);
+    }
+    if (!modelDraft && !ngramDraft && !mtpDraft && !eagle3Draft) {
       return null;
     }
-    if (modelDraft && ngramDraft) {
+    int flavours =
+      (modelDraft ? 1 : 0) +
+      (ngramDraft ? 1 : 0) +
+      (mtpDraft ? 1 : 0) +
+      (eagle3Draft ? 1 : 0);
+    if (flavours > 1) {
       System.err.println(
-        "Error: use either --draft (model drafting) or --ngram (prompt-lookup), not both."
+        "Error: use exactly one of --draft (model drafting), --ngram (prompt-lookup), " +
+          "--mtp (nextn self-speculation) or --eagle3 (EAGLE3 head)."
       );
       System.exit(1);
     }
@@ -615,7 +692,7 @@ public class Main {
     if (ngramDraft) {
       if (adaptive) {
         System.err.println(
-          "Error: --p_min/--draft_min (adaptive early-stop) apply only to --draft model drafting, not --ngram."
+          "Error: --p_min/--draft_min (adaptive early-stop) do not apply to --ngram (no draft confidence to gate on)."
         );
         System.exit(1);
       }
@@ -837,17 +914,24 @@ public class Main {
       Performance:
         --perf <true|false>         Show performance metrics (default: false)
 
-      Speculative decoding (optional; draft-->verify-->accept speedup):
+      Speculative decoding (optional; draft-->verify-->accept speedup; pick exactly one flavour):
         --draft <path>              Draft model GGUF for model drafting (must share the target's
-                                    vocab). Mutually exclusive with --ngram.
+                                    vocab).
         --ngram <window>            Enable n-gram prompt-lookup drafting with this window, no draft
                                     model (default window: 2).
+        --mtp                       MTP (nextn) self-speculation: the target model's own multi-token-
+                                    prediction head drafts, no separate model. Requires a model with
+                                    n_layer_nextn > 0 and the staging nextn API in the bundled
+                                    llama.cpp.
+        --eagle3 <path>             EAGLE3 head model GGUF (arch eagle3, trained for this target)
+                                    drafting from the target's intermediate hidden states. Dense
+                                    targets; prompt must fit one batch.
         --n_draft <int>             Max tokens drafted/proposed per round (default: 4).
                                     Lossless greedy under --strategy DETERMINISTIC; otherwise an exact
                                     sampler using temperature/top-k/top-p only (penalties/min-p/grammar/
                                     mirostat do not apply). Incompatible with CONSTRAINED/ADAPTIVE and --mmproj.
         --p_min <float>             Adaptive early-stop: stop drafting once the draft's top-token
-                                    probability drops below this (model drafting only; 0 = disabled).
+                                    probability drops below this (not --ngram; 0 = disabled).
                                     Distinct from --min_p (which is min-p sampling).
         --draft_min <int>           Min tokens to draft before --p_min applies (default: 1; clamped to
                                     [1, n_draft]).
@@ -898,6 +982,8 @@ public class Main {
         java -jar llamaj.cpp.jar --model ./model.gguf --strategy DETERMINISTIC --ngram 2 --n_draft 4
         java -jar llamaj.cpp.jar --model ./model.gguf --strategy DETERMINISTIC --draft ./draft.gguf --n_draft 6
         java -jar llamaj.cpp.jar --model ./model.gguf --strategy DETERMINISTIC --draft ./draft.gguf --n_draft 8 --p_min 0.6
+        java -jar llamaj.cpp.jar --model ./mtp-model.gguf --strategy DETERMINISTIC --mtp --n_draft 2
+        java -jar llamaj.cpp.jar --model ./model.gguf --strategy DETERMINISTIC --eagle3 ./eagle3-head.gguf --n_draft 2
       """
     );
   }

--- a/src/main/java/io/gravitee/llama/cpp/cxx/CxxFunction.java
+++ b/src/main/java/io/gravitee/llama/cpp/cxx/CxxFunction.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.cxx;
+
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
+import java.util.List;
+
+/**
+ * A C++-exported free function as data: C name, return layout ({@code null} = void), and
+ * {@link CxxParam} parameter kinds. Everything a binding needs is derived from the
+ * signature: the Itanium-mangled symbol name ({@code _Z<len><name><params>} — return types are
+ * not encoded for free functions) and the FFM {@link FunctionDescriptor}.
+ *
+ * <p>Declared as static constants and resolved/invoked through
+ * {@link CxxFunctions} — adding a binding is one declaration line.
+ *
+ * @param name   The unmangled C++ function name
+ * @param ret    Return layout, or {@code null} for {@code void}
+ * @param params Parameter kinds, in order
+ * @author GraviteeSource Team
+ */
+public record CxxFunction(
+  String name,
+  MemoryLayout ret,
+  List<CxxParam> params
+) {
+  public static CxxFunction of(
+    String name,
+    MemoryLayout ret,
+    CxxParam... params
+  ) {
+    return new CxxFunction(name, ret, List.of(params));
+  }
+
+  /** The Itanium-mangled symbol name derived from the signature. */
+  public String symbol() {
+    StringBuilder sb = new StringBuilder("_Z")
+      .append(name.length())
+      .append(name);
+    for (CxxParam p : params) {
+      sb.append(p.mangle());
+    }
+    return sb.toString();
+  }
+
+  /** The FFM downcall descriptor derived from the signature. */
+  public FunctionDescriptor descriptor() {
+    MemoryLayout[] args = params
+      .stream()
+      .map(CxxParam::layout)
+      .toArray(MemoryLayout[]::new);
+    return ret == null
+      ? FunctionDescriptor.ofVoid(args)
+      : FunctionDescriptor.of(ret, args);
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/cxx/CxxFunctions.java
+++ b/src/main/java/io/gravitee/llama/cpp/cxx/CxxFunctions.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.cxx;
+
+import io.gravitee.llama.cpp.LlamaException;
+import java.lang.foreign.Linker;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Resolution + invocation engine for {@link CxxFunction} declarations: looks each symbol up
+ * by its derived mangled name via {@link SymbolLookup#loaderLookup()} (the native libraries must
+ * already be {@code System.load}-ed), builds the downcall handle once, and dispatches calls.
+ *
+ * <p>A symbol that fails to resolve is remembered as absent — {@link #call} then throws a
+ * {@link LlamaException} naming the function and its expected mangling (fail-fast, never a
+ * silent wrong-ABI call), and {@link #report} marks it {@code MISSING} so a broken llama.cpp
+ * version bump is diagnosable with a single {@code nm} diff.
+ *
+ * @author GraviteeSource Team
+ */
+public final class CxxFunctions {
+
+  private CxxFunctions() {}
+
+  private static final Linker LINKER = Linker.nativeLinker();
+  private static final SymbolLookup LOOKUP = SymbolLookup.loaderLookup();
+
+  // Lazily-resolved handle cache; Optional.empty() = looked up, absent in the loaded libs.
+  private static final Map<CxxFunction, Optional<MethodHandle>> CACHE =
+    new ConcurrentHashMap<>();
+
+  private static Optional<MethodHandle> handle(CxxFunction fn) {
+    return CACHE.computeIfAbsent(fn, f ->
+      LOOKUP.find(f.symbol()).map(seg ->
+        LINKER.downcallHandle(seg, f.descriptor())
+      )
+    );
+  }
+
+  /** Whether this function's mangled symbol resolves against the loaded native libraries. */
+  public static boolean resolves(CxxFunction fn) {
+    return handle(fn).isPresent();
+  }
+
+  /** Whether every function in the group resolves. */
+  public static boolean allResolve(List<CxxFunction> group) {
+    for (CxxFunction fn : group) {
+      if (!resolves(fn)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Per-symbol resolution report for a group (MISSING entries include the expected mangling). */
+  public static String report(List<CxxFunction> group) {
+    StringBuilder sb = new StringBuilder();
+    for (CxxFunction fn : group) {
+      if (!sb.isEmpty()) {
+        sb.append('\n');
+      }
+      sb
+        .append(String.format("%-32s: ", fn.name()))
+        .append(resolves(fn) ? "RESOLVED" : "MISSING (" + fn.symbol() + ")");
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Invokes the function with the given arguments (boxed; negligible next to a native decode).
+   * Throws {@link LlamaException} if the symbol is absent or the call fails.
+   */
+  public static Object call(CxxFunction fn, Object... args) {
+    MethodHandle h = handle(fn).orElseThrow(() ->
+      new LlamaException(
+        "staging symbol not present in the loaded native libraries: " +
+          fn.name() +
+          " (" +
+          fn.symbol() +
+          ")"
+      )
+    );
+    try {
+      return h.invokeWithArguments(args);
+    } catch (LlamaException e) {
+      throw e;
+    } catch (Throwable t) {
+      throw new LlamaException(fn.name() + " failed", t);
+    }
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/cxx/CxxParam.java
+++ b/src/main/java/io/gravitee/llama/cpp/cxx/CxxParam.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.cxx;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+
+import java.lang.foreign.MemoryLayout;
+
+/**
+ * C++ parameter kinds under the Itanium ABI, pairing the name-mangling token with the FFM
+ * layout a downcall uses for it. Covers the types appearing in llama.cpp's staging API; extend
+ * with further kinds (tokens per the Itanium C++ ABI mangling grammar) as upstream adds
+ * signatures.
+ *
+ * <p>Pointer-to-struct kinds encode {@code P<len><name>} ({@code PK...} when const-qualified);
+ * builtin kinds are single letters ({@code b} bool, {@code i} int, {@code j} unsigned int, ...).
+ *
+ * @author GraviteeSource Team
+ */
+public enum CxxParam {
+  /** {@code llama_context*} */
+  CTX("P13llama_context", ADDRESS),
+  /** {@code const llama_model*} */
+  CONST_MODEL("PK11llama_model", ADDRESS),
+  /** {@code bool} */
+  BOOL("b", JAVA_BOOLEAN),
+  /** {@code int32_t} */
+  INT32("i", JAVA_INT),
+  /** {@code uint32_t} */
+  UINT32("j", JAVA_INT);
+
+  private final String mangle;
+  private final MemoryLayout layout;
+
+  CxxParam(String mangle, MemoryLayout layout) {
+    this.mangle = mangle;
+    this.layout = layout;
+  }
+
+  /** The Itanium mangling token for this parameter kind. */
+  public String mangle() {
+    return mangle;
+  }
+
+  /** The FFM layout a downcall passes this parameter as. */
+  public MemoryLayout layout() {
+    return layout;
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/draft/Eagle3Draft.java
+++ b/src/main/java/io/gravitee/llama/cpp/draft/Eagle3Draft.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.draft;
+
+import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
+
+import io.gravitee.llama.cpp.LlamaBatch;
+import io.gravitee.llama.cpp.LlamaContext;
+import io.gravitee.llama.cpp.LlamaException;
+import io.gravitee.llama.cpp.LlamaExt;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.List;
+
+/**
+ * EAGLE3 draft source — a separate tiny trained head model (GGUF arch {@code eagle3}) proposes
+ * draft tokens from the <i>target's</i> intermediate hidden states. Works with dense targets
+ * that carry no nextn head.
+ *
+ * <p>Counterpart of {@link NgramIndex}/{@link MtpDraft} for the EAGLE3 flavour. Owns the protocol
+ * mechanics (ported from llama.cpp {@code common/speculative.cpp} draft-eagle3, single-sequence
+ * form): per-token capture of the 3 declared target layers' input hiddens → interleaved feature
+ * rows → {@code llama_encode} on the head (encoder) → {@code g_embd} rows → decoder consumes
+ * shifted pairs {@code (token[P+1], g[P])} at pos P via dual token+embd batches; drafts beyond
+ * the first chain on the decoder's own pre-norm hidden. Accept/reject stays in
+ * {@code Speculation}; orchestration in the iterator's EAGLE3 round.
+ *
+ * <p>The head context is created and owned by the caller (like a model-draft context). Layer
+ * capture on the target and nextn capture on the head are enabled by
+ * {@link io.gravitee.llama.cpp.ConversationState#setEagle3}. Deviation from the C impl: each round wipes the head's KV
+ * from the boundary and re-syncs only the accepted pairs — one extra tiny decode per round for a
+ * no-duplicate-cells invariant. Dense targets only.
+ *
+ * @author GraviteeSource Team
+ */
+public final class Eagle3Draft implements HiddenStateDraft {
+
+  private final Arena arena;
+  private final LlamaContext dft;
+  private final int[] layerIds;
+  private final int nEmbdTgt;
+  private final int nEmbdDec;
+  private final int nEmbdEnc;
+  private final int maxRows; // nDraft + 1: verify-round row count, also the sync-batch capacity
+
+  // Persistent native scratch (lazily built, reused across rounds, freed once by free()).
+  private MemorySegment features; // [maxRows, nEmbdEnc] interleaved target features
+  private MemorySegment embdRows; // [maxRows, nEmbdDec] decoder embd rows
+  private LlamaBatch dualBatch; // up-to-maxRows dual token+embd decoder batch
+  private LlamaBatch encShell; // raw embd-only encoder batch (all arrays NULLed)
+
+  // Pending boundary g row: g at position nPast-1, paired with idLast at draft time.
+  private float[] boundary;
+
+  public Eagle3Draft(
+    Arena arena,
+    LlamaContext eagle3Context,
+    int[] layerIds,
+    int nEmbdTgt,
+    int nEmbdDec,
+    int nDraft
+  ) {
+    this.arena = arena;
+    this.dft = eagle3Context;
+    this.layerIds = layerIds;
+    this.nEmbdTgt = nEmbdTgt;
+    this.nEmbdDec = nEmbdDec;
+    this.nEmbdEnc = layerIds.length * nEmbdTgt;
+    this.maxRows = nDraft + 1;
+  }
+
+  @Override
+  public LlamaContext context() {
+    return dft;
+  }
+
+  public boolean hasBoundary() {
+    return boundary != null;
+  }
+
+  public float[] boundary() {
+    return boundary;
+  }
+
+  public void setBoundary(float[] g) {
+    this.boundary = g;
+  }
+
+  /**
+   * Encoder pass over the target's captured layer inputs for its last decode ({@code nRows}
+   * tokens): interleave the layers into {@code [nRows, 3*nEmbdTgt]} features, run
+   * {@code llama_encode} on the head (chunked by its n_ubatch), and return the g_embd rows.
+   */
+  public float[][] encodeCaptured(LlamaContext target, int nRows) {
+    return encodeCaptured(target, 0, nRows);
+  }
+
+  /**
+   * As {@link #encodeCaptured(LlamaContext, int)} but reading the capture buffer starting at
+   * {@code rowOffset} — a fused multi-sequence verify decode captures all sequences' rows in one
+   * buffer, and each sequence encodes only its own slice (its verify-batch base offset).
+   */
+  public float[][] encodeCaptured(
+    LlamaContext target,
+    int rowOffset,
+    int nRows
+  ) {
+    MemorySegment feat = nRows <= maxRows
+      ? featuresBuf()
+      : arena.allocate((long) nRows * nEmbdEnc * Float.BYTES); // prompt prefill: one-shot
+    for (int k = 0; k < layerIds.length; k++) {
+      MemorySegment layer = LlamaExt.getEmbeddingsLayerInp(
+        target,
+        layerIds[k]
+      ).reinterpret((long) (rowOffset + nRows) * nEmbdTgt * Float.BYTES);
+      for (int i = 0; i < nRows; i++) {
+        MemorySegment.copy(
+          layer,
+          (long) (rowOffset + i) * nEmbdTgt * Float.BYTES,
+          feat,
+          ((long) i * nEmbdEnc + (long) k * nEmbdTgt) * Float.BYTES,
+          (long) nEmbdTgt * Float.BYTES
+        );
+      }
+    }
+
+    float[][] g = new float[nRows][];
+    int nUb = dft.nUbatch();
+    for (int off = 0; off < nRows; off += nUb) {
+      int n = Math.min(nUb, nRows - off);
+      LlamaBatch shell = encShell();
+      LlamaExt.setBatchNTokens(shell, n);
+      LlamaExt.setBatchEmbd(
+        shell,
+        feat.asSlice((long) off * nEmbdEnc * Float.BYTES)
+      );
+      if (shell.encode(dft) != 0) {
+        throw new LlamaException(
+          "EAGLE3 encoder failed (n=" + n + ", off=" + off + ")"
+        );
+      }
+      MemorySegment gBuf = LlamaExt.getEmbeddingsNextnAll(dft).reinterpret(
+        (long) n * nEmbdDec * Float.BYTES
+      );
+      for (int i = 0; i < n; i++) {
+        float[] row = new float[nEmbdDec];
+        MemorySegment.copy(
+          gBuf,
+          JAVA_FLOAT,
+          (long) i * nEmbdDec * Float.BYTES,
+          row,
+          0,
+          nEmbdDec
+        );
+        g[off + i] = row;
+      }
+    }
+    return g;
+  }
+
+  /**
+   * Decoder sync of shifted pairs {@code (toks[i] @ poss[i], gRows[i])} with no logits — keeps the
+   * head's KV in lockstep with committed tokens. Chunked by the persistent batch capacity.
+   */
+  public void syncPairs(
+    int[] toks,
+    int[] poss,
+    float[][] gRows,
+    List<Integer> seq
+  ) {
+    int total = toks.length;
+    int off = 0;
+    while (off < total) {
+      int n = Math.min(maxRows, total - off);
+      LlamaBatch b = dual();
+      b.clear();
+      for (int i = 0; i < n; i++) {
+        b.add(toks[off + i], poss[off + i], seq, false);
+        MemorySegment.copy(
+          gRows[off + i],
+          0,
+          embdRows,
+          JAVA_FLOAT,
+          (long) i * nEmbdDec * Float.BYTES,
+          nEmbdDec
+        );
+      }
+      if (b.decode(dft) != 0) {
+        throw new LlamaException("EAGLE3 decoder sync failed");
+      }
+      off += n;
+    }
+  }
+
+  /**
+   * One decoder draft step: decode {@code (token @ pos)} with {@code hidden} as its embd row,
+   * logits on. Caller reads logits from batch row {@code 0} and chains via {@link #chainHidden()}.
+   */
+  @Override
+  public void step(int token, int pos, List<Integer> seq, float[] hidden) {
+    LlamaBatch b = dual();
+    b.clear();
+    b.add(token, pos, seq, true);
+    MemorySegment.copy(hidden, 0, embdRows, JAVA_FLOAT, 0, nEmbdDec);
+    if (b.decode(dft) != 0) {
+      throw new LlamaException("EAGLE3 draft decode failed");
+    }
+  }
+
+  /** The decoder's own pre-norm hidden for the row just decoded — seed for the next chained draft. */
+  @Override
+  public int hiddenSize() {
+    return nEmbdDec;
+  }
+
+  @Override
+  public float[] chainHidden(int row) {
+    return LlamaExt.getEmbeddingsNextnIth(dft, row, nEmbdDec);
+  }
+
+  private MemorySegment featuresBuf() {
+    if (features == null) {
+      features = arena.allocate((long) maxRows * nEmbdEnc * Float.BYTES);
+    }
+    return features;
+  }
+
+  private LlamaBatch dual() {
+    if (dualBatch == null) {
+      embdRows = arena.allocate((long) maxRows * nEmbdDec * Float.BYTES);
+      dualBatch = new LlamaBatch(arena, maxRows, 0, 1);
+      LlamaExt.setBatchEmbd(dualBatch, embdRows); // arena-owned, survives clear()
+    }
+    return dualBatch;
+  }
+
+  private LlamaBatch encShell() {
+    if (encShell == null) {
+      encShell = new LlamaBatch(arena, 1, 0, 1);
+      // Raw embd-only encoder batch, mirroring the C impl's stack struct: token/pos/seq/logits
+      // all NULL so llama_encode auto-fills them. The originally-allocated tiny arrays leak once.
+      for (String field : new String[] {
+        "token",
+        "pos",
+        "n_seq_id",
+        "seq_id",
+        "logits",
+      }) {
+        LlamaExt.setBatchPointer(encShell, field, MemorySegment.NULL);
+      }
+    }
+    return encShell;
+  }
+
+  /**
+   * Frees the persistent native scratch exactly once (idempotent). Injected embd pointers are
+   * arena-owned, NOT malloc'd — they must be nulled before {@code llama_batch_free}.
+   */
+  public void free() {
+    if (dualBatch != null) {
+      LlamaExt.setBatchEmbd(dualBatch, MemorySegment.NULL);
+      dualBatch.free();
+      dualBatch = null;
+    }
+    if (encShell != null) {
+      LlamaExt.setBatchPointer(encShell, "embd", MemorySegment.NULL);
+      encShell.free();
+      encShell = null;
+    }
+    features = null;
+    embdRows = null;
+    boundary = null;
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/draft/HiddenStateDraft.java
+++ b/src/main/java/io/gravitee/llama/cpp/draft/HiddenStateDraft.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.draft;
+
+import io.gravitee.llama.cpp.LlamaContext;
+import java.util.List;
+
+/**
+ * A draft source that proposes tokens by decoding {@code (token, hidden-state)} pairs and
+ * chaining on its own hidden output — the shape shared by {@link MtpDraft} (nextn
+ * self-speculation) and {@link Eagle3Draft} (EAGLE3 head). Lets the speculative decoder drive
+ * both flavours' draft chains through one code path.
+ *
+ * @author GraviteeSource Team
+ */
+public sealed interface HiddenStateDraft permits MtpDraft, Eagle3Draft {
+  /** The draft context this source decodes on (logits are read from its batch row 0). */
+  LlamaContext context();
+
+  /** The width of the hidden-state rows this source consumes and produces. */
+  int hiddenSize();
+
+  /** Decode one {@code (token @ pos)} step with {@code hidden} injected as its embd row. */
+  void step(int token, int pos, List<Integer> seq, float[] hidden);
+
+  /**
+   * The source's own hidden state for output row {@code row} of the last decode — the seed for
+   * that sequence's next chained draft. Fused (multi-sequence) steps read one row per sequence.
+   */
+  float[] chainHidden(int row);
+
+  /** Single-row convenience: {@code chainHidden(0)}. */
+  default float[] chainHidden() {
+    return chainHidden(0);
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/draft/MtpDraft.java
+++ b/src/main/java/io/gravitee/llama/cpp/draft/MtpDraft.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.draft;
+
+import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
+
+import io.gravitee.llama.cpp.LlamaBatch;
+import io.gravitee.llama.cpp.LlamaContext;
+import io.gravitee.llama.cpp.LlamaException;
+import io.gravitee.llama.cpp.LlamaExt;
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.List;
+
+/**
+ * MTP (nextn) self-speculation draft source — the model's own multi-token-prediction head
+ * proposes draft tokens, no separate draft model (requires {@code n_layer_nextn > 0}).
+ *
+ * <p>Counterpart of {@link NgramIndex} for the MTP flavour: this class owns the draft-step
+ * mechanics (dual token+embd decode on the MTP context, hidden-state chaining via the staging
+ * nextn API), while accept/reject stays in {@code Speculation} and orchestration in the
+ * iterator's MTP round. The MTP context itself (built from the <i>target</i> model with
+ * {@code ctx_type=MTP}, {@code ctx_other=target}, {@code n_rs_seq>0}) is created and owned by
+ * the caller, like the model-draft context.
+ *
+ * <p>The seed is the target's post-norm hidden state at the last committed position
+ * ({@code nPast-1}); drafts beyond the first chain on the MTP context's own nextn hidden
+ * ({@link LlamaExt#getEmbeddingsNextnIth}). Requires embeddings enabled on the target context
+ * (done by {@link io.gravitee.llama.cpp.ConversationState#setMtp}) and the staging nextn symbols
+ * ({@link LlamaExt#available()}).
+ *
+ * @author GraviteeSource Team
+ */
+public final class MtpDraft implements HiddenStateDraft {
+
+  private final Arena arena;
+  private final LlamaContext mtp;
+  private final int nEmbd;
+
+  // Persistent native scratch (lazily built, reused across rounds, freed once by free()).
+  private MemorySegment embd; // single-row hidden-state buffer injected into the batch
+  private LlamaBatch batch; // 1-token dual token+embd batch
+
+  // The target's post-norm hidden at the last committed position — the seed for draft step 0.
+  private float[] seed;
+
+  public MtpDraft(Arena arena, LlamaContext mtpContext, int nEmbd) {
+    this.arena = arena;
+    this.mtp = mtpContext;
+    this.nEmbd = nEmbd;
+  }
+
+  @Override
+  public LlamaContext context() {
+    return mtp;
+  }
+
+  public boolean hasSeed() {
+    return seed != null;
+  }
+
+  public float[] seed() {
+    return seed;
+  }
+
+  public void setSeed(float[] hidden) {
+    this.seed = hidden;
+  }
+
+  /**
+   * One MTP draft step: decode {@code (token @ pos)} with {@code hidden} injected as the batch's
+   * embd row. The caller reads the resulting logits from batch row {@code 0} and, when chaining,
+   * the next hidden via {@link #chainHidden()}.
+   */
+  @Override
+  public void step(int token, int pos, List<Integer> seq, float[] hidden) {
+    LlamaBatch b = batch();
+    MemorySegment.copy(hidden, 0, embd, JAVA_FLOAT, 0, nEmbd);
+    b.clear();
+    b.add(token, pos, seq, true);
+    if (b.decode(mtp) != 0) {
+      throw new LlamaException("MTP draft decode failed");
+    }
+  }
+
+  /** The MTP context's own nextn hidden for the row just decoded — seed for the next chained draft. */
+  @Override
+  public int hiddenSize() {
+    return nEmbd;
+  }
+
+  @Override
+  public float[] chainHidden(int row) {
+    return LlamaExt.getEmbeddingsNextnIth(mtp, row, nEmbd);
+  }
+
+  private LlamaBatch batch() {
+    if (batch == null) {
+      embd = arena.allocate((long) nEmbd * Float.BYTES);
+      batch = new LlamaBatch(arena, 1, 0, 1);
+      // Dual token+embd batch: llama_batch_init allocated only the token array; inject our
+      // persistent arena-owned hidden buffer as the embd pointer (survives clear()).
+      LlamaExt.setBatchEmbd(batch, embd);
+    }
+    return batch;
+  }
+
+  /**
+   * Frees the persistent native scratch exactly once (idempotent). The injected embd pointer is
+   * arena-owned, NOT malloc'd — it must be nulled before {@code llama_batch_free}, which would
+   * otherwise {@code free()} it and corrupt the heap.
+   */
+  public void free() {
+    if (batch != null) {
+      LlamaExt.setBatchEmbd(batch, MemorySegment.NULL);
+      batch.free();
+      batch = null;
+    }
+    embd = null;
+    seed = null;
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/draft/NgramIndex.java
+++ b/src/main/java/io/gravitee/llama/cpp/draft/NgramIndex.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.llama.cpp;
+package io.gravitee.llama.cpp.draft;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -36,7 +36,7 @@ import java.util.Map;
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
-final class NgramIndex {
+public final class NgramIndex {
 
   private static final int[] NO_DRAFT = new int[0];
   private static final long HASH_PRIME = 1099511628211L;
@@ -46,19 +46,19 @@ final class NgramIndex {
   private int histLen;
   private final Map<Long, Positions> index = new HashMap<>();
 
-  NgramIndex(int ngram) {
+  public NgramIndex(int ngram) {
     this.ngram = ngram;
     this.history = new int[16];
   }
 
   /** Resets to empty, reusing the buffer — for a re-initialized conversation. */
-  void clear() {
+  public void clear() {
     histLen = 0;
     index.clear();
   }
 
   /** Appends one committed token and indexes the {@code ngram} window it completes (if any). */
-  void append(int token) {
+  public void append(int token) {
     if (histLen == history.length) {
       history = Arrays.copyOf(history, history.length * 2);
     }
@@ -74,7 +74,7 @@ final class NgramIndex {
    * Proposes up to {@code kMax} tokens that followed the most recent earlier occurrence of the last
    * {@code ngram} tokens; empty array if there is no earlier match.
    */
-  int[] propose(int kMax) {
+  public int[] propose(int kMax) {
     if (histLen < ngram + 1) {
       return NO_DRAFT;
     }

--- a/src/main/java/io/gravitee/llama/cpp/speculative/Eagle3SpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/Eagle3SpeculativeDecoding.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.speculative;
+
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+
+import io.gravitee.llama.cpp.*;
+import io.gravitee.llama.cpp.draft.Eagle3Draft;
+import java.util.List;
+
+/**
+ * EAGLE3 speculative decoding: a trained head model proposes tokens from the target's captured
+ * layer inputs. The head keeps a shifted-pair decoder KV ({@code (token at P+1, g at P)} at
+ * pos P) and a pending boundary g row completed at draft time with the freshest sampled token;
+ * each round the verify rows' features are encoded and the decoder re-synced with only the
+ * accepted pairs (no stale cells). Dense targets only.
+ *
+ * @author GraviteeSource Team
+ */
+public final class Eagle3SpeculativeDecoding
+  extends HiddenStateSpeculativeDecoding {
+
+  public static final Eagle3SpeculativeDecoding INSTANCE =
+    new Eagle3SpeculativeDecoding();
+
+  private Eagle3SpeculativeDecoding() {}
+
+  /**
+   * Encodes the target's captured prompt-layer features into g_embd rows and syncs the head
+   * decoder with the shifted pairs {@code (token[k+1], g[k])} at pos k; the last g row becomes
+   * the pending boundary. The layer capture buffer only covers the target's <b>last</b> decode,
+   * so the prompt must fit in a single target batch.
+   */
+  @Override
+  public void prefill(ConversationState state) {
+    var e3 = state.getEagle3Draft();
+    var target = state.getContext();
+    var tokenized = state.getTokenized();
+    int n = tokenized.size();
+    int seqId = state.getSequenceId();
+    if (n > target.nBatch()) {
+      throw new LlamaException(
+        "EAGLE3 requires the prompt (" +
+          n +
+          " tokens) to fit in one target batch (n_batch=" +
+          target.nBatch() +
+          "): layer capture covers only the last target decode"
+      );
+    }
+    e3.context().getMemory().seqRm(seqId, -1, -1);
+    float[][] g = e3.encodeCaptured(target, n);
+    if (n > 1) {
+      int[] toks = new int[n - 1];
+      int[] poss = new int[n - 1];
+      float[][] rows = new float[n - 1][];
+      for (int k = 0; k + 1 < n; k++) {
+        toks[k] = tokenized.data().getAtIndex(JAVA_INT, k + 1);
+        poss[k] = k;
+        rows[k] = g[k];
+      }
+      e3.syncPairs(toks, poss, rows, List.of(seqId));
+    }
+    e3.setBoundary(g[n - 1]);
+  }
+
+  @Override
+  protected List<LlamaOutput> roundImpl(
+    LlamaIterator<?> it,
+    ConversationState state
+  ) {
+    LlamaContext target = state.getContext();
+    Eagle3Draft e3 = state.getEagle3Draft();
+    Speculation spec = state.getSpeculation();
+    int seqId = state.getSequenceId();
+    int nPast = state.getNPast();
+    int idLast = state.getNewTokenId();
+    var seq = List.of(seqId);
+    // EAGLE3 decoder convention: the pair at head pos P is (token at target pos P+1, g at P).
+    // The pending boundary sits at B = nPast-1, completed now with idLast (the token at nPast).
+    int boundaryPos = nPast - 1;
+
+    e3.context().getMemory().seqRm(seqId, boundaryPos, -1);
+    Drafted d = draftChain(
+      it,
+      e3,
+      spec,
+      boundaryPos,
+      idLast,
+      e3.boundary(),
+      seq,
+      state
+    );
+
+    decodeVerify(
+      spec.verifyBatch(),
+      target,
+      idLast,
+      nPast,
+      d.tokens(),
+      d.m(),
+      seq
+    );
+    Verdict v = accept(it, spec, target, d.tokens(), d.snaps(), d.m());
+
+    // Encode the verify rows' captured features → g rows (gv[r] = g at target pos nPast+r).
+    // Read before any further target decode overwrites the capture buffers.
+    float[][] gv = e3.encodeCaptured(target, d.m() + 1);
+
+    int newNPast = nPast + v.matched() + 1;
+    target.getMemory().seqRm(seqId, newNPast, -1);
+
+    // Head resync: wipe from the boundary, then re-decode only the accepted shifted pairs —
+    // (idLast @ B, boundary g) plus (drafted[k] @ B+1+k, gv[k]) for accepted k.
+    e3.context().getMemory().seqRm(seqId, boundaryPos, -1);
+    int[] toks = new int[v.matched() + 1];
+    int[] poss = new int[v.matched() + 1];
+    float[][] rows = new float[v.matched() + 1][];
+    toks[0] = idLast;
+    poss[0] = boundaryPos;
+    rows[0] = e3.boundary();
+    for (int k = 0; k < v.matched(); k++) {
+      toks[k + 1] = d.tokens()[k];
+      poss[k + 1] = boundaryPos + 1 + k;
+      rows[k + 1] = gv[k];
+    }
+    e3.syncPairs(toks, poss, rows, seq);
+    e3.setBoundary(gv[v.matched()]);
+
+    List<LlamaOutput> out = emitCommitted(it, state, d.tokens(), v);
+    commit(state, v, d.m(), newNPast);
+    return out;
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/speculative/HiddenStateSpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/HiddenStateSpeculativeDecoding.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.speculative;
+
+import io.gravitee.llama.cpp.*;
+import io.gravitee.llama.cpp.draft.HiddenStateDraft;
+import java.util.List;
+
+/**
+ * Base for the flavours whose drafter decodes {@code (token, hidden-state)} pairs and chains on
+ * its own hidden output ({@link MtpSpeculativeDecoding}, {@link Eagle3SpeculativeDecoding}) —
+ * owns their shared draft-chain loop, including greedy/confident/snapshot sampling and the
+ * adaptive {@code pMin} early-stop (identical semantics to model drafting).
+ *
+ * @author GraviteeSource Team
+ */
+public abstract sealed class HiddenStateSpeculativeDecoding
+  extends SpeculativeDecoding
+  permits MtpSpeculativeDecoding, Eagle3SpeculativeDecoding {
+
+  /** Drafted tokens (m of them), their snapshots when sampling (null for greedy configs). */
+  record Drafted(int[] tokens, Speculation.Snapshot[] snaps, int m) {}
+
+  /**
+   * Draft chain: step k decodes {@code (prevToken @ basePos+k)} with the current hidden,
+   * samples the draft, then chains on the source's own hidden.
+   */
+  static Drafted draftChain(
+    LlamaIterator<?> it,
+    HiddenStateDraft drafter,
+    Speculation spec,
+    int basePos,
+    int idLast,
+    float[] seedHidden,
+    List<Integer> seq,
+    ConversationState state
+  ) {
+    int kMax = state.getNDraft();
+    int nVocab = state.getContext().nVocab();
+    boolean greedy = spec.isGreedy();
+    boolean adaptive = spec.isAdaptive();
+    LlamaSampler chain = spec.chain();
+
+    int[] drafted = new int[kMax];
+    Speculation.Snapshot[] snaps = greedy
+      ? null
+      : new Speculation.Snapshot[kMax];
+    float[] probOut = new float[1];
+    int m = 0;
+    int prev = idLast;
+    float[] h = seedHidden;
+    for (int i = 0; i < kMax; i++) {
+      drafter.step(prev, basePos + i, seq, h);
+      float conf;
+      if (greedy) {
+        if (adaptive) {
+          drafted[m] = spec.draftGreedyConfident(
+            it.logitsRow(drafter.context(), -1, nVocab),
+            nVocab,
+            probOut
+          );
+          conf = probOut[0];
+        } else {
+          drafted[m] = chain.sample(drafter.context());
+          conf = 1.0f;
+        }
+      } else {
+        Speculation.Snapshot s = spec.draft(
+          chain,
+          it.logitsRow(drafter.context(), -1, nVocab)
+        );
+        snaps[m] = s;
+        drafted[m] = s.selectedId();
+        conf = s.maxProb();
+      }
+      prev = drafted[m];
+      m++;
+      if (adaptive && m >= spec.draftMin() && conf < spec.pMin()) {
+        break;
+      }
+      if (m < kMax) {
+        h = drafter.chainHidden(); // the source's own hidden seeds the next chained draft
+      }
+    }
+    return new Drafted(drafted, snaps, m);
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/speculative/ModelDraftSpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/ModelDraftSpeculativeDecoding.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.speculative;
+
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+
+import io.gravitee.llama.cpp.*;
+import java.util.List;
+
+/**
+ * Model-draft speculative decoding: a separate small model (shared vocab) proposes tokens one
+ * decode at a time — with optional adaptive early-stop — and its KV cache is kept in lockstep
+ * with the target's (prompt replay at prefill, rollback to the accepted boundary each round,
+ * and a gap-fill decode on full accept).
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public final class ModelDraftSpeculativeDecoding extends SpeculativeDecoding {
+
+  public static final ModelDraftSpeculativeDecoding INSTANCE =
+    new ModelDraftSpeculativeDecoding();
+
+  private ModelDraftSpeculativeDecoding() {}
+
+  /**
+   * Replays the prompt into the draft context so its KV matches the target after
+   * {@code processPrompt}. Starts from a clean draft KV for this seqId: with a shared draft
+   * context, a reused seqId would otherwise inherit stale cells from a previous sequence
+   * (degrades accept rate; can't corrupt output since the target still verifies every token).
+   */
+  @Override
+  public void prefill(ConversationState state) {
+    var draft = state.getDraftContext();
+    var tokenized = state.getTokenized();
+    int total = tokenized.size();
+    int nBatch = Math.max(1, draft.nBatch());
+    int seqId = state.getSequenceId();
+    draft.getMemory().seqRm(seqId, -1, -1);
+    int offset = 0;
+    while (offset < total) {
+      int chunk = Math.min(nBatch, total - offset);
+      LlamaBatch batch = new LlamaBatch(state.getArena(), chunk, 0, 1);
+      try {
+        for (int i = 0; i < chunk; i++) {
+          int tok = tokenized.data().getAtIndex(JAVA_INT, offset + i);
+          batch.add(tok, offset + i, List.of(seqId), false);
+        }
+        if (batch.decode(draft) != 0) {
+          throw new LlamaException("Draft prefill decode failed");
+        }
+      } finally {
+        batch.free();
+      }
+      offset += chunk;
+    }
+  }
+
+  @Override
+  protected List<LlamaOutput> roundImpl(
+    LlamaIterator<?> it,
+    ConversationState state
+  ) {
+    LlamaContext target = state.getContext();
+    LlamaContext draft = state.getDraftContext();
+    Speculation spec = state.getSpeculation();
+    int seqId = state.getSequenceId();
+    int kMax = state.getNDraft();
+    int nPast = state.getNPast();
+    int idLast = state.getNewTokenId();
+    int nVocab = target.nVocab();
+    boolean greedy = spec.isGreedy();
+    boolean adaptive = spec.isAdaptive();
+    var seq = List.of(seqId);
+
+    LlamaSampler chain = spec.chain();
+    LlamaBatch draftBatch = spec.draftBatch();
+
+    // Draft up to kMax tokens (positions nPast..nPast+m-1), stopping early once the draft's
+    // top-token probability drops below pMin (adaptive only) — tokens drafted past the point
+    // where the draft is unsure are usually rejected anyway.
+    int[] drafted = new int[kMax];
+    Speculation.Snapshot[] snaps = greedy
+      ? null
+      : new Speculation.Snapshot[kMax];
+    float[] probOut = new float[1];
+    int m = 0;
+    int prev = idLast;
+    for (int i = 0; i < kMax; i++) {
+      draftBatch.clear();
+      draftBatch.add(prev, nPast + i, seq, true);
+      if (draftBatch.decode(draft) != 0) {
+        throw new LlamaException("Speculative draft decode failed");
+      }
+      float conf;
+      if (greedy) {
+        if (adaptive) {
+          drafted[m] = spec.draftGreedyConfident(
+            it.logitsRow(draft, -1, nVocab),
+            nVocab,
+            probOut
+          );
+          conf = probOut[0];
+        } else {
+          drafted[m] = chain.sample(draft);
+          conf = 1.0f;
+        }
+      } else {
+        Speculation.Snapshot s = spec.draft(
+          chain,
+          it.logitsRow(draft, -1, nVocab)
+        );
+        snaps[m] = s;
+        drafted[m] = s.selectedId();
+        conf = s.maxProb();
+      }
+      prev = drafted[m];
+      m++;
+      if (adaptive && m >= spec.draftMin() && conf < spec.pMin()) {
+        break;
+      }
+    }
+
+    decodeVerify(spec.verifyBatch(), target, idLast, nPast, drafted, m, seq);
+    Verdict v = accept(it, spec, target, drafted, snaps, m);
+
+    // Roll back both caches to the accepted boundary.
+    int newNPast = nPast + v.matched() + 1;
+    target.getMemory().seqRm(seqId, newNPast, -1);
+    draft.getMemory().seqRm(seqId, newNPast, -1);
+
+    // Fill decode, only on full accept: advance the draft KV by one so it covers position
+    // nPast+m for next round (no gap). On partial accept the seqRm above already trimmed the
+    // draft past nPast+matched, so a fill would be discarded — skipping it saves a draft
+    // forward pass. The sampled token is discarded.
+    if (v.matched() == m) {
+      draftBatch.clear();
+      draftBatch.add(prev, nPast + m, seq, true);
+      if (draftBatch.decode(draft) != 0) {
+        throw new LlamaException("Speculative draft decode failed");
+      }
+    }
+
+    List<LlamaOutput> out = emitCommitted(it, state, drafted, v);
+    commit(state, v, m, newNPast);
+    return out;
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/speculative/MtpSpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/MtpSpeculativeDecoding.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.speculative;
+
+import io.gravitee.llama.cpp.*;
+import io.gravitee.llama.cpp.draft.MtpDraft;
+import java.util.List;
+
+/**
+ * MTP (nextn) self-speculative decoding: the target model's own multi-token-prediction head
+ * proposes tokens — no separate draft model. The head is seeded with the target's post-norm
+ * hidden at the last committed position and chains on its own nextn hidden; the seed advances
+ * to the last accepted verify row each round.
+ *
+ * @author GraviteeSource Team
+ */
+public final class MtpSpeculativeDecoding
+  extends HiddenStateSpeculativeDecoding {
+
+  public static final MtpSpeculativeDecoding INSTANCE =
+    new MtpSpeculativeDecoding();
+
+  private MtpSpeculativeDecoding() {}
+
+  /**
+   * No token replay — the head shares the target's weights and is seeded per round with the
+   * target's post-norm hidden. After {@code processPrompt} the target's single output row
+   * (index 0) is the last prompt token's hidden: the initial seed.
+   */
+  @Override
+  public void prefill(ConversationState state) {
+    var mtp = state.getMtpDraft();
+    mtp.context().getMemory().seqRm(state.getSequenceId(), -1, -1);
+    mtp.setSeed(state.getContext().getEmbeddingsIth(0));
+  }
+
+  @Override
+  protected List<LlamaOutput> roundImpl(
+    LlamaIterator<?> it,
+    ConversationState state
+  ) {
+    LlamaContext target = state.getContext();
+    MtpDraft mtp = state.getMtpDraft();
+    Speculation spec = state.getSpeculation();
+    int seqId = state.getSequenceId();
+    int nPast = state.getNPast();
+    int idLast = state.getNewTokenId();
+    var seq = List.of(seqId);
+
+    // Wipe stale head cells in this round's write window (previous round's chain overrun).
+    mtp.context().getMemory().seqRm(seqId, nPast, -1);
+    Drafted d = draftChain(
+      it,
+      mtp,
+      spec,
+      nPast,
+      idLast,
+      mtp.seed(),
+      seq,
+      state
+    );
+
+    decodeVerify(
+      spec.verifyBatch(),
+      target,
+      idLast,
+      nPast,
+      d.tokens(),
+      d.m(),
+      seq
+    );
+    Verdict v = accept(it, spec, target, d.tokens(), d.snaps(), d.m());
+
+    // Next round's seed: the target's hidden at the last ACCEPTED verify row (input position
+    // nPast+matched — the position preceding the new idLast). Read before any further decode.
+    float[] newSeed = target.getEmbeddingsIth(v.matched());
+
+    int newNPast = nPast + v.matched() + 1;
+    target.getMemory().seqRm(seqId, newNPast, -1);
+    mtp.context().getMemory().seqRm(seqId, newNPast, -1);
+    mtp.setSeed(newSeed);
+
+    List<LlamaOutput> out = emitCommitted(it, state, d.tokens(), v);
+    commit(state, v, d.m(), newNPast);
+    return out;
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/speculative/NgramSpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/NgramSpeculativeDecoding.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.speculative;
+
+import io.gravitee.llama.cpp.*;
+import java.util.List;
+
+/**
+ * N-gram (prompt-lookup) speculative decoding: proposals come from the committed history — no
+ * draft model, no draft forward pass, no draft KV. Verify/accept treat each proposal as a
+ * point-mass draft (q = 1); only the target cache is rolled back, and committed tokens are
+ * appended to the history for the next round's lookup.
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public final class NgramSpeculativeDecoding extends SpeculativeDecoding {
+
+  public static final NgramSpeculativeDecoding INSTANCE =
+    new NgramSpeculativeDecoding();
+
+  private NgramSpeculativeDecoding() {}
+
+  @Override
+  protected List<LlamaOutput> roundImpl(
+    LlamaIterator<?> it,
+    ConversationState state
+  ) {
+    LlamaContext target = state.getContext();
+    Speculation spec = state.getSpeculation();
+    int seqId = state.getSequenceId();
+    int nPast = state.getNPast();
+    int idLast = state.getNewTokenId();
+    var seq = List.of(seqId);
+
+    int[] drafted = state.proposeNgram(state.getNDraft());
+    int m = drafted.length;
+
+    decodeVerify(spec.verifyBatch(), target, idLast, nPast, drafted, m, seq);
+    // Point-mass draft: snaps == null → q = 1 accept + point-mass residual.
+    Verdict v = accept(it, spec, target, drafted, null, m);
+
+    // Roll back ONLY the target cache (no draft cache exists).
+    int newNPast = nPast + v.matched() + 1;
+    target.getMemory().seqRm(seqId, newNPast, -1);
+
+    List<LlamaOutput> out = emitCommitted(it, state, drafted, v);
+
+    // Append the committed tokens (matched drafts + the extra) to history so the next round can
+    // look them up; keeps histLen == newNPast + 1 regardless of EOG/quota early stop.
+    for (int i = 0; i < v.matched(); i++) {
+      state.appendHistory(drafted[i]);
+    }
+    state.appendHistory(v.extra());
+
+    commit(state, v, m, newNPast);
+    return out;
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/speculative/Speculation.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/Speculation.java
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.llama.cpp;
+package io.gravitee.llama.cpp.speculative;
 
 import static java.lang.foreign.ValueLayout.JAVA_FLOAT;
 
+import io.gravitee.llama.cpp.*;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.util.Random;
@@ -34,17 +35,17 @@ import java.util.Random;
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
-final class Speculation {
+public final class Speculation {
 
   /** Post-sampler candidate distribution snapshot ({@code id -> prob} over the kept support). */
-  record Snapshot(
+  public record Snapshot(
     int[] ids,
     float[] probs,
     int selectedId,
     float selectedProbability
   ) {
     /** Highest probability over the kept support — the draft's confidence (for adaptive stop). */
-    float maxProb() {
+    public float maxProb() {
       float max = 0.0f;
       for (float p : probs) {
         if (p > max) {
@@ -71,7 +72,7 @@ final class Speculation {
   private LlamaBatch draftBatch;
   private LlamaBatch verifyBatch;
 
-  Speculation(Arena arena, int nVocab, SpeculativeConfig config) {
+  public Speculation(Arena arena, int nVocab, SpeculativeConfig config) {
     this.config = config;
     this.arena = arena;
     this.targetBuf = new LlamaTokenDataArray(arena, nVocab);
@@ -80,19 +81,19 @@ final class Speculation {
     this.qScatter = new float[nVocab];
   }
 
-  boolean isGreedy() {
+  public boolean isGreedy() {
     return config.isGreedy();
   }
 
-  boolean isAdaptive() {
+  public boolean isAdaptive() {
     return config.isAdaptive();
   }
 
-  int draftMin() {
+  public int draftMin() {
     return config.draftMin();
   }
 
-  float pMin() {
+  public float pMin() {
     return config.pMin();
   }
 
@@ -101,7 +102,7 @@ final class Speculation {
    * reused across rounds. Reuse gives the stochastic chain a single continuous RNG stream (more
    * correct than re-seeding every round); the greedy chain is stateless. Freed by {@link #free()}.
    */
-  LlamaSampler chain() {
+  public LlamaSampler chain() {
     if (chain == null) {
       chain = buildChain();
     }
@@ -126,7 +127,7 @@ final class Speculation {
   }
 
   /** Persistent single-token draft batch (reused via {@code clear()}). */
-  LlamaBatch draftBatch() {
+  public LlamaBatch draftBatch() {
     if (draftBatch == null) {
       draftBatch = new LlamaBatch(arena, 1, 0, 1);
     }
@@ -134,7 +135,7 @@ final class Speculation {
   }
 
   /** Persistent verify batch sized for idLast + up to {@code nDraft} drafted tokens. */
-  LlamaBatch verifyBatch() {
+  public LlamaBatch verifyBatch() {
     if (verifyBatch == null) {
       verifyBatch = new LlamaBatch(arena, config.nDraft() + 1, 0, 1);
     }
@@ -146,7 +147,7 @@ final class Speculation {
    * idempotent (a double-free is a no-op) and a re-initialized conversation lazily rebuilds them on
    * next use. Must be called on the owning iterator thread before the state's arena is closed.
    */
-  void free() {
+  public void free() {
     if (chain != null) {
       chain.free();
       chain = null;
@@ -168,7 +169,7 @@ final class Speculation {
    * tie-break) and writes its softmax probability {@code 1/Σexp(logit-maxLogit)} into
    * {@code probOut[0]}. Used only when adaptive early stop is enabled.
    */
-  int draftGreedyConfident(
+  public int draftGreedyConfident(
     MemorySegment logitsRow,
     int nVocab,
     float[] probOut
@@ -190,12 +191,12 @@ final class Speculation {
     return argmax;
   }
 
-  Snapshot draft(LlamaSampler chain, MemorySegment logitsRow) {
+  public Snapshot draft(LlamaSampler chain, MemorySegment logitsRow) {
     return snapshot(draftBuf, chain, logitsRow);
   }
 
   /** Selected token only — applies the chain to the target buffer and returns its choice. */
-  int targetSelect(LlamaSampler chain, MemorySegment logitsRow) {
+  public int targetSelect(LlamaSampler chain, MemorySegment logitsRow) {
     return select(targetBuf, chain, logitsRow);
   }
 
@@ -243,7 +244,7 @@ final class Speculation {
    * as the {@link Snapshot}-based {@link #accept} (one native apply + at most one accept coin), so the
    * sampled distribution is identical — this only avoids materializing the target snapshot.
    */
-  boolean acceptTarget(
+  public boolean acceptTarget(
     LlamaSampler chain,
     MemorySegment logitsRow,
     int draftedToken,
@@ -275,7 +276,7 @@ final class Speculation {
    * (two passes; no {@code float[]} of differences). Must be called immediately after a rejecting
    * {@link #acceptTarget} for the same position (no intervening fill/apply).
    */
-  int residualTargetScatter(Snapshot draft) {
+  public int residualTargetScatter(Snapshot draft) {
     int[] draftIds = draft.ids();
     float[] draftProbs = draft.probs();
     for (int i = 0; i < draftIds.length; i++) {
@@ -321,7 +322,7 @@ final class Speculation {
    * {@code (p - 1)₊ = 0} there) and renormalized. Allocation-free. Must be called immediately after
    * a rejecting {@link #acceptTarget} for the same position.
    */
-  int residualTargetPointMass(int token) {
+  public int residualTargetPointMass(int token) {
     int n = (int) targetBuf.size();
     double sum = 0.0;
     for (int i = 0; i < n; i++) {

--- a/src/main/java/io/gravitee/llama/cpp/speculative/SpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/SpeculativeDecoding.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.speculative;
+
+import io.gravitee.llama.cpp.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A speculative-decoding flavour's single-sequence round (BatchIterator drives the same draft
+ * sources through its fused multi-sequence phases). One round = <b>draft</b> (flavour-specific) →
+ * <b>verify</b> (one batched target decode) → <b>accept</b> (greedy longest-prefix, or rejection
+ * sampling) → <b>rollback + emit</b>. Subclasses implement only what makes their flavour
+ * different — how drafts are produced and how their side state advances:
+ *
+ * <ul>
+ *   <li>{@link NgramSpeculativeDecoding} — proposals from the committed history; no draft KV.</li>
+ *   <li>{@link ModelDraftSpeculativeDecoding} — a separate small model decoded token-by-token.</li>
+ *   <li>{@link MtpSpeculativeDecoding} — the target's own nextn head.</li>
+ *   <li>{@link Eagle3SpeculativeDecoding} — a trained EAGLE3 head over the target's captured
+ *       layer inputs.</li>
+ * </ul>
+ *
+ * The right variant is attached to the {@link ConversationState} by its {@code setDraft} /
+ * {@code setNgram} / {@code setMtp} / {@code setEagle3} setter; the iterators just delegate.
+ * The sampling math (draft snapshots, accept test, residual draws) lives in
+ * {@link Speculation}; detokenization/emission stays on the iterator
+ * ({@code emitSpeculative}). Greedy configs are lossless w.r.t. plain greedy decoding; sampling
+ * configs are exact samplers of the target distribution. Implementations are stateless
+ * singletons — all per-conversation state lives on the {@link ConversationState}.
+ *
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public abstract sealed class SpeculativeDecoding
+  permits
+    ModelDraftSpeculativeDecoding,
+    NgramSpeculativeDecoding,
+    HiddenStateSpeculativeDecoding {
+
+  /**
+   * Brings the flavour's draft-side state in line with the freshly-processed prompt (called
+   * once after {@code processPrompt}). Default: nothing to prefill.
+   */
+  public void prefill(ConversationState state) {}
+
+  /**
+   * Runs one draft → verify → accept round and returns the committed tokens as outputs.
+   * Requires {@code state.getNewTokenId()} to be set (the last token, not yet in any KV);
+   * updates the state's {@code nPast}/{@code newTokenId} and sets the finish reason on EOG or
+   * token-limit. On failure the state's persistent native scratch is released (idempotent).
+   */
+  public final List<LlamaOutput> round(
+    LlamaIterator<?> it,
+    ConversationState state
+  ) {
+    try {
+      return roundImpl(it, state);
+    } catch (RuntimeException e) {
+      state.freeSpeculativeScratch();
+      throw e;
+    }
+  }
+
+  /** The flavour-specific round body. */
+  protected abstract List<LlamaOutput> roundImpl(
+    LlamaIterator<?> it,
+    ConversationState state
+  );
+
+  /* -------------------------------- shared mechanics -------------------------------- */
+
+  /** Accepted-prefix length + the correction (partial accept) or bonus (full accept) token. */
+  record Verdict(int matched, int extra) {}
+
+  /** One batched target decode of {@code [idLast, drafted[0..m-1]]} with logits on every row. */
+  static void decodeVerify(
+    LlamaBatch verifyBatch,
+    LlamaContext target,
+    int idLast,
+    int nPast,
+    int[] drafted,
+    int m,
+    List<Integer> seq
+  ) {
+    verifyBatch.clear();
+    verifyBatch.add(idLast, nPast, seq, true);
+    for (int i = 0; i < m; i++) {
+      verifyBatch.add(drafted[i], nPast + 1 + i, seq, true);
+    }
+    if (verifyBatch.decode(target) != 0) {
+      throw new LlamaException("Speculative verify decode failed");
+    }
+  }
+
+  /**
+   * Accepts drafts against the verify rows: greedy longest-prefix when the config is greedy
+   * (lossless), otherwise rejection sampling ({@code min(1, p/q)} accept + residual draw on the
+   * first rejection — an exact sampler of the target distribution). {@code snaps == null} means
+   * a point-mass draft (n-gram, q = 1); otherwise q comes from the draft snapshots.
+   */
+  static Verdict accept(
+    LlamaIterator<?> it,
+    Speculation spec,
+    LlamaContext target,
+    int[] drafted,
+    Speculation.Snapshot[] snaps,
+    int m
+  ) {
+    LlamaSampler chain = spec.chain();
+    if (spec.isGreedy()) {
+      int matched = 0;
+      int correction = -1;
+      for (int i = 0; i < m; i++) {
+        int t = chain.sample(target, i);
+        if (t == drafted[i]) {
+          matched++;
+        } else {
+          correction = t;
+          break;
+        }
+      }
+      int extra = matched == m ? chain.sample(target, m) : correction;
+      return new Verdict(matched, extra);
+    }
+
+    int nVocab = target.nVocab();
+    int matched = 0;
+    int extra = -1;
+    for (int i = 0; i < m; i++) {
+      float q = snaps == null ? 1.0f : snaps[i].selectedProbability();
+      if (
+        spec.acceptTarget(chain, it.logitsRow(target, i, nVocab), drafted[i], q)
+      ) {
+        matched++;
+      } else {
+        extra = snaps == null
+          ? spec.residualTargetPointMass(drafted[i])
+          : spec.residualTargetScatter(snaps[i]);
+        break;
+      }
+    }
+    if (matched == m) {
+      extra = spec.targetSelect(chain, it.logitsRow(target, m, nVocab));
+    }
+    return new Verdict(matched, extra);
+  }
+
+  /** Emits the accepted drafts then the extra token (stops early on EOG/quota). */
+  static List<LlamaOutput> emitCommitted(
+    LlamaIterator<?> it,
+    ConversationState state,
+    int[] drafted,
+    Verdict v
+  ) {
+    List<LlamaOutput> out = new ArrayList<>();
+    boolean cont = true;
+    for (int i = 0; i < v.matched() && cont; i++) {
+      cont = it.emitSpeculative(state, drafted[i], out);
+    }
+    if (cont) {
+      it.emitSpeculative(state, v.extra(), out);
+    }
+    return out;
+  }
+
+  /** Advances the conversation to the accepted boundary and records accept statistics. */
+  static void commit(
+    ConversationState state,
+    Verdict v,
+    int drafted,
+    int newNPast
+  ) {
+    state.setNPast(newNPast);
+    state.setNewTokenId(v.extra());
+    state.recordSpeculation(drafted, v.matched());
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/LlamaExtSymbolsTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/LlamaExtSymbolsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Locks {@link LlamaExt.Fn}'s derived Itanium mangling against the symbol names observed in the
+ * pinned libllama ({@code nm -gU libllama.dylib}). Pure string logic — no native lib needed —
+ * so a typo in a signature declaration fails fast in any environment. Whether the symbols
+ * actually resolve against the bundled build is asserted separately by
+ * {@code MtpEagle3SpeculativeTest#staging_symbols_resolve_against_bundled_llama_cpp}.
+ *
+ * @author GraviteeSource Team
+ */
+class LlamaExtSymbolsTest {
+
+  @Test
+  void derived_symbols_match_libllama_exports() {
+    // MTP (nextn) group — verified against libllama b9673 and b9873.
+    assertThat(LlamaExt.SET_EMBEDDINGS_NEXTN.symbol()).isEqualTo(
+      "_Z26llama_set_embeddings_nextnP13llama_contextbb"
+    );
+    assertThat(LlamaExt.GET_EMBEDDINGS_NEXTN_ITH.symbol()).isEqualTo(
+      "_Z30llama_get_embeddings_nextn_ithP13llama_contexti"
+    );
+    assertThat(LlamaExt.GET_CTX_OTHER.symbol()).isEqualTo(
+      "_Z19llama_get_ctx_otherP13llama_context"
+    );
+
+    // EAGLE3 group — verified against libllama b9873.
+    assertThat(LlamaExt.SET_EMBEDDINGS_LAYER_INP.symbol()).isEqualTo(
+      "_Z30llama_set_embeddings_layer_inpP13llama_contextjb"
+    );
+    assertThat(LlamaExt.GET_EMBEDDINGS_LAYER_INP.symbol()).isEqualTo(
+      "_Z30llama_get_embeddings_layer_inpP13llama_contextj"
+    );
+    assertThat(LlamaExt.GET_EMBEDDINGS_NEXTN.symbol()).isEqualTo(
+      "_Z26llama_get_embeddings_nextnP13llama_context"
+    );
+    assertThat(LlamaExt.MODEL_TARGET_LAYER_IDS.symbol()).isEqualTo(
+      "_Z28llama_model_target_layer_idsPK11llama_model"
+    );
+    assertThat(LlamaExt.MODEL_TARGET_LAYER_IDS_N.symbol()).isEqualTo(
+      "_Z30llama_model_target_layer_ids_nPK11llama_model"
+    );
+  }
+
+  @Test
+  void resolution_report_names_every_declared_symbol() {
+    // Report generation is pure over the group lists; every declared symbol must appear.
+    String mtp = LlamaExt.resolutionReport();
+    assertThat(mtp)
+      .contains("llama_set_embeddings_nextn")
+      .contains("llama_get_embeddings_nextn_ith")
+      .contains("llama_get_ctx_other");
+
+    String eagle3 = LlamaExt.eagle3ResolutionReport();
+    assertThat(eagle3)
+      .contains("llama_set_embeddings_layer_inp")
+      .contains("llama_get_embeddings_layer_inp")
+      .contains("llama_get_embeddings_nextn")
+      .contains("llama_model_target_layer_ids");
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/MtpEagle3SpeculativeTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/MtpEagle3SpeculativeTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static io.gravitee.llama.cpp.LlamaCppTest.MODEL_PATH;
+import static io.gravitee.llama.cpp.LlamaCppTest.MODEL_TO_DOWNLOAD;
+import static io.gravitee.llama.cpp.LlamaCppTest.REASONING_MODEL_PATH;
+import static io.gravitee.llama.cpp.LlamaCppTest.REASONNING_MODEL_TO_DOWNLOAD;
+import static io.gravitee.llama.cpp.LlamaCppTest.getModelPath;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
+import java.lang.foreign.Arena;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validation/gating tests for the MTP (nextn) self-speculation and EAGLE3 draft sources —
+ * config rejection, capability probing, head-model validation, and MTP/EAGLE3 states joining
+ * a BatchIterator parallel step.
+ *
+ * <p>End-to-end MTP/EAGLE3 rounds require multi-GB capability models (a nextn-headed target /
+ * a target-specific EAGLE3 head GGUF) that are impractical in CI; the round logic is validated
+ * manually — see docs/speculative-decoding.
+ *
+ * @author GraviteeSource Team
+ */
+@Tag("integration")
+class MtpEagle3SpeculativeTest extends LlamaCppTest {
+
+  private static Arena arena;
+
+  @BeforeAll
+  static void beforeAll() {
+    arena = Arena.ofConfined();
+    String libPath = LlamaLibLoader.load();
+    LlamaRuntime.llama_backend_init();
+    LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    LlamaRuntime.llama_backend_free();
+    arena.close();
+    arena = null;
+  }
+
+  @Test
+  void staging_symbols_resolve_against_bundled_llama_cpp() {
+    // The pinned llama.cpp build must expose both staging groups; if a version bump breaks the
+    // mangled names, this fails fast with the per-symbol report.
+    assertThat(LlamaExt.available()).as(LlamaExt.resolutionReport()).isTrue();
+    assertThat(LlamaExt.eagle3Available())
+      .as(LlamaExt.eagle3ResolutionReport())
+      .isTrue();
+  }
+
+  @Test
+  void setMtp_rejects_ngram_config() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena).nCtx(256).nBatch(256);
+    var ctx = track(new LlamaContext(arena, model, cp));
+    var state = ConversationState.create(
+      arena,
+      ctx,
+      new LlamaTokenizer(new LlamaVocab(model), ctx),
+      track(new LlamaSampler(arena).greedy())
+    );
+
+    assertThatThrownBy(() ->
+      state.setMtp(ctx, SpeculativeConfig.ngramGreedy(4, 2))
+    )
+      .isInstanceOf(LlamaException.class)
+      .hasMessageContaining("ngram");
+  }
+
+  @Test
+  void setEagle3_rejects_non_eagle3_head_model() {
+    assumeTrue(LlamaExt.eagle3Available());
+    Path targetPath = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    Path headPath = getModelPath(
+      REASONING_MODEL_PATH,
+      REASONNING_MODEL_TO_DOWNLOAD
+    );
+    var target = track(
+      new LlamaModel(arena, targetPath, new LlamaModelParams(arena))
+    );
+    // An ordinary LM is not an EAGLE3 head: it declares no target extract layers.
+    var fakeHead = track(
+      new LlamaModel(arena, headPath, new LlamaModelParams(arena))
+    );
+    var cp = new LlamaContextParams(arena).nCtx(256).nBatch(256);
+    var ctx = track(new LlamaContext(arena, target, cp));
+    var headCtx = track(new LlamaContext(arena, fakeHead, cp));
+    var state = ConversationState.create(
+      arena,
+      ctx,
+      new LlamaTokenizer(new LlamaVocab(target), ctx),
+      track(new LlamaSampler(arena).greedy())
+    );
+
+    assertThatThrownBy(() ->
+      state.setEagle3(headCtx, fakeHead, SpeculativeConfig.greedy(4))
+    )
+      .isInstanceOf(LlamaException.class)
+      .hasMessageContaining("EAGLE3");
+  }
+
+  @Test
+  void batchIterator_accepts_mtp_states() {
+    assumeTrue(LlamaExt.available());
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena).nCtx(256).nBatch(256);
+    var ctx = track(new LlamaContext(arena, model, cp));
+    // Any same-vocab context passes setMtp's validation (the capability probe for a real nextn
+    // head is native context creation; end-to-end fused rounds need a capability model and are
+    // validated manually — see the class javadoc).
+    var mtpish = track(new LlamaContext(arena, model, cp));
+    var state = ConversationState.create(
+      arena,
+      ctx,
+      new LlamaTokenizer(new LlamaVocab(model), ctx),
+      track(new LlamaSampler(arena).greedy())
+    ).setMtp(mtpish, SpeculativeConfig.greedy(4));
+
+    assertThat(state.isMtp()).isTrue();
+    assertThat(state.isSpeculative()).isTrue();
+
+    // MTP/EAGLE3 states join the fused multi-sequence step like any other speculative state.
+    try (var batchIterator = new BatchIterator(arena, ctx)) {
+      batchIterator.addState(state);
+    }
+    state.freeSpeculativeScratch();
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/NgramLookupTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/NgramLookupTest.java
@@ -17,6 +17,7 @@ package io.gravitee.llama.cpp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.gravitee.llama.cpp.draft.NgramIndex;
 import org.junit.jupiter.api.Test;
 
 /**

--- a/src/test/java/io/gravitee/llama/cpp/SpeculationTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/SpeculationTest.java
@@ -18,6 +18,7 @@ package io.gravitee.llama.cpp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
+import io.gravitee.llama.cpp.speculative.Speculation;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;


### PR DESCRIPTION
  ## What's new                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                           
  ### Two speculative flavours                                                                                                                                                                                                                             
  - **MTP self-speculation** (`--mtp`, `ConversationState.setMtp`) — drives the target model's                                                                                                                                                             
    own multi-token-prediction head; no separate draft model. Requires a model with                                                                                                                                                                        
    `n_layer_nextn > 0` (e.g. Qwen3.6-MoE family). The head runs as a second context over the                                                                                                                                                              
    target's weights (`ctx_type=MTP`, `ctx_other`), seeded per round with the target's post-norm                                                                                                                                                           
    hidden state.                                                                                                                                                                                                                                          
  - **EAGLE3** (`--eagle3 <path>`, `ConversationState.setEagle3`) — a target-specific trained                                                                                                                                                              
    head (GGUF arch `eagle3`) drafting from the target's intermediate hidden states; works with                                                                                                                                                            
    dense targets that have no nextn head. Ports the encoder/decoder protocol from llama.cpp's                                                                                                                                                             
    `common/speculative.cpp` (draft-eagle3), single-sequence form.                                                                                                                                                                                         
                                                                                                                                                                                                                                                           
  Both support greedy (lossless) and temperature/top-k/top-p (exact rejection sampling), and the
  existing `--p_min`/`--draft_min` adaptive early-stop. The four flavours are mutually exclusive.
  All four run on both iterators: `DefaultLlamaIterator` (single sequence) and `BatchIterator`
  (parallel multi-sequence). Hidden-state drafts (MTP/EAGLE3) join the fused batch like any other
  speculative state — they are grouped by draft context, then drafted/verified/accepted per
  sequence within the shared step.                                                                                                                                                              
                                                                                                                                                                                                                                                           
  ### C++ ABI binding layer (`io.gravitee.llama.cpp.cxx`)                                                                                                                                                                                                  
  The nextn/EAGLE3 functions live in llama.cpp's staging header (`src/llama-ext.h`), which is not                                                                                                                                                          
  `extern "C"` — the symbols are Itanium-mangled and jextract cannot bind them. Instead of                                                                                                                                                                 
  hardcoding mangled strings, each function is declared as a data record (`CxxFunction`: C name,                                                                                                                                                           
  return layout, `CxxParam` kinds) from which the mangled symbol and FFM descriptor are derived;                                                                                                                                                           
  `CxxFunctions` resolves and dispatches. Adding a staging function is one declaration line.                                                                                                                                                               
  Fail-fast by design: if a llama.cpp bump changes a signature, the symbol vanishes,                                                                                                                                                                       
  `available()` turns false, and setters throw with a per-symbol resolution report — never a                                                                                                                                                               
  silent wrong-ABI call.                                                                                                                                                                                                                                   

### Structure                                                                                                                                                                                                                                            
  - `io.gravitee.llama.cpp.speculative` — `SpeculativeDecoding`, a **sealed** strategy hierarchy                                                                                                                                                           
    (`ModelDraft` / `Ngram` / `HiddenState` → `Mtp` / `Eagle3`) holding the shared                                                                                                                                                                         
    verify → accept → rollback → emit mechanics once; each flavour subclass contains only its                                                                                                                                                              
    draft production and side-state advance. `Speculation` (rejection-sampling math) moves here.                                                                                                                                                           
    The variant is attached by the `ConversationState` setter — no dispatch code.                                                                                                                                                                          
  - `io.gravitee.llama.cpp.draft` — the draft sources: `NgramIndex`, `MtpDraft`, `Eagle3Draft`                                                                                                                                                             
    (the latter two behind the sealed `HiddenStateDraft` interface).                                                                                                                                                                                       
  - `LlamaIterator` shrinks from ~1,200 to ~470 lines; greedy/stochastic round duplication is                                                                                                                                                              
    folded into shared helpers with identical sampler-call ordering (output is bit-identical).                                                                                                                                                             
  - New public API: `LlamaContext.nUbatch()`, `LlamaBatch.encode(ctx)`,                                                                                                                                                                                    
    `LlamaRuntime.llama_encode` / `llama_model_n_layer_nextn`, batch-field helpers on `LlamaExt`.                                                                                                                                                          
                                                                                                                                                                                                                                                           
  ## Performance (M4 Max, greedy, measured via the PoC harness before productization)                                                                                                                                                                      
                                                                                                                                                                                                                                                           
  | Flavour | Target | Best config | Speedup vs AR |                                                                                                                                                                                                       
  |---|---|---|---|                                                                                                                                                                                                                                        
  | MTP | Qwen3.6-35B-A3B (MoE) | K=2 | **1.27×** (63 → 80 tok/s) |                                                                                                                                                                                        
  | EAGLE3 | Qwen3-14B Q8 (dense) | K=2, chat prompts | **1.60×** (24 → 38 tok/s) |                                                                                                                                                                        
                                                                                                                                                                                                                                                           
  Keep `n_draft` small (2–3): acceptance-vs-cost peaks low on Metal, where a multi-token verify                                                                                                                                                            
  batch is meaningfully more expensive than a single decode. On Apple Silicon these roughly match                                                                                                                                                          
  a good two-model draft; they pay off when no compatible small draft model exists (MTP: the head                                                                                                                                                          
  ships inside the GGUF) or on hardware with cheaper verify (CUDA-class). EAGLE3 benchmark                                                                                                                                                                 
  prompts must be chat-shaped — raw completions understate community-trained heads.                                                                                                                                                                        
                                                                                                                                                                                                                                                           
  ## Testing                                                                                                                                                                                                                                               
  - `LlamaExtSymbolsTest` (pure) — locks the derived Itanium manglings against the observed                                                                                                                                                                
    `nm` exports of the pinned libllama.                                                                                                                                                                                                                   
  - `MtpEagle3SpeculativeTest` (integration, small models) — staging-symbol resolution canary
    for version bumps, config/head validation, and MTP/EAGLE3 states joining a `BatchIterator`
    parallel step.                                                                                                                                                                                       
  - Existing `SpeculativeDecodingTest` suite covers the refactored model-draft/n-gram paths                                                                                                                                                                
    (spec output must match plain greedy).                                                                                                                                                                                                                 
  - End-to-end MTP/EAGLE3 rounds need multi-GB capability models (nextn-headed target /                                                                                                                                                                    
    target-specific head) impractical in CI — validated manually against Qwen3.6-35B-A3B and                                                                                                                                                               
    Qwen3-14B + its EAGLE3 speculator; numbers above.                                                                                                                                                                                                      
                                                                                                                                                                                                                                                           
  ## Notes / limitations                                                                                                                                                                                                                                   
  - MTP/EAGLE3 depend on llama.cpp *staging* symbols; re-verify on every version bump (the CI                                                                                                                                                              
    canary fails loudly). When upstream promotes the API to `extern "C"`, the `cxx` bindings can                                                                                                                                                           
    be replaced by jextract and deleted.                                                                                                                                                                                                                   
  - EAGLE3: dense targets only; prompt must fit one target batch (layer capture covers only the                                                                                                                                                            
    last decode).                                                                                                                                                                                                                                          
  - MTP on hybrid attention+SSM targets allocates recurrent rollback snapshots                                                                                                                                                                             
    (`n_rs_seq = n_draft+1`) on both contexts.                                                                                                                                                                                                             
  - Docs: `docs/speculative-decoding/README.md` covers all four flavours, usage, and the
    measured numbers.
  - CI: the CircleCI model set is now driven by a single manifest (`scripts/ci-models.txt`)
    downloaded in parallel (`scripts/download_ci_models.sh`) and cached per-OS, replacing the
    sequential per-repo download steps.
