### PR TITLE
fix: seed state from prompt suffix

### DIFF
--- a/src/main/java/io/gravitee/llama/cpp/ConversationState.java
+++ b/src/main/java/io/gravitee/llama/cpp/ConversationState.java
@@ -175,7 +175,7 @@ public class ConversationState {
     this.promptText = prompt;
     this.tokenTracking.initialize(tokenized.size());
     this.stateEvaluation.initialize(new StateEvaluation.Config(stateBounds));
-    this.generationState = ANSWER;
+    this.generationState = stateEvaluation.initialState(prompt);
     this.finishReason = null;
     this.newTokenId = null;
     this.piece = null;

--- a/src/main/java/io/gravitee/llama/cpp/modules/StateEvaluation.java
+++ b/src/main/java/io/gravitee/llama/cpp/modules/StateEvaluation.java
@@ -85,10 +85,29 @@ public class StateEvaluation
       .stream()
       .filter(not(e -> this.stateAlreadyOccurred(e.getValue())))
       .map(Entry::getValue)
-      .filter(
-        stateBounds ->
-          isNullOrBlank(stateBounds) || stateBounds.start().equals(piece)
-      )
+      .filter(not(StateEvaluation::isNullOrBlank))
+      .filter(stateBounds -> stateBounds.start().equals(piece))
+      .map(StateBounds::state)
+      .findFirst()
+      .orElse(GenerationState.ANSWER);
+  }
+
+  /**
+   * Resolves the state generation should start in for the given prompt.
+   * Chat templates may pre-fill a state's open tag at the end of the prompt
+   * (e.g. a template ending with {@code <think>}), in which case the model
+   * never emits the tag itself and generation must begin inside that state.
+   */
+  public GenerationState initialState(String prompt) {
+    if (!isInitialized() || prompt == null) {
+      return GenerationState.ANSWER;
+    }
+    var trimmed = prompt.stripTrailing();
+    return states
+      .values()
+      .stream()
+      .filter(not(StateEvaluation::isNullOrBlank))
+      .filter(stateBounds -> trimmed.endsWith(stateBounds.start()))
       .map(StateBounds::state)
       .findFirst()
       .orElse(GenerationState.ANSWER);

--- a/src/test/java/io/gravitee/llama/cpp/modules/StateEvaluationTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/modules/StateEvaluationTest.java
@@ -96,48 +96,69 @@ class StateEvaluationTest {
   }
 
   @Test
-  void blank_start_tools_enters_on_first_piece() {
-    var eval = of(new StateBounds(TOOLS, "", "<|eom_id|>"));
-
-    assertThat(step(eval, ANSWER, "{\"name\"")).isEqualTo(TOOLS);
-    assertThat(step(eval, TOOLS, ":\"get_weather\"")).isEqualTo(TOOLS);
-    assertThat(step(eval, TOOLS, "<|eom_id|>")).isEqualTo(ANSWER);
-  }
-
-  @Test
-  void null_start_tools_enters_on_first_piece_without_throwing() {
-    var eval = of(new StateBounds(TOOLS, null, "<|eom_id|>"));
-
-    assertThat(step(eval, ANSWER, "{\"name\"")).isEqualTo(TOOLS);
-    assertThat(step(eval, TOOLS, "<|eom_id|>")).isEqualTo(ANSWER);
-  }
-
-  @Test
-  void blank_start_tools_reenters_after_end() {
-    var eval = of(new StateBounds(TOOLS, "", "<|eom_id|>"));
-
-    step(eval, ANSWER, "{\"a\"");
-    step(eval, TOOLS, "<|eom_id|>");
-    assertThat(step(eval, ANSWER, "next")).isEqualTo(TOOLS);
-  }
-
-  @Test
-  void blank_start_reasoning_occurs_once_then_answers() {
+  void blank_start_bounds_never_match_a_generated_piece() {
     var eval = of(new StateBounds(REASONING, "", "</think>"));
 
-    assertThat(step(eval, ANSWER, "first")).isEqualTo(REASONING);
-    assertThat(step(eval, REASONING, "more")).isEqualTo(REASONING);
-    assertThat(step(eval, REASONING, "</think>")).isEqualTo(ANSWER);
-
-    assertThat(step(eval, ANSWER, "actual answer")).isEqualTo(ANSWER);
+    assertThat(step(eval, ANSWER, "first")).isEqualTo(ANSWER);
+    assertThat(step(eval, ANSWER, "more")).isEqualTo(ANSWER);
   }
 
   @Test
-  void blank_start_section_still_terminates_only_on_its_end_delimiter() {
-    var eval = of(new StateBounds(TOOLS, "", "<|eom_id|>"));
+  void null_start_bounds_never_match_a_generated_piece() {
+    var eval = of(new StateBounds(TOOLS, null, "<|eom_id|>"));
 
-    step(eval, ANSWER, "{");
-    assertThat(step(eval, TOOLS, "<|eot_id|>")).isEqualTo(TOOLS);
-    assertThat(step(eval, TOOLS, "<|eom_id|>")).isEqualTo(ANSWER);
+    assertThat(step(eval, ANSWER, "{\"name\"")).isEqualTo(ANSWER);
+  }
+
+  @Test
+  void initial_state_is_answer_when_prompt_lacks_open_tag() {
+    var eval = of(new StateBounds(REASONING, "<think>", "</think>"));
+
+    assertThat(eval.initialState("<|im_start|>assistant\n")).isEqualTo(ANSWER);
+  }
+
+  @Test
+  void initial_state_enters_reasoning_when_prompt_ends_with_open_tag() {
+    var eval = of(new StateBounds(REASONING, "<think>", "</think>"));
+
+    assertThat(eval.initialState("<|im_start|>assistant\n<think>")).isEqualTo(
+      REASONING
+    );
+  }
+
+  @Test
+  void initial_state_ignores_trailing_whitespace_after_open_tag() {
+    var eval = of(new StateBounds(REASONING, "<think>", "</think>"));
+
+    assertThat(
+      eval.initialState("<|im_start|>assistant\n<think>\n\n")
+    ).isEqualTo(REASONING);
+  }
+
+  @Test
+  void initial_state_ignores_blank_start_bounds() {
+    var eval = of(new StateBounds(REASONING, "", "</think>"));
+
+    assertThat(eval.initialState("any prompt at all")).isEqualTo(ANSWER);
+  }
+
+  @Test
+  void initial_state_is_answer_when_uninitialized_or_null_prompt() {
+    var uninitialized = new StateEvaluation();
+    assertThat(uninitialized.initialState("prompt<think>")).isEqualTo(ANSWER);
+
+    var eval = of(new StateBounds(REASONING, "<think>", "</think>"));
+    assertThat(eval.initialState(null)).isEqualTo(ANSWER);
+  }
+
+  @Test
+  void seeded_reasoning_exits_on_end_tag_and_does_not_reenter() {
+    var eval = of(new StateBounds(REASONING, "<think>", "</think>"));
+    var state = eval.initialState("prompt ending with <think>\n");
+    assertThat(state).isEqualTo(REASONING);
+
+    assertThat(step(eval, state, "pondering")).isEqualTo(REASONING);
+    assertThat(step(eval, REASONING, "</think>")).isEqualTo(ANSWER);
+    assertThat(step(eval, ANSWER, "<think>")).isEqualTo(ANSWER);
   }
 }


### PR DESCRIPTION
### Problem

#114 made the reasoning open tag optional by letting a StateBounds with a null/blank start match any first generated piece. This handled templates that pre-fill <think> at the end of the prompt (so the model never emits the tag itself), but the match was unconditional:

- Every conversation configured with a blank start tag entered REASONING immediately, even when the template didn't force thinking (e.g. thinking disabled, non-reasoning turn).
- For TOOLS, a blank start caused re-entry into the tool state on the very next piece after the end tag.

### Fix

Instead of matching on generated pieces, detect the pre-filled tag where it actually lives: at the end of the prompt.

- StateEvaluation.initialState(prompt) (new): strips trailing whitespace and returns the state whose open tag the prompt ends with (...<think> or ...<think>\n\n → REASONING), else ANSWER. Null/blank start tags are ignored.
- ConversationState.initialize(prompt) now seeds generationState from initialState(prompt) instead of hardcoding ANSWER. Exiting a seeded state reuses the existing detectEndState path, including the occurred-once bookkeeping for REASONING.
- detectNewState no longer treats null/blank start tags as match-anything — such bounds are now inert during generation.

Matching stays literal (endsWith/equals, no regex): tags are fixed strings from config, and several contain regex metacharacters (<|eom_id|>).

Tests

Replaced the blank-start tests in StateEvaluationTest (which encoded the old unconditional behavior) with coverage for: prompt-suffix seeding with and without trailing whitespace, blank/null starts never matching pieces or seeding, uninitialized/null-prompt fallback, and the full lifecycle of a seeded reasoning state (exits on </thi
