### PR TITLE
perf: cut per-round overhead in speculative decoding

### DIFF
--- a/docs/speculative-decoding/README.md
+++ b/docs/speculative-decoding/README.md
@@ -82,7 +82,7 @@ var mtpParams = new LlamaContextParams(arena)
     .ctxOther(targetCtx)     // borrows the target's tensors
     .ctxTypeMtp();
 var mtpCtx = new LlamaContext(arena, model, mtpParams);
-state.setMtp(mtpCtx, SpeculativeConfig.greedy(2)); // K=2 is the measured optimum on Metal
+state.setMtp(mtpCtx, SpeculativeConfig.greedy(2));
 ```
 
 Hybrid attention+SSM targets (the Qwen3.6-MoE family) also need `nRsSeq(nDraft + 1)` on the
@@ -152,9 +152,42 @@ Helpers: `isGreedy()` (`temperature <= 0`), `isAdaptive()` (`pMin > 0` and model
 - **Adaptive early stop** (`pMin > 0`) changes only *how many* tokens are speculated per round, not *which* are emitted, so it preserves greedy losslessness and sampling exactness.
 - All four flavours work with both `DefaultLlamaIterator` (single sequence) and `BatchIterator` (fused multi-sequence). For the fused path, size the target context so `nBatch >= sum(nDraft + 1)` across sequences.
 - **Fused MTP/EAGLE3**: sequences sharing a head context draft in lockstep — each chain step is one batched dual *(token, hidden)* decode across sequences (this also amortizes the per-draft dispatch cost that dominates small-graph decodes), they verify in the shared fused target decode, and each sequence then advances its own seed (MTP: the target's hidden at its last accepted verify row) or boundary (EAGLE3: per-sequence slice of the layer capture, encoded and re-synced) from its slice of the verify buffers. Size the **head context** for the batch: `nSeqMax` matching the target's and `nOutputsMax >= nSeqMax` (the bundled CLI does this; if you build the MTP context yourself, see the usage snippet above).
-- EAGLE3 tip: keep `nDraft` small (2–3) and benchmark with chat-shaped prompts — community heads are instruct-trained, raw completions understate them. MTP/EAGLE3 pay off most where no compatible small draft model exists (MTP: the head ships inside the GGUF; EAGLE3: dense targets with a published head).
 - **Staging-API dependency:** MTP/EAGLE3 resolve C++-mangled symbols from the bundled llama.cpp at runtime (`LlamaExt.available()` / `eagle3Available()`). A llama.cpp version bump can invalidate them; the setters then fail fast with a per-symbol resolution report rather than mis-calling a changed ABI.
 - **Resources/lifecycle:** the `Speculation` allocates persistent native scratch (sampler chain + draft/verify batches) on the state's `Arena`, freed once on teardown. Close the iterator (try-with-resources) when abandoning a stream so the scratch is freed and the sequence cleared; the contexts stay reusable afterward.
+
+## Benchmarks (July 2026, Apple M4 Max)
+
+Measured with the bundled CLI (`--perf true`) on an Apple M4 Max (Metal), reading the
+**Effective decode** line — emitted tokens over wall-clock from the first emitted token, the
+only rate that is valid under speculation (the native `Generation speed` counter cannot see
+batch-verified tokens and reads `0.00`). Chat-shaped prompts of a few hundred tokens;
+run-to-run variance is a few percent, and accept rate (and therefore speedup) depends on the
+content being generated.
+
+**Target: Qwen3.6-35B-A3B (MoE, Q4_K_S)**
+
+| Config | Effective decode | Accept rate | Speedup |
+|---|---|---|---|
+| Autoregressive (no speculation) | 62.8 tok/s | — | 1.00× |
+| `--mtp true`, K=2–4, `p_min` 0.6–0.8 | 82–84 tok/s | ~0.78 | **~1.34×** |
+
+MTP plateaus at the same throughput for every draft length — the per-round decode dispatch
+floor dominates on a fast MoE — so prefer `--n_draft 2`.
+
+**Target: Qwen3-14B (Q8_0)**
+
+| Config | Effective decode | Accept rate | Speedup |
+|---|---|---|---|
+| Autoregressive (no speculation) | 22.0 tok/s | — | 1.00× |
+| `--draft` Qwen3-8B Q4_K_M, K=2 | 28.7 tok/s | 0.83 | 1.30× |
+| `--eagle3` Qwen3-14B EAGLE3 head Q8_0, K=2–3 | 32–34 tok/s | 0.52–0.57 | 1.46–1.53× |
+| `--draft` **Qwen3-0.6B Q8_0, K=3, `p_min` 0.6** | **35.0 tok/s** | 0.69 | **1.59×** |
+| `--draft` Qwen3-0.6B Q8_0, K=4 | 31.6 tok/s | 0.58 | 1.44× |
+
+Takeaways: the winning formula is a *cheap* draft with a *decent* accept rate — the 8B draft
+accepts best (0.83) but each drafted token costs ~40% of a target decode, while the 0.6B
+draft costs ~4% and wins overall despite the lower accept. Drafting deeper than the accept
+rate supports (K=4 here) lowers throughput: tail proposals fail, dragging whole rounds down.
 
 ## See also
 - [Text Generation & Sampling](../text-generation/README.md) — the underlying sampler chain and iterators speculation builds on.

--- a/src/main/java/io/gravitee/llama/cpp/ConversationState.java
+++ b/src/main/java/io/gravitee/llama/cpp/ConversationState.java
@@ -77,6 +77,13 @@ public class ConversationState {
   private Speculation speculation;
   private long nDrafted;
   private long nAccepted;
+  // Rolling accept rate driving the adaptive per-round draft budget (getNDraft). Starts
+  // optimistic so the first rounds draft at the configured maximum.
+  private static final double EWMA_ALPHA = 0.3;
+  private double ewmaAcceptRate = 1.0;
+  // Deferred draft-KV fill from a full-accept round (model-draft flavour); -1 = none.
+  private int pendingDraftFillToken = -1;
+  private int pendingDraftFillPos;
 
   // N-gram (prompt-lookup) drafting history + position index (the committed token stream
   // prompt+generated, on the heap, NOT the confined arena). Built lazily by setNgram().
@@ -412,8 +419,22 @@ public class ConversationState {
     return draftContext;
   }
 
+  /**
+   * Tokens to draft this round. Fixed configs always return the configured {@code nDraft}.
+   * Adaptive configs ({@code pMin > 0}) additionally scale the per-round budget with the
+   * recent accept rate (EWMA): a draft that keeps getting rejected wastes its decodes past
+   * the first position, so the budget shrinks toward {@code draftMin} and recovers as
+   * accepts return. Verify-batch capacity is sized off the configured maximum, so the
+   * dynamic value is always safe.
+   */
   public int getNDraft() {
-    return speculativeConfig.nDraft();
+    int max = speculativeConfig.nDraft();
+    if (!speculativeConfig.isAdaptive()) {
+      return max;
+    }
+    int min = speculativeConfig.draftMin();
+    int k = (int) Math.round(min + ewmaAcceptRate * (max - min));
+    return Math.max(min, Math.min(max, k));
   }
 
   public Speculation getSpeculation() {
@@ -455,10 +476,38 @@ public class ConversationState {
     return ngramIndex.propose(kMax);
   }
 
-  /** Accumulates speculative accept statistics for {@link #acceptRate()}. */
+  /** Accumulates speculative accept statistics for {@link #acceptRate()} and {@link #getNDraft()}. */
   public void recordSpeculation(int drafted, int accepted) {
     this.nDrafted += drafted;
     this.nAccepted += accepted;
+    if (drafted > 0) {
+      ewmaAcceptRate =
+        (1 - EWMA_ALPHA) * ewmaAcceptRate +
+        EWMA_ALPHA * ((double) accepted / drafted);
+    }
+  }
+
+  /* ----- deferred draft-KV fill (model-draft flavour, see ModelDraftSpeculativeDecoding) ----- */
+
+  public boolean hasPendingDraftFill() {
+    return pendingDraftFillToken != -1;
+  }
+
+  public int pendingDraftFillToken() {
+    return pendingDraftFillToken;
+  }
+
+  public int pendingDraftFillPos() {
+    return pendingDraftFillPos;
+  }
+
+  public void setPendingDraftFill(int token, int pos) {
+    this.pendingDraftFillToken = token;
+    this.pendingDraftFillPos = pos;
+  }
+
+  public void clearPendingDraftFill() {
+    this.pendingDraftFillToken = -1;
   }
 
   /** Fraction of drafted tokens accepted so far — a sanity check on the speedup. */

--- a/src/main/java/io/gravitee/llama/cpp/LlamaTokenDataArray.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaTokenDataArray.java
@@ -58,11 +58,23 @@ public final class LlamaTokenDataArray {
   private final int nVocab;
   private final MemorySegment data; // n_vocab * llama_token_data
   private final MemorySegment array; // the llama_token_data_array header
+  // Pristine candidate image (ids ascending, logit 0, p 0). fill() restores it with one bulk
+  // copy instead of three per-element writes; a sorting/truncating apply() can then never leak
+  // stale ids or probs into the next fill.
+  private final MemorySegment template;
 
   public LlamaTokenDataArray(SegmentAllocator allocator, int nVocab) {
     this.nVocab = nVocab;
     this.data = allocator.allocate(TD_SIZE * nVocab, 4);
     this.array = allocator.allocate(ARR_SIZE, 8);
+    this.template = allocator.allocate(TD_SIZE * nVocab, 4);
+    for (int id = 0; id < nVocab; id++) {
+      template.set(
+        ValueLayout.JAVA_INT,
+        (long) id * TD_SIZE + TD_ID_OFFSET,
+        id
+      );
+    }
     array.set(ValueLayout.ADDRESS, ARR_DATA_OFFSET, data);
     array.set(ValueLayout.JAVA_LONG, ARR_SIZE_OFFSET, nVocab);
   }
@@ -75,12 +87,13 @@ public final class LlamaTokenDataArray {
    * @param rowOffset  Float offset into {@code logits} where the row begins
    */
   public void fill(MemorySegment logits, long rowOffset) {
+    data.copyFrom(template);
     for (int id = 0; id < nVocab; id++) {
-      long base = (long) id * TD_SIZE;
-      float logit = logits.getAtIndex(ValueLayout.JAVA_FLOAT, rowOffset + id);
-      data.set(ValueLayout.JAVA_INT, base + TD_ID_OFFSET, id);
-      data.set(ValueLayout.JAVA_FLOAT, base + TD_LOGIT_OFFSET, logit);
-      data.set(ValueLayout.JAVA_FLOAT, base + TD_P_OFFSET, 0.0f);
+      data.set(
+        ValueLayout.JAVA_FLOAT,
+        (long) id * TD_SIZE + TD_LOGIT_OFFSET,
+        logits.getAtIndex(ValueLayout.JAVA_FLOAT, rowOffset + id)
+      );
     }
     array.set(ValueLayout.JAVA_LONG, ARR_SIZE_OFFSET, nVocab);
     array.set(ValueLayout.JAVA_LONG, ARR_SELECTED_OFFSET, -1L);

--- a/src/main/java/io/gravitee/llama/cpp/Main.java
+++ b/src/main/java/io/gravitee/llama/cpp/Main.java
@@ -434,15 +434,28 @@ public class Main {
       // native gen-speed counter (single-token n_eval) can't see batch-verified tokens, and the
       // target context's timers exclude the draft model — so emitted/wall-clock is the honest rate.
       int[] emitted = { 0 };
+      long[] firstTokenNs = { 0 };
       long genStartNs = System.nanoTime();
       var answer = iterator
         .stream()
-        .peek(o -> emitted[0] += o.numberOfTokens())
+        .peek(o -> {
+          if (firstTokenNs[0] == 0) {
+            firstTokenNs[0] = System.nanoTime();
+          }
+          emitted[0] += o.numberOfTokens();
+        })
         .map(LlamaOutput::content)
         .peek(System.out::print)
         .reduce((a, b) -> a + b)
         .orElse("");
-      double genWallSec = (System.nanoTime() - genStartNs) / 1_000_000_000.0;
+      long genEndNs = System.nanoTime();
+      double genWallSec = (genEndNs - genStartNs) / 1_000_000_000.0;
+      // Decode-only window: first emitted token → end. The first token's own latency carries
+      // the prompt eval, so it anchors the window rather than counting toward it.
+      double decodeWallSec = firstTokenNs[0] == 0
+        ? 0.0
+        : (genEndNs - firstTokenNs[0]) / 1_000_000_000.0;
+      int decodeTokens = Math.max(0, emitted[0] - 1);
 
       if (LlamaLogLevel.DEBUG.equals(logLevel)) {
         if (reasoningTags.isConfigured()) {
@@ -492,12 +505,17 @@ public class Main {
             state.acceptRate()
           );
         }
-        // Speculation-correct rate: emitted tokens over wall-clock (captures draft + target time).
-        // Compare this line across --draft vs no-draft runs; the native gen-speed above is invalid
-        // under speculation. Includes prompt time, so use a short prompt or large --quota to compare.
+        // Speculation-correct rates: emitted tokens over wall-clock (captures draft + target
+        // time — the native gen-speed above is invalid under speculation). The first line
+        // includes prompt eval; the second starts at the first emitted token, so it is the one
+        // to compare across --draft vs no-draft runs regardless of prompt length.
         System.out.printf(
-          "Effective generation: %.2f tokens/sec%n",
+          "Effective generation (incl. prompt): %.2f tokens/sec%n",
           genWallSec > 0 ? emitted[0] / genWallSec : 0.0
+        );
+        System.out.printf(
+          "Effective decode: %.2f tokens/sec%n",
+          decodeWallSec > 0 ? decodeTokens / decodeWallSec : 0.0
         );
         System.out.println("===================");
       }

--- a/src/main/java/io/gravitee/llama/cpp/speculative/ModelDraftSpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/ModelDraftSpeculativeDecoding.java
@@ -49,6 +49,7 @@ public final class ModelDraftSpeculativeDecoding extends SpeculativeDecoding {
     int total = tokenized.size();
     int nBatch = Math.max(1, draft.nBatch());
     int seqId = state.getSequenceId();
+    state.clearPendingDraftFill(); // a fresh prompt replay invalidates any deferred fill
     draft.getMemory().seqRm(seqId, -1, -1);
     int offset = 0;
     while (offset < total) {
@@ -101,6 +102,17 @@ public final class ModelDraftSpeculativeDecoding extends SpeculativeDecoding {
     int prev = idLast;
     for (int i = 0; i < kMax; i++) {
       draftBatch.clear();
+      // Piggy-back the deferred fill from the previous round's full accept (see below) onto
+      // this round's first draft decode — one dispatch instead of two.
+      if (i == 0 && state.hasPendingDraftFill()) {
+        draftBatch.add(
+          state.pendingDraftFillToken(),
+          state.pendingDraftFillPos(),
+          seq,
+          false
+        );
+        state.clearPendingDraftFill();
+      }
       draftBatch.add(prev, nPast + i, seq, true);
       if (draftBatch.decode(draft) != 0) {
         throw new LlamaException("Speculative draft decode failed");
@@ -142,16 +154,14 @@ public final class ModelDraftSpeculativeDecoding extends SpeculativeDecoding {
     target.getMemory().seqRm(seqId, newNPast, -1);
     draft.getMemory().seqRm(seqId, newNPast, -1);
 
-    // Fill decode, only on full accept: advance the draft KV by one so it covers position
-    // nPast+m for next round (no gap). On partial accept the seqRm above already trimmed the
-    // draft past nPast+matched, so a fill would be discarded — skipping it saves a draft
-    // forward pass. The sampled token is discarded.
+    // Fill, only on full accept: the draft KV must eventually cover position nPast+m (token
+    // drafted[m-1]) so there is no gap before next round's drafting. Instead of a dedicated
+    // decode here, defer it into the next round's first draft batch (one dispatch instead of
+    // two). On partial accept the seqRm above already trimmed the draft past nPast+matched,
+    // so no fill is needed. If the conversation finishes on this round the pending fill is
+    // simply never consumed.
     if (v.matched() == m) {
-      draftBatch.clear();
-      draftBatch.add(prev, nPast + m, seq, true);
-      if (draftBatch.decode(draft) != 0) {
-        throw new LlamaException("Speculative draft decode failed");
-      }
+      state.setPendingDraftFill(prev, nPast + m);
     }
 
     List<LlamaOutput> out = emitCommitted(it, state, drafted, v);

--- a/src/main/java/io/gravitee/llama/cpp/speculative/Speculation.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/Speculation.java
@@ -126,10 +126,14 @@ public final class Speculation {
     return s;
   }
 
-  /** Persistent single-token draft batch (reused via {@code clear()}). */
+  /**
+   * Persistent draft batch (reused via {@code clear()}). Capacity 2: the first draft decode of
+   * a round may carry a deferred KV fill row from the previous round's full accept alongside
+   * the drafted token (see {@link ModelDraftSpeculativeDecoding}).
+   */
   public LlamaBatch draftBatch() {
     if (draftBatch == null) {
-      draftBatch = new LlamaBatch(arena, 1, 0, 1);
+      draftBatch = new LlamaBatch(arena, 2, 0, 1);
     }
     return draftBatch;
   }
@@ -183,9 +187,16 @@ public final class Speculation {
         argmax = id;
       }
     }
+    // Logits more than 17 nats below the max contribute < nVocab * e^-17 (~1e-2 even at a
+    // 150k vocab) to the softmax denominator — skip their Math.exp entirely. The confidence
+    // only gates the pMin early-stop, so this bounded underestimate of sum is harmless.
+    float cutoff = maxLogit - 17.0f;
     double sum = 0.0;
     for (int id = 0; id < nVocab; id++) {
-      sum += Math.exp(logitsRow.getAtIndex(JAVA_FLOAT, id) - maxLogit);
+      float l = logitsRow.getAtIndex(JAVA_FLOAT, id);
+      if (l > cutoff) {
+        sum += Math.exp(l - maxLogit);
+      }
     }
     probOut[0] = (float) (1.0 / sum); // exp(maxLogit-maxLogit)=1, so the top prob is 1/sum
     return argmax;


### PR DESCRIPTION
Four micro-optimizations on the speculative hot path plus an honest
`--perf` metric, with benchmark tables added to the docs. Output remains lossless (greedy) /
exact (sampling) — none of these change which tokens are emitted.

## Changes

### Deferred draft-KV gap-fill (one dispatch instead of two)
On a full accept, model drafting previously issued a dedicated draft decode just to fill the
draft KV at the bonus position. That fill row is now deferred and piggy-backed onto the next
round's first draft decode (`Speculation.draftBatch()` capacity 1 → 2), saving one draft
dispatch per full-accept round — the rounds that occur most at high accept rates. Pending
fill state lives on `ConversationState`; it is invalidated by a prompt replay and simply
never consumed if the conversation finishes.

### EWMA-adaptive per-round draft budget
`getNDraft()` now scales the per-round draft window between `draftMin` and `nDraft` by a
rolling (EWMA, α=0.3) accept rate when adaptive mode is on — a drafter that keeps getting
rejected stops wasting decodes past the first positions, and the budget recovers as accepts
return. Complements the existing `pMin` confidence early-stop (which reacts within a round;
this reacts across rounds). Starts optimistic so first rounds draft at the configured max;
verify-batch capacity is still sized off the configured max, so the dynamic value is always
safe.

### `LlamaTokenDataArray.fill()` via pristine template
The candidate buffer is reset with one bulk `copyFrom` of a pre-built template (ids
ascending, p=0) plus logit-only writes, replacing three per-element writes across the vocab.
This also guarantees a sorting/truncating `apply()` can never leak stale ids/probs into the
next fill.

### Softmax cutoff in `draftGreedyConfident`
Logits more than 17 nats below the max contribute negligibly to the softmax denominator —
their `Math.exp` calls are skipped. The confidence only gates the `pMin` early-stop, so the
bounded underestimate is harmless.

### Honest `--perf` timing
`Effective decode` is now measured from the first emitted token (excludes prompt processing),
making it comparable across runs with different prompt lengths.

## Benchmarks

Added a benchmark section to `docs/speculative-decoding/README.md` (Apple M4 Max, bundled
CLI, `Effective decode`): MTP ~1.34× on a MoE target with no compatible small draft; on a
dense 14B, EAGLE3 1.46–1.53× and a 0.6B model draft with `p_min` 0.6 winning at 1.59× —
the cheap-draft-decent-accept formula. Full tables and takeaways in the docs.