### PR TITLE
feat: cross-request KV prefix reuse, MTP prefill fixes, and channel-aware tag matching

### DIFF
--- a/src/main/java/io/gravitee/llama/cpp/BatchIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/BatchIterator.java
@@ -150,35 +150,40 @@ public final class BatchIterator
 
     currentOutputs.clear();
 
-    // Prepare states: clean up finished ones, process prompts for new ones, and collect active states.
-    List<ConversationState> activeStates = prepareActiveStates();
+    // A step may emit nothing while every active sequence is buffering a multi-token marker
+    // prefix; keep stepping until something is emitted or no sequences remain (each step
+    // commits >= 1 token per active sequence, so this terminates).
+    while (currentOutputs.isEmpty()) {
+      // Prepare states: clean up finished ones, process prompts for new ones, and collect active states.
+      List<ConversationState> activeStates = prepareActiveStates();
 
-    // If we just emitted the first tokens from prompt processing, return them immediately.
-    // This ensures a responsive start for each conversation.
-    if (!currentOutputs.isEmpty()) {
-      return true;
+      // If we just emitted the first tokens from prompt processing, return them immediately.
+      // This ensures a responsive start for each conversation.
+      if (!currentOutputs.isEmpty()) {
+        return true;
+      }
+
+      // If there are no more active conversations, we are done.
+      if (activeStates.isEmpty()) {
+        return false;
+      }
+
+      // Speculative states verify together in ONE target decode (fused); non-speculative states
+      // use the normal fused single-token batch.
+      List<ConversationState> speculative = new ArrayList<>();
+      List<ConversationState> normal = new ArrayList<>();
+      for (ConversationState state : activeStates) {
+        (state.isSpeculative() ? speculative : normal).add(state);
+      }
+      if (!speculative.isEmpty()) {
+        speculativeFusedStep(speculative);
+      }
+      if (!normal.isEmpty()) {
+        processInBatches(normal);
+      }
     }
 
-    // If there are no more active conversations, we are done.
-    if (activeStates.isEmpty()) {
-      return false;
-    }
-
-    // Speculative states verify together in ONE target decode (fused); non-speculative states
-    // use the normal fused single-token batch.
-    List<ConversationState> speculative = new ArrayList<>();
-    List<ConversationState> normal = new ArrayList<>();
-    for (ConversationState state : activeStates) {
-      (state.isSpeculative() ? speculative : normal).add(state);
-    }
-    if (!speculative.isEmpty()) {
-      speculativeFusedStep(speculative);
-    }
-    if (!normal.isEmpty()) {
-      processInBatches(normal);
-    }
-
-    return !currentOutputs.isEmpty();
+    return true;
   }
 
   /**
@@ -766,6 +771,15 @@ public final class BatchIterator
       s.appendHistory(extra);
     }
 
+    // Committed-token history: the rows surviving the rollback are idLast (still in
+    // s.getNewTokenId() until below) + the accepted drafts — keeps history.size() == nPast.
+    var history = s.getTokenHistory();
+    history.truncate(s.getNPast());
+    history.append(s.getNewTokenId());
+    for (int i = 0; i < matched; i++) {
+      history.append(drafted[i]);
+    }
+
     s.setNPast(newNPast);
     s.setNewTokenId(extra);
     s.recordSpeculation(m, matched);
@@ -845,7 +859,19 @@ public final class BatchIterator
 
       // If the state is new, process its prompt to get the first token.
       if (state.getNewTokenId() == null) {
-        processPromptForState(state);
+        try {
+          processPromptForState(state);
+        } catch (LlamaException e) {
+          // A failed prompt decode is terminal for THIS state. Without this the state would
+          // stay in the map with newTokenId == null and every batch() call would retry the
+          // doomed prefill forever (observed as a hot error loop). Fail the sequence, force
+          // a full KV wipe (its cache is suspect), and keep serving the others.
+          state.setFinishReason(FinishReason.STOP);
+          state.setFinished(true);
+          cleanupState(state, false);
+          it.remove();
+          throw e;
+        }
         // If prompt processing immediately results in a finish condition, clean up.
         if (state.getFinishReason() != null) {
           cleanupState(state);
@@ -856,17 +882,20 @@ public final class BatchIterator
 
       activeStates.add(state);
 
-      // If the first token for this state hasn't been emitted yet, add it to the output queue.
+      // If the first token for this state hasn't been emitted yet, add it to the output queue
+      // (unless it is buffered as a multi-token marker prefix — then there is nothing to emit).
       if (!firstTokenEmitted.get(state.getSequenceId())) {
-        currentOutputs.add(
-          new LlamaOutput(
-            state.getPiece(),
-            1,
-            state.getSequenceId(),
-            null,
-            state.getLogprobs()
-          )
-        );
+        if (state.getPiece() != null && !state.getPiece().isEmpty()) {
+          currentOutputs.add(
+            new LlamaOutput(
+              state.getPiece(),
+              state.getPieceTokens(),
+              state.getSequenceId(),
+              null,
+              state.getLogprobs()
+            )
+          );
+        }
         firstTokenEmitted.put(state.getSequenceId(), true);
       }
     }
@@ -932,6 +961,9 @@ public final class BatchIterator
    * @param state The conversation state to process.
    */
   private void sampleAndProcessNextToken(ConversationState state) {
+    // The token just decoded at position nPast (decodeBatch added state.getNewTokenId()); it
+    // enters the committed history when nPast is incremented below.
+    int decodedToken = state.getNewTokenId();
     int batchPos = seqIdToBatchPos.get(state.getSequenceId());
     int newToken = state.getSampler().sample(context, batchPos);
     String tokenPiece = decodeTokenPiece(state, newToken);
@@ -939,38 +971,48 @@ public final class BatchIterator
     // Collect logprobs before processing (logits are invalidated after next decode).
     Logprobs logprobs = collectLogprobs(state, newToken, batchPos);
 
-    processSampledToken(state, tokenPiece);
-
-    // Check if the generation should continue for this state.
-    if (!shouldContinue(state, newToken)) {
-      if (state.getTokenizer().isEog(newToken)) {
-        // Decrement token count for EOG token, as it's not part of the generated content.
-        state
-          .getTokenTracking()
-          .consume(
-            new io.gravitee.llama.cpp.modules.TokenTracking.Context(
-              state.getGenerationState(),
-              -1
-            )
-          );
+    // End-of-generation: the EOG token is neither processed nor counted, but a buffered
+    // multi-token marker prefix (if any) is flushed to the current channel.
+    if (state.getTokenizer().isEog(newToken)) {
+      if (state.getFinishReason() != FinishReason.TOOL_CALL) {
+        state.setFinishReason(FinishReason.STOP);
       }
+      state.setFinished(true);
+      flushPendingMarker(state, currentOutputs);
       return;
     }
 
-    // Update the state with the new token and add it to the output queue.
+    var emission = processSampledToken(state, newToken, tokenPiece);
+
+    // Check token limit — LENGTH always overrides, even TOOL_CALL
+    int maxTokens = state.getMaxTokens();
+    if (maxTokens != -1 && maxTokens <= state.getAnswerTokens()) {
+      state.setFinishReason(FinishReason.LENGTH);
+      state.setFinished(true);
+      return;
+    }
+
+    // Update the state with the new token and add it to the output queue (nothing is queued
+    // while a multi-token marker prefix is buffered).
     state.setNewTokenId(newToken);
-    state.setPiece(tokenPiece);
+    state.setPiece(emission.emit());
+    state.setPieceTokens(emission.emitTokens());
     state.setLogprobs(logprobs);
     state.incrementNPast();
-    currentOutputs.add(
-      new LlamaOutput(
-        state.getPiece(),
-        1,
-        state.getSequenceId(),
-        null,
-        logprobs
-      )
-    );
+    state.getTokenHistory().append(decodedToken);
+    // Nothing is queued while a marker prefix is buffered, and a confirmed marker's text is
+    // suppressed (empty emit with emitTokens > 0 — counted, never streamed).
+    if (!emission.emit().isEmpty()) {
+      currentOutputs.add(
+        new LlamaOutput(
+          emission.emit(),
+          emission.emitTokens(),
+          state.getSequenceId(),
+          null,
+          logprobs
+        )
+      );
+    }
   }
 
   /**
@@ -981,7 +1023,8 @@ public final class BatchIterator
   private void handleDecodeError(List<ConversationState> batchStates) {
     for (ConversationState state : batchStates) {
       state.setFinishReason(FinishReason.STOP);
-      cleanupState(state);
+      // Decode error: the cache contents are suspect — always full-wipe.
+      cleanupState(state, false);
     }
     seqIdToState.clear();
   }
@@ -994,9 +1037,24 @@ public final class BatchIterator
    * @return true if the sequence was removed, false if not found
    */
   public boolean removeState(int sequenceId) {
+    return removeState(sequenceId, false);
+  }
+
+  /**
+   * Removes a specific conversation state, optionally keeping its KV cache resident for a later
+   * prefix-reuse initialization on the same sequence id.
+   *
+   * <p>{@code keepKv == true} skips the KV wipe; {@code keepKv == false} forces the wipe even
+   * when the state was marked {@link ConversationState#setRetainKv(boolean) retainKv}.
+   *
+   * @param sequenceId The sequence ID to remove
+   * @param keepKv     Whether to keep the sequence's KV cache resident
+   * @return true if the sequence was removed, false if not found
+   */
+  public boolean removeState(int sequenceId, boolean keepKv) {
     ConversationState state = seqIdToState.remove(sequenceId);
     if (state != null) {
-      cleanupState(state);
+      cleanupState(state, keepKv);
       return true;
     }
     return false;
@@ -1025,8 +1083,8 @@ public final class BatchIterator
 
     stopped = true;
 
-    // Clean up all remaining sequences from KV cache
-    seqIdToState.values().forEach(state -> cleanupState(state));
+    // Clean up all remaining sequences from KV cache (teardown: always full-wipe)
+    seqIdToState.values().forEach(state -> cleanupState(state, false));
 
     seqIdToState.clear();
     firstTokenEmitted.clear();
@@ -1094,9 +1152,22 @@ public final class BatchIterator
     free();
   }
 
+  /**
+   * Internal cleanup honoring the state's {@link ConversationState#isRetainKv() retainKv} flag:
+   * natural completion (finished states, immediate prompt finish, onFinished) retains the KV
+   * when the state was marked. Teardown paths that invalidate the cache ({@link #stop()},
+   * decode errors) and explicit {@code removeState(id, false)} force the wipe instead via
+   * {@link #cleanupState(ConversationState, boolean)}.
+   */
   private void cleanupState(ConversationState state) {
+    cleanupState(state, state.isRetainKv());
+  }
+
+  private void cleanupState(ConversationState state, boolean keepKv) {
     int sequenceId = state.getSequenceId();
-    context.getMemory().seqRm(sequenceId, -1, -1);
+    if (!keepKv) {
+      context.getMemory().seqRm(sequenceId, -1, -1);
+    }
     // Free the speculative state's persistent native scratch (idempotent: null-on-free, so the
     // common path of removal-then-stop never double-frees). Non-speculative states have none.
     if (state.isSpeculative()) {

--- a/src/main/java/io/gravitee/llama/cpp/ConversationState.java
+++ b/src/main/java/io/gravitee/llama/cpp/ConversationState.java
@@ -25,6 +25,7 @@ import io.gravitee.llama.cpp.draft.NgramIndex;
 import io.gravitee.llama.cpp.modules.PromptMemory;
 import io.gravitee.llama.cpp.modules.StateEvaluation;
 import io.gravitee.llama.cpp.modules.StopString;
+import io.gravitee.llama.cpp.modules.TokenHistory;
 import io.gravitee.llama.cpp.modules.TokenTracking;
 import io.gravitee.llama.cpp.speculative.*;
 import io.gravitee.llama.cpp.utils.Utf8Decoder;
@@ -48,6 +49,21 @@ public class ConversationState {
   private final int sequenceId;
   private int nPast = 0;
   private String promptText;
+
+  // KV prefix reuse: how many leading prompt tokens' KV rows are reused from a previous
+  // generation on this sequence (processPrompt then only decodes the suffix), and whether the
+  // sequence's KV should be retained (not wiped) when this state finishes / is cleaned up.
+  private int reusePrefixTokens = 0;
+  private boolean retainKv = false;
+  // Whether the requested prefix reuse was actually honored by the memory backend. Set to
+  // false when processPrompt's partial seq_rm is rejected (recurrent/hybrid models whose
+  // rollback-snapshot window n_rs_seq cannot cover the required rewind) and a cold full
+  // prefill is performed instead.
+  private boolean prefixReuseHonored = true;
+
+  // Committed-token history: token ids whose KV rows are resident, positions [0, nPast).
+  // history.size() == nPast at all stable points (see TokenHistory).
+  private final TokenHistory tokenHistory = new TokenHistory();
 
   // Tokenization
   private TokenizerResponse tokenized;
@@ -101,6 +117,9 @@ public class ConversationState {
   // Iteration state (used by iterator)
   Integer newTokenId;
   String piece;
+  // Number of generated tokens the current `piece` covers: 1 normally, 0 while a multi-token
+  // marker prefix is buffered (empty piece), N when a buffered marker resolves.
+  int pieceTokens = 1;
   Logprobs logprobs;
 
   private ConversationState(
@@ -171,7 +190,50 @@ public class ConversationState {
    * @return This state for chaining
    */
   public ConversationState initialize(String prompt) {
+    return initialize(prompt, 0);
+  }
+
+  /**
+   * Initializes this conversation with a prompt, reusing the KV rows of the first
+   * {@code reusePrefixTokens} prompt tokens already resident for this sequence (from a previous
+   * generation retained via {@link #setRetainKv(boolean)} / {@code removeState(id, true)}).
+   * {@code processPrompt} then wipes the sequence's KV from {@code reusePrefixTokens} on and
+   * decodes only the prompt suffix at absolute positions.
+   *
+   * <p>{@code reusePrefixTokens} must be within {@code [0, tokenized.size()]}; a value equal to
+   * the full prompt length is clamped to {@code size - 1}: the last prompt token must be
+   * re-decoded to produce logits — its KV row gets trimmed and rewritten identically.
+   *
+   * <p>The committed-token history restarts as the FULL new tokenized prompt (all of it becomes
+   * KV-resident once prefill completes).
+   *
+   * @param prompt            The prompt text
+   * @param reusePrefixTokens Number of leading prompt tokens whose KV rows are reused
+   * @return This state for chaining
+   */
+  public ConversationState initialize(String prompt, int reusePrefixTokens) {
     this.tokenized = tokenizer.tokenize(arena, prompt);
+    int size = tokenized.size();
+    if (reusePrefixTokens < 0 || reusePrefixTokens > size) {
+      throw new LlamaException(
+        "reusePrefixTokens (" +
+          reusePrefixTokens +
+          ") must be within [0, " +
+          size +
+          "] (the tokenized prompt length)"
+      );
+    }
+    if (reusePrefixTokens == size && size > 0) {
+      // Clamp: the last prompt token is always re-decoded to produce logits.
+      reusePrefixTokens = size - 1;
+    }
+    this.reusePrefixTokens = reusePrefixTokens;
+    this.prefixReuseHonored = true;
+    int[] promptTokens = new int[size];
+    for (int i = 0; i < size; i++) {
+      promptTokens[i] = tokenized.data().getAtIndex(JAVA_INT, i);
+    }
+    this.tokenHistory.initialize(promptTokens);
     this.promptText = prompt;
     this.tokenTracking.initialize(tokenized.size());
     this.stateEvaluation.initialize(new StateEvaluation.Config(stateBounds));
@@ -179,6 +241,7 @@ public class ConversationState {
     this.finishReason = null;
     this.newTokenId = null;
     this.piece = null;
+    this.pieceTokens = 1;
     this.logprobs = null;
     this.nPast = 0;
     this.decoder.reset();
@@ -636,6 +699,64 @@ public class ConversationState {
     this.nPast++;
   }
 
+  /** Leading prompt tokens whose KV rows are reused by this initialization (see initialize). */
+  public int getReusePrefixTokens() {
+    return reusePrefixTokens;
+  }
+
+  /**
+   * Resets the reuse offset to 0. Called by the prefill when the memory backend rejects a
+   * partial trim (recurrent/hybrid models) and a cold full prefill is performed instead, so
+   * observers see the reuse that actually happened.
+   */
+  public void clearReusePrefixTokens() {
+    this.reusePrefixTokens = 0;
+    this.prefixReuseHonored = false;
+  }
+
+  /**
+   * Whether the prefix reuse requested via {@link #initialize(String, int)} was actually honored
+   * by the prefill. {@code false} means the memory backend rejected the partial trim — attention
+   * models never reject it, but recurrent/hybrid models (SSM, gated-deltanet: e.g. qwen3next,
+   * qwen3.5/3.6) can only rewind their recurrent state within the per-token snapshot window
+   * ({@code n_rs_seq}); a rewind farther back than that forces a cold full prefill and this
+   * returns {@code false}. Callers advertising prefix reuse (cross-request KV caches) should
+   * check this after prompt processing rather than trusting the requested reuse count.
+   */
+  public boolean isPrefixReuseHonored() {
+    return prefixReuseHonored;
+  }
+
+  /**
+   * When {@code true}, this sequence's KV cache is retained (not wiped) when the state finishes
+   * naturally or is cleaned up by its iterator — enabling a later
+   * {@code initialize(prompt, reusePrefixTokens)} on the same sequence id to reuse the resident
+   * prefix. Explicit {@code BatchIterator.removeState(id, false)}, {@code stop()} and
+   * decode-error teardown always wipe regardless.
+   */
+  public ConversationState setRetainKv(boolean retainKv) {
+    this.retainKv = retainKv;
+    return this;
+  }
+
+  public boolean isRetainKv() {
+    return retainKv;
+  }
+
+  /**
+   * Snapshot of the committed token ids — the tokens whose KV rows are resident for this
+   * sequence, positions {@code [0, nPast)}. Length {@code == nPast} at all stable points
+   * (text path; the multimodal path does not maintain the history).
+   */
+  public int[] committedTokens() {
+    return tokenHistory.toArray();
+  }
+
+  /** Internal: the committed-token history backing {@link #committedTokens()}. */
+  public TokenHistory getTokenHistory() {
+    return tokenHistory;
+  }
+
   public TokenizerResponse getTokenized() {
     return tokenized;
   }
@@ -707,6 +828,15 @@ public class ConversationState {
 
   public void setPiece(String piece) {
     this.piece = piece;
+  }
+
+  /** Number of generated tokens covered by the current {@link #getPiece() piece}. */
+  public int getPieceTokens() {
+    return pieceTokens;
+  }
+
+  public void setPieceTokens(int pieceTokens) {
+    this.pieceTokens = pieceTokens;
   }
 
   public Logprobs getLogprobs() {

--- a/src/main/java/io/gravitee/llama/cpp/DefaultLlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/DefaultLlamaIterator.java
@@ -52,6 +52,10 @@ public final class DefaultLlamaIterator
     if (currentState.isSpeculative()) {
       return speculativeBatch();
     }
+    if (currentState.isFinished()) {
+      // A previous step finished generation but emitted a final flushed marker prefix.
+      return false;
+    }
     var arena = currentState.getArena();
     var context = currentState.getContext();
     var sampler = currentState.getSampler();
@@ -92,8 +96,9 @@ public final class DefaultLlamaIterator
       return false;
     }
 
-    // After single token: increment nPast
+    // After single token: increment nPast — the decoded token's KV row is now resident.
     currentState.incrementNPast();
+    currentState.getTokenHistory().append(currentState.getNewTokenId());
 
     int newToken = sampler.sample(context);
     String tokenPiece = decodeTokenPiece(currentState, newToken);
@@ -101,19 +106,32 @@ public final class DefaultLlamaIterator
     // Collect logprobs before processing (logits are invalidated after next decode).
     Logprobs logprobs = collectLogprobs(currentState, newToken, -1);
 
-    // Process the sampled token using shared helper method
-    processSampledToken(currentState, tokenPiece);
-
     if (isEog(newToken)) {
-      incrementTokenCount(-1);
       batch.free();
+      currentState.setFinished(true);
+      // Generation ended while a multi-token marker prefix may still be buffered — flush it
+      // to the current channel as one final emission instead of dropping it.
+      var flush = currentState
+        .getStateEvaluation()
+        .flushPending(currentState.getGenerationState());
+      if (flush.emitTokens() > 0) {
+        incrementTokenCount(flush.emitTokens());
+        currentState.setPiece(flush.emit());
+        currentState.setPieceTokens(flush.emitTokens());
+        currentState.setLogprobs(null);
+        return true;
+      }
       return false;
     }
+
+    // Process the sampled token using shared helper method (token-sequence aware)
+    var emission = processSampledToken(currentState, newToken, tokenPiece);
 
     batch.free();
 
     currentState.setNewTokenId(newToken);
-    currentState.setPiece(tokenPiece);
+    currentState.setPiece(emission.emit());
+    currentState.setPieceTokens(emission.emitTokens());
     currentState.setLogprobs(logprobs);
 
     feedPromptMemory(tokenPiece);
@@ -143,19 +161,32 @@ public final class DefaultLlamaIterator
         if (currentState.isNgram()) {
           currentState.seedNgramHistory();
         }
-        pending.add(
-          new LlamaOutput(
-            currentState.getPiece(),
-            1,
-            currentState.getLogprobs()
-          )
-        );
+        if (
+          currentState.getPiece() != null && !currentState.getPiece().isEmpty()
+        ) {
+          pending.add(
+            new LlamaOutput(
+              currentState.getPiece(),
+              currentState.getPieceTokens(),
+              currentState.getLogprobs()
+            )
+          );
+        }
       } else {
         currentState.setFinished(true);
       }
-      return !pending.isEmpty();
+      if (!pending.isEmpty()) {
+        return true;
+      }
+      // fall through: the first token was buffered as a marker prefix — run rounds until
+      // something is emitted or generation finishes.
     }
-    pending.addAll(speculativeRound(currentState));
+    // A round may emit nothing while a multi-token marker prefix is being buffered; keep
+    // going until something is emitted or the state finishes (each round commits >= 1 token,
+    // so this terminates).
+    while (pending.isEmpty() && !currentState.isFinished()) {
+      pending.addAll(speculativeRound(currentState));
+    }
     return !pending.isEmpty();
   }
 
@@ -166,7 +197,7 @@ public final class DefaultLlamaIterator
     }
     return new LlamaOutput(
       currentState.getPiece(),
-      1,
+      currentState.getPieceTokens(),
       currentState.getLogprobs()
     );
   }
@@ -182,9 +213,11 @@ public final class DefaultLlamaIterator
     if (currentState.isSpeculative()) {
       currentState.freeSpeculativeScratch();
     }
-    currentState
-      .getContext()
-      .getMemory()
-      .seqRm(currentState.getSequenceId(), -1, -1);
+    if (!currentState.isRetainKv()) {
+      currentState
+        .getContext()
+        .getMemory()
+        .seqRm(currentState.getSequenceId(), -1, -1);
+    }
   }
 }

--- a/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
@@ -131,37 +131,94 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
     } else {
       int totalTokens = state.getTokenized().size();
       int batchSize = Math.max(1, context.nBatch());
-      int offset = 0;
-      while (offset < totalTokens) {
-        int chunkSize = Math.min(batchSize, totalTokens - offset);
-        LlamaBatch promptBatch = new LlamaBatch(arena, chunkSize, 0, 1);
+      // KV prefix reuse: the first `start` prompt tokens' KV rows are already resident for this
+      // sequence (start == 0 for a cold prompt). Wipe everything from `start` on so behavior is
+      // self-contained regardless of whether the caller cleaned the sequence, then decode only
+      // the suffix at absolute positions.
+      int start = state.getReusePrefixTokens();
+      if (!context.getMemory().seqRm(state.getSequenceId(), start, -1)) {
+        // Recurrent/hybrid models (SSM, gated-deltanet attention) cannot rewind their state to
+        // an arbitrary position — partial seq_rm is rejected natively. Fall back to a cold
+        // prefill: full wipe, no reuse. Correctness over speed; callers see reuse == 0.
+        context.getMemory().seqRm(state.getSequenceId(), -1, -1);
+        start = 0;
+        state.clearReusePrefixTokens();
+      }
+      // MTP keeps embeddings enabled on the target context (the head seed is the target's
+      // post-norm hidden). With embeddings on, llama.cpp forces EVERY batch token to be an
+      // output row ("embeddings required but some input tokens were not marked as outputs ->
+      // overriding"), turning the prefill into an O(prompt) lm_head + embedding extraction
+      // instead of O(1). Only the LAST prompt token's hidden is ever needed (the MTP seed),
+      // so decode the bulk of the prompt with embeddings temporarily off and the final token
+      // in its own single-token batch with embeddings restored — a single output row, no
+      // native override.
+      boolean mtpEmbeddings = state.isMtp();
+      int bulkEnd = mtpEmbeddings ? totalTokens - 1 : totalTokens;
+      if (mtpEmbeddings) {
+        context.setEmbeddings(false);
+      }
+      try {
+        int offset = start;
+        while (offset < bulkEnd) {
+          int chunkSize = Math.min(batchSize, bulkEnd - offset);
+          LlamaBatch promptBatch = new LlamaBatch(arena, chunkSize, 0, 1);
 
-        // Add tokens to the batch for the current chunk.
-        for (int i = 0; i < chunkSize; i++) {
-          int tokenId = state
-            .getTokenized()
-            .data()
-            .getAtIndex(JAVA_INT, offset + i);
-          // We only need the logits for the very last token of the prompt to sample the next one.
-          boolean logits = (offset + i) == totalTokens - 1;
-          promptBatch.add(
-            tokenId,
-            offset + i,
-            java.util.List.of(state.getSequenceId()),
-            logits
-          );
-        }
+          // Add tokens to the batch for the current chunk.
+          for (int i = 0; i < chunkSize; i++) {
+            int tokenId = state
+              .getTokenized()
+              .data()
+              .getAtIndex(JAVA_INT, offset + i);
+            // We only need the logits for the very last token of the prompt to sample the
+            // next one (on the MTP path that token is decoded separately below).
+            boolean logits = (offset + i) == totalTokens - 1;
+            promptBatch.add(
+              tokenId,
+              offset + i,
+              java.util.List.of(state.getSequenceId()),
+              logits
+            );
+          }
 
-        // Decode the batch of prompt tokens.
-        if (promptBatch.decode(context) != 0) {
+          // Decode the batch of prompt tokens.
+          if (promptBatch.decode(context) != 0) {
+            promptBatch.free();
+            throw new LlamaException(
+              "Failed to decode prompt for sequence " + state.getSequenceId()
+            );
+          }
+
           promptBatch.free();
+          offset += chunkSize;
+        }
+      } finally {
+        if (mtpEmbeddings) {
+          // Restore for the final prompt token (seed extraction) and the verify rounds.
+          context.setEmbeddings(true);
+        }
+      }
+
+      if (mtpEmbeddings && totalTokens > start) {
+        // Final prompt token: its logits sample the first token and its embedding row seeds
+        // the MTP head. A 1-token batch with logits=true satisfies output_all — no override.
+        int lastToken = state
+          .getTokenized()
+          .data()
+          .getAtIndex(JAVA_INT, totalTokens - 1);
+        LlamaBatch lastBatch = new LlamaBatch(arena, 1, 0, 1);
+        lastBatch.add(
+          lastToken,
+          totalTokens - 1,
+          java.util.List.of(state.getSequenceId()),
+          true
+        );
+        if (lastBatch.decode(context) != 0) {
+          lastBatch.free();
           throw new LlamaException(
             "Failed to decode prompt for sequence " + state.getSequenceId()
           );
         }
-
-        promptBatch.free();
-        offset += chunkSize;
+        lastBatch.free();
       }
 
       // After processing the entire prompt, update the past token count (n_past).
@@ -175,24 +232,21 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
     // Collect logprobs if requested.
     Logprobs logprobs = collectLogprobs(state, newToken, -1);
 
-    // Update state evaluation based on the first token.
-    GenerationState newState = state
+    // Update state evaluation based on the first token (token-sequence aware: the emitted
+    // text may be empty while a multi-token marker prefix is buffered).
+    var emission = state
       .getStateEvaluation()
-      .evaluate(
-        new io.gravitee.llama.cpp.modules.StateEvaluation.Context(
-          state.getGenerationState(),
-          tokenPiece
-        )
-      );
-    state.setGenerationState(newState);
+      .evaluateToken(state.getGenerationState(), newToken, tokenPiece);
+    state.setGenerationState(emission.state());
 
-    // Track the consumption of the first token.
+    // Track the consumption of the first token (resolved tokens only; buffered marker-prefix
+    // tokens are tracked when the marker is confirmed or refuted).
     state
       .getTokenTracking()
       .consume(
         new io.gravitee.llama.cpp.modules.TokenTracking.Context(
           state.getGenerationState(),
-          1
+          emission.emitTokens()
         )
       );
 
@@ -200,7 +254,8 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
     if (!tokenizer.isEog(newToken)) {
       // If not finished, set the new token and piece for the next iteration.
       state.setNewTokenId(newToken);
-      state.setPiece(tokenPiece);
+      state.setPiece(emission.emit());
+      state.setPieceTokens(emission.emitTokens());
       state.setLogprobs(logprobs);
     } else {
       // If finished, set the stop reason.
@@ -210,44 +265,46 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
 
   /**
    * Processes a sampled token for a given state.
-   * Updates state evaluation, checks for tool calls, and tracks tokens.
+   * Updates state evaluation (token-sequence aware), checks for tool calls, and tracks tokens.
    *
    * @param state The conversation state to update
+   * @param tokenId The sampled token id
    * @param tokenPiece The token piece that was sampled
+   * @return the emission for this step: text to emit (may be empty while a multi-token marker
+   *         prefix is buffered, or cover several buffered pieces on resolution) and the number
+   *         of generated tokens it covers
    */
-  protected void processSampledToken(
+  protected io.gravitee.llama.cpp.modules.StateEvaluation.Emission processSampledToken(
     ConversationState state,
+    int tokenId,
     String tokenPiece
   ) {
     // Update state evaluation
     GenerationState previousState = state.getGenerationState();
-    GenerationState newState = state
+    var emission = state
       .getStateEvaluation()
-      .evaluate(
-        new io.gravitee.llama.cpp.modules.StateEvaluation.Context(
-          previousState,
-          tokenPiece
-        )
-      );
-    state.setGenerationState(newState);
+      .evaluateToken(previousState, tokenId, tokenPiece);
+    state.setGenerationState(emission.state());
 
     // Mark tool call as finished once we leave the tools section
     if (
       previousState == GenerationState.TOOLS &&
-      newState == GenerationState.ANSWER
+      emission.state() == GenerationState.ANSWER
     ) {
       state.setFinishReason(FinishReason.TOOL_CALL);
     }
 
-    // Track tokens
+    // Track tokens (resolved tokens only; buffered marker-prefix tokens are tracked in the
+    // state they resolve to)
     state
       .getTokenTracking()
       .consume(
         new io.gravitee.llama.cpp.modules.TokenTracking.Context(
           state.getGenerationState(),
-          1
+          emission.emitTokens()
         )
       );
+    return emission;
   }
 
   /**
@@ -427,10 +484,12 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
         state.setFinishReason(STOP);
       }
       state.setFinished(true);
+      flushPendingMarker(state, out);
       return false;
     }
     String piece = decodeTokenPiece(state, token);
-    processSampledToken(state, piece); // updates generation state + token tracking
+    // updates generation state + token tracking; may buffer or resolve marker pieces
+    var emission = processSampledToken(state, token, piece);
     // Mirror the autoregressive iterator: the token that reaches the quota is counted but
     // NOT emitted (the AR path stops via hasNotReachedQuota() after incrementing). Drop it
     // here too, otherwise speculative emits one extra token at the boundary.
@@ -440,8 +499,45 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
       state.setFinished(true);
       return false;
     }
-    out.add(new LlamaOutput(piece, 1, state.getSequenceId()));
+    // Buffered marker prefixes emit nothing, and confirmed marker text is suppressed
+    // (empty emit with emitTokens > 0 — counted, never streamed).
+    if (!emission.emit().isEmpty()) {
+      out.add(
+        new LlamaOutput(
+          emission.emit(),
+          emission.emitTokens(),
+          state.getSequenceId()
+        )
+      );
+    }
     return true;
+  }
+
+  /**
+   * Emits (and tracks) any buffered marker-prefix pieces when generation ends while a
+   * multi-token marker was still unconfirmed — the buffered text belongs to the current
+   * channel and must not be dropped.
+   */
+  protected void flushPendingMarker(
+    ConversationState state,
+    List<LlamaOutput> out
+  ) {
+    var flush = state
+      .getStateEvaluation()
+      .flushPending(state.getGenerationState());
+    if (flush.emitTokens() > 0) {
+      state
+        .getTokenTracking()
+        .consume(
+          new io.gravitee.llama.cpp.modules.TokenTracking.Context(
+            state.getGenerationState(),
+            flush.emitTokens()
+          )
+        );
+      out.add(
+        new LlamaOutput(flush.emit(), flush.emitTokens(), state.getSequenceId())
+      );
+    }
   }
 
   /**
@@ -453,7 +549,7 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
     if (currentState.isSpeculative()) {
       currentState.freeSpeculativeScratch();
     }
-    if (currentState.getFinishReason() != null) {
+    if (currentState.getFinishReason() != null && !currentState.isRetainKv()) {
       currentState
         .getContext()
         .getMemory()

--- a/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
@@ -286,10 +286,11 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
       .evaluateToken(previousState, tokenId, tokenPiece);
     state.setGenerationState(emission.state());
 
-    // Mark tool call as finished once we leave the tools section
+    // Mark tool call as finished once we leave the tools section — via its close marker
+    // (→ ANSWER) or a chained cross-transition directly into another state (Harmony-style).
     if (
       previousState == GenerationState.TOOLS &&
-      emission.state() == GenerationState.ANSWER
+      emission.state() != GenerationState.TOOLS
     ) {
       state.setFinishReason(FinishReason.TOOL_CALL);
     }

--- a/src/main/java/io/gravitee/llama/cpp/LlamaTokenizer.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaTokenizer.java
@@ -47,7 +47,10 @@ public final class LlamaTokenizer {
       llama_tokenize(
         vocab.segment,
         promptSegment.data,
-        prompt.length(),
+        // text_len is a BYTE count: the segment is NUL-terminated UTF-8, so its
+        // byte size minus the terminator — NOT prompt.length() (UTF-16 chars),
+        // which silently truncates any prompt containing multi-byte characters.
+        (int) promptSegment.data.byteSize() - 1,
         tokenBuffer,
         nbPromptTokens,
         isFirst,
@@ -70,7 +73,7 @@ public final class LlamaTokenizer {
     int nbPromptTokens = -llama_tokenize(
       vocab.segment,
       promptSegment,
-      prompt.length(),
+      (int) promptSegment.byteSize() - 1,
       MemorySegment.NULL,
       0,
       isFirst,

--- a/src/main/java/io/gravitee/llama/cpp/modules/StateEvaluation.java
+++ b/src/main/java/io/gravitee/llama/cpp/modules/StateEvaluation.java
@@ -154,29 +154,17 @@ public class StateEvaluation
       ? piece
       : pending.toString() + piece;
 
-    // Confirmation candidate: the accumulated text fully covers a marker (possibly with a
-    // boundary-spanning remainder). Prefer the longest such marker.
+    // Candidate set — channels CHAIN rather than nest (Harmony-style): in ANY state the
+    // candidates are (a) the current state's close marker (→ ANSWER) and (b) the OPEN
+    // markers of the OTHER states (→ that state directly, the current span implicitly
+    // closing). Longest-match-wins across all candidates, since markers may share prefixes
+    // (e.g. both Harmony continuations start with "<|end|><|start|>assistant<|channel|>").
     String bestMarker = null;
     GenerationState bestTarget = null;
     boolean anyPrefix = false;
 
-    if (currentState == GenerationState.ANSWER) {
-      for (Entry<GenerationState, StateBounds> e : states.entrySet()) {
-        StateBounds bounds = e.getValue();
-        if (stateAlreadyOccurred(bounds) || isNullOrBlank(bounds)) {
-          continue;
-        }
-        String marker = bounds.start();
-        if (accumulated.startsWith(marker)) {
-          if (bestMarker == null || marker.length() > bestMarker.length()) {
-            bestMarker = marker;
-            bestTarget = bounds.state();
-          }
-        } else if (marker.startsWith(accumulated)) {
-          anyPrefix = true;
-        }
-      }
-    } else {
+    // (a) the current state's close marker
+    if (currentState != GenerationState.ANSWER) {
       String marker = states.get(currentState).end();
       if (marker != null && !marker.isBlank()) {
         if (accumulated.startsWith(marker)) {
@@ -185,6 +173,27 @@ public class StateEvaluation
         } else if (marker.startsWith(accumulated)) {
           anyPrefix = true;
         }
+      }
+    }
+
+    // (b) the other states' open markers (cross-transitions when not in ANSWER)
+    for (Entry<GenerationState, StateBounds> e : states.entrySet()) {
+      StateBounds bounds = e.getValue();
+      if (
+        bounds.state() == currentState ||
+        stateAlreadyOccurred(bounds) ||
+        isNullOrBlank(bounds)
+      ) {
+        continue;
+      }
+      String marker = bounds.start();
+      if (accumulated.startsWith(marker)) {
+        if (bestMarker == null || marker.length() > bestMarker.length()) {
+          bestMarker = marker;
+          bestTarget = bounds.state();
+        }
+      } else if (marker.startsWith(accumulated)) {
+        anyPrefix = true;
       }
     }
 

--- a/src/main/java/io/gravitee/llama/cpp/modules/StateEvaluation.java
+++ b/src/main/java/io/gravitee/llama/cpp/modules/StateEvaluation.java
@@ -28,6 +28,24 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 /**
+ * State-machine over generation channels (ANSWER / REASONING / TOOLS) driven by tag markers.
+ *
+ * <p>Two matching entry points:
+ * <ul>
+ *   <li>{@link #evaluate(Context)} — the historical single-piece string-equality matching (a
+ *   marker matches only when one detokenized piece equals it exactly).</li>
+ *   <li>{@link #evaluateToken} — TEXT-based streaming matching, robust to arbitrary
+ *   tokenizations of the same marker text (fused pieces, subword splits, or pieces spanning
+ *   the marker boundary such as {@code "thought\nThe"}). Pieces whose accumulated text is a
+ *   strict prefix of a candidate marker are buffered (emitted as an empty delta) until the
+ *   marker text is fully covered — <b>confirmation</b>: the state flips, the marker text is
+ *   pure syntax and is suppressed (never emitted to any channel; its tokens are counted in
+ *   the post-flip state), and the remainder of a boundary-spanning piece is emitted as the
+ *   first text of the post-flip channel — or until the text diverges from every candidate —
+ *   <b>refutation</b>: the buffered text is emitted in the current channel and the refuting
+ *   piece is re-scanned (it may itself start a marker prefix).</li>
+ * </ul>
+ *
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
  * @author GraviteeSource Team
  */
@@ -37,11 +55,17 @@ public class StateEvaluation
   private Map<GenerationState, StateBounds> states;
   private Map<GenerationState, Boolean> occurredState;
 
+  // Streaming text buffer: while pendingTokens > 0, `pending` holds the last pendingTokens
+  // pieces' text, all of it being a strict prefix of at least one candidate marker.
+  private final StringBuilder pending = new StringBuilder();
+  private int pendingTokens;
+
   @Override
   public boolean isInitialized() {
     return states != null && !states.isEmpty();
   }
 
+  /** Piece-mode evaluation (single-piece equality). Kept for the historical contract. */
   @Override
   public GenerationState evaluate(Context context) {
     return isInitialized()
@@ -55,6 +79,162 @@ public class StateEvaluation
       }
       : GenerationState.ANSWER;
   }
+
+  /**
+   * Text-based streaming evaluation of one generated token.
+   *
+   * <p>Returns the resulting state plus the text to emit for this step: normally the piece
+   * itself ({@code emitTokens == 1}); an empty string while a marker prefix is buffered
+   * ({@code emitTokens == 0}); on confirmation the marker text is suppressed and only the
+   * boundary-spanning remainder (possibly empty) is emitted, with all covered tokens counted
+   * in the post-flip state; on refutation the buffered text (plus this piece, unless it
+   * restarts a marker prefix) is emitted in the current channel.
+   *
+   * @param tokenId the sampled token id (unused by the text matcher; kept for call-site
+   *                symmetry)
+   */
+  public Emission evaluateToken(
+    GenerationState currentState,
+    int tokenId,
+    String piece
+  ) {
+    if (!isInitialized() || currentState == null) {
+      return new Emission(GenerationState.ANSWER, piece, 1);
+    }
+    if (piece == null) {
+      piece = "";
+    }
+    if (pendingTokens == 0 && piece.isEmpty()) {
+      // Nothing buffered and nothing to match (e.g. a partial-UTF-8 piece): plain emit.
+      return new Emission(currentState, piece, 1);
+    }
+    return matchText(currentState, piece, true);
+  }
+
+  /**
+   * Flushes any buffered marker-prefix text (generation ended while a candidate marker was
+   * still unconfirmed). The flushed text belongs to the current channel.
+   */
+  public Emission flushPending(GenerationState currentState) {
+    if (pendingTokens == 0) {
+      return new Emission(currentState, "", 0);
+    }
+    String text = pending.toString();
+    int n = pendingTokens;
+    resetBuffer();
+    return new Emission(currentState, text, n);
+  }
+
+  public boolean hasPending() {
+    return pendingTokens > 0;
+  }
+
+  /* ----- text-based streaming matching ----- */
+
+  /**
+   * Matches the accumulated text (buffer + piece) against the current state's candidate
+   * markers (open markers of not-yet-occurred states in ANSWER; the close marker of the
+   * current state in REASONING/TOOLS). {@code allowRestart} guards the single-level
+   * refutation re-scan.
+   */
+  private Emission matchText(
+    GenerationState currentState,
+    String piece,
+    boolean allowRestart
+  ) {
+    if (currentState != GenerationState.ANSWER) {
+      StateBounds bounds = states.get(currentState);
+      if (stateAlreadyOccurred(bounds)) {
+        // Legacy contract: a state whose close already occurred resolves to ANSWER.
+        return new Emission(GenerationState.ANSWER, piece, 1);
+      }
+    }
+
+    String accumulated = pendingTokens == 0
+      ? piece
+      : pending.toString() + piece;
+
+    // Confirmation candidate: the accumulated text fully covers a marker (possibly with a
+    // boundary-spanning remainder). Prefer the longest such marker.
+    String bestMarker = null;
+    GenerationState bestTarget = null;
+    boolean anyPrefix = false;
+
+    if (currentState == GenerationState.ANSWER) {
+      for (Entry<GenerationState, StateBounds> e : states.entrySet()) {
+        StateBounds bounds = e.getValue();
+        if (stateAlreadyOccurred(bounds) || isNullOrBlank(bounds)) {
+          continue;
+        }
+        String marker = bounds.start();
+        if (accumulated.startsWith(marker)) {
+          if (bestMarker == null || marker.length() > bestMarker.length()) {
+            bestMarker = marker;
+            bestTarget = bounds.state();
+          }
+        } else if (marker.startsWith(accumulated)) {
+          anyPrefix = true;
+        }
+      }
+    } else {
+      String marker = states.get(currentState).end();
+      if (marker != null && !marker.isBlank()) {
+        if (accumulated.startsWith(marker)) {
+          bestMarker = marker;
+          bestTarget = GenerationState.ANSWER;
+        } else if (marker.startsWith(accumulated)) {
+          anyPrefix = true;
+        }
+      }
+    }
+
+    if (bestMarker != null) {
+      // Confirmed: marker text suppressed; the boundary-spanning remainder (if any) is the
+      // first text of the post-flip channel; all covered tokens are counted post-flip.
+      if (currentState != GenerationState.ANSWER) {
+        setAlreadyOccurredIfNecessary(currentState);
+      }
+      String remainder = accumulated.substring(bestMarker.length());
+      int n = pendingTokens + 1;
+      resetBuffer();
+      return new Emission(bestTarget, remainder, n);
+    }
+
+    if (anyPrefix) {
+      // Still a strict prefix of at least one candidate marker: buffer, emit nothing.
+      pending.append(piece);
+      pendingTokens++;
+      return new Emission(currentState, "", 0);
+    }
+
+    if (pendingTokens == 0) {
+      // No buffer, no match: plain content.
+      return new Emission(currentState, piece, 1);
+    }
+
+    // Refutation: the accumulated text diverged from every candidate. Flush the buffered
+    // text to the current channel and re-scan the refuting piece alone (it may itself start
+    // a marker prefix).
+    String flushed = pending.toString();
+    int flushedTokens = pendingTokens;
+    resetBuffer();
+    if (!allowRestart) {
+      return new Emission(currentState, flushed + piece, flushedTokens + 1);
+    }
+    Emission restart = matchText(currentState, piece, false);
+    return new Emission(
+      restart.state(),
+      flushed + restart.emit(),
+      flushedTokens + restart.emitTokens()
+    );
+  }
+
+  private void resetBuffer() {
+    pending.setLength(0);
+    pendingTokens = 0;
+  }
+
+  /* ----- piece-mode internals (unchanged semantics) ----- */
 
   private GenerationState detectEndState(
     GenerationState currentState,
@@ -94,9 +274,14 @@ public class StateEvaluation
 
   /**
    * Resolves the state generation should start in for the given prompt.
-   * Chat templates may pre-fill a state's open tag at the end of the prompt
-   * (e.g. a template ending with {@code <think>}), in which case the model
-   * never emits the tag itself and generation must begin inside that state.
+   *
+   * <p>Chat templates may pre-fill a state's open tag at the end of the prompt (e.g. a template
+   * ending with {@code <think>}), and continuation prompts may end anywhere inside an
+   * unfinished span (open tag present, close tag not yet emitted). In both cases the model
+   * never (re-)emits the open tag itself and generation must begin inside that state, so a
+   * prompt whose LAST open-tag occurrence is not followed by the corresponding close tag seeds
+   * that state. Matching is string-based on the rendered prompt, so it is independent of how
+   * the markers tokenize.
    */
   public GenerationState initialState(String prompt) {
     if (!isInitialized() || prompt == null) {
@@ -107,10 +292,20 @@ public class StateEvaluation
       .values()
       .stream()
       .filter(not(StateEvaluation::isNullOrBlank))
-      .filter(stateBounds -> trimmed.endsWith(stateBounds.start()))
+      .filter(stateBounds -> insideOpenSpan(trimmed, stateBounds))
       .map(StateBounds::state)
       .findFirst()
       .orElse(GenerationState.ANSWER);
+  }
+
+  private static boolean insideOpenSpan(String prompt, StateBounds bounds) {
+    int lastStart = prompt.lastIndexOf(bounds.start());
+    if (lastStart < 0) {
+      return false;
+    }
+    String end = bounds.end();
+    int lastEnd = end == null || end.isBlank() ? -1 : prompt.lastIndexOf(end);
+    return lastStart > lastEnd;
   }
 
   private static boolean isNullOrBlank(StateBounds stateBounds) {
@@ -137,9 +332,18 @@ public class StateEvaluation
     this.occurredState = this.states.keySet()
       .stream()
       .collect(toMap(identity(), __ -> false));
+    resetBuffer();
   }
 
   public record Config(List<StateBounds> states) {}
 
   public record Context(GenerationState currentState, String piece) {}
+
+  /**
+   * Result of evaluating one token: the resulting generation state, the text to emit for this
+   * step, and how many generated tokens it covers (0 while buffering a marker prefix; N when
+   * buffered pieces resolve — marker text itself is always suppressed). Emitted text always
+   * belongs to {@code state}.
+   */
+  public record Emission(GenerationState state, String emit, int emitTokens) {}
 }

--- a/src/main/java/io/gravitee/llama/cpp/modules/TokenHistory.java
+++ b/src/main/java/io/gravitee/llama/cpp/modules/TokenHistory.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.modules;
+
+import java.util.Arrays;
+
+/**
+ * Committed-token history of a conversation: the token ids whose KV rows are resident for the
+ * conversation's sequence, i.e. the tokens at positions {@code [0, nPast)}.
+ *
+ * <p>Invariant: {@code size() == nPast} at all stable points — after prompt prefill (the full
+ * tokenized prompt), after each autoregressive commit ({@code nPast} increment), and after each
+ * speculative round's commit. Speculative rollbacks ({@code seqRm(seq, pos, -1)}) are mirrored
+ * by {@link #truncate(int)}.
+ *
+ * <p>Heap-only bookkeeping — no native calls. Used by KV prefix reuse to know which prompt
+ * prefix is already resident when a sequence is re-initialized with
+ * {@code ConversationState.initialize(prompt, reusePrefixTokens)}.
+ *
+ * @author GraviteeSource Team
+ */
+public final class TokenHistory {
+
+  private int[] tokens = new int[256];
+  private int size = 0;
+
+  /** Restarts the history with the given tokens (the freshly tokenized prompt). */
+  public void initialize(int[] promptTokens) {
+    if (tokens.length < promptTokens.length) {
+      tokens = new int[Math.max(promptTokens.length, tokens.length * 2)];
+    }
+    System.arraycopy(promptTokens, 0, tokens, 0, promptTokens.length);
+    size = promptTokens.length;
+  }
+
+  /** Appends one committed token (its KV row just became resident — nPast incremented). */
+  public void append(int token) {
+    if (size == tokens.length) {
+      tokens = Arrays.copyOf(tokens, tokens.length * 2);
+    }
+    tokens[size++] = token;
+  }
+
+  /** Truncates to {@code length} tokens (mirrors a KV rollback). No-op when already shorter. */
+  public void truncate(int length) {
+    if (length < 0) {
+      throw new IllegalArgumentException("negative history length: " + length);
+    }
+    if (length < size) {
+      size = length;
+    }
+  }
+
+  /** Number of committed tokens ({@code == nPast} at stable points). */
+  public int size() {
+    return size;
+  }
+
+  /** Snapshot of the committed token ids, positions {@code [0, size())}. */
+  public int[] toArray() {
+    return Arrays.copyOf(tokens, size);
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/speculative/Eagle3SpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/Eagle3SpeculativeDecoding.java
@@ -140,7 +140,7 @@ public final class Eagle3SpeculativeDecoding
     e3.setBoundary(gv[v.matched()]);
 
     List<LlamaOutput> out = emitCommitted(it, state, d.tokens(), v);
-    commit(state, v, d.m(), newNPast);
+    commit(state, v, d.tokens(), d.m(), newNPast);
     return out;
   }
 }

--- a/src/main/java/io/gravitee/llama/cpp/speculative/ModelDraftSpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/ModelDraftSpeculativeDecoding.java
@@ -165,7 +165,7 @@ public final class ModelDraftSpeculativeDecoding extends SpeculativeDecoding {
     }
 
     List<LlamaOutput> out = emitCommitted(it, state, drafted, v);
-    commit(state, v, m, newNPast);
+    commit(state, v, drafted, m, newNPast);
     return out;
   }
 }

--- a/src/main/java/io/gravitee/llama/cpp/speculative/MtpSpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/MtpSpeculativeDecoding.java
@@ -37,14 +37,17 @@ public final class MtpSpeculativeDecoding
 
   /**
    * No token replay — the head shares the target's weights and is seeded per round with the
-   * target's post-norm hidden. After {@code processPrompt} the target's single output row
-   * (index 0) is the last prompt token's hidden: the initial seed.
+   * target's post-norm hidden. After {@code processPrompt} the target's single output row is
+   * the last prompt token's hidden: the initial seed. Read via index {@code -1} (last output
+   * row): a positive index maps through {@code output_ids[token_index]}, which only equals the
+   * output row when every batch token requested logits (the verify path) — after a prompt
+   * prefill (full or KV-prefix-reused) only the final prompt token has an output row.
    */
   @Override
   public void prefill(ConversationState state) {
     var mtp = state.getMtpDraft();
     mtp.context().getMemory().seqRm(state.getSequenceId(), -1, -1);
-    mtp.setSeed(state.getContext().getEmbeddingsIth(0));
+    mtp.setSeed(state.getContext().getEmbeddingsIth(-1));
   }
 
   @Override
@@ -94,7 +97,7 @@ public final class MtpSpeculativeDecoding
     mtp.setSeed(newSeed);
 
     List<LlamaOutput> out = emitCommitted(it, state, d.tokens(), v);
-    commit(state, v, d.m(), newNPast);
+    commit(state, v, d.tokens(), d.m(), newNPast);
     return out;
   }
 }

--- a/src/main/java/io/gravitee/llama/cpp/speculative/NgramSpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/NgramSpeculativeDecoding.java
@@ -66,7 +66,7 @@ public final class NgramSpeculativeDecoding extends SpeculativeDecoding {
     }
     state.appendHistory(v.extra());
 
-    commit(state, v, m, newNPast);
+    commit(state, v, drafted, m, newNPast);
     return out;
   }
 }

--- a/src/main/java/io/gravitee/llama/cpp/speculative/SpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/SpeculativeDecoding.java
@@ -177,15 +177,27 @@ public abstract sealed class SpeculativeDecoding
     return out;
   }
 
-  /** Advances the conversation to the accepted boundary and records accept statistics. */
+  /**
+   * Advances the conversation to the accepted boundary and records accept statistics. Also
+   * updates the committed-token history to the tokens whose KV rows survived the rollback:
+   * {@code idLast} (the pre-round newTokenId, decoded at the old nPast) plus the accepted
+   * drafts — keeping {@code history.size() == nPast}.
+   */
   static void commit(
     ConversationState state,
     Verdict v,
-    int drafted,
+    int[] drafted,
+    int nDrafted,
     int newNPast
   ) {
+    var history = state.getTokenHistory();
+    history.truncate(state.getNPast()); // mirror the KV rollback (defensive no-op normally)
+    history.append(state.getNewTokenId()); // idLast — setNewTokenId(extra) happens below
+    for (int i = 0; i < v.matched(); i++) {
+      history.append(drafted[i]);
+    }
     state.setNPast(newNPast);
     state.setNewTokenId(v.extra());
-    state.recordSpeculation(drafted, v.matched());
+    state.recordSpeculation(nDrafted, v.matched());
   }
 }

--- a/src/test/java/io/gravitee/llama/cpp/LlamaTokenizerUtf8Test.java
+++ b/src/test/java/io/gravitee/llama/cpp/LlamaTokenizerUtf8Test.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static io.gravitee.llama.cpp.LlamaCppTest.MODEL_PATH;
+import static io.gravitee.llama.cpp.LlamaCppTest.MODEL_TO_DOWNLOAD;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
+import java.lang.foreign.Arena;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test: llama_tokenize takes a BYTE length. Passing the Java string length
+ * (UTF-16 chars) silently truncated the tail of any prompt containing multi-byte UTF-8
+ * (observed as GLM-4 losing its trailing <|assistant|> marker and the end of the user
+ * turn). The detokenized pieces of a multi-byte prompt must round-trip to the full text.
+ */
+class LlamaTokenizerUtf8Test extends LlamaCppTest {
+
+  private static Arena arena;
+
+  @BeforeAll
+  static void beforeAll() {
+    arena = Arena.ofConfined();
+    String libPath = LlamaLibLoader.load();
+    LlamaRuntime.llama_backend_init();
+    LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    LlamaRuntime.llama_backend_free();
+  }
+
+  @Test
+  void tokenize_must_not_truncate_multibyte_utf8_prompts() {
+    var model = track(
+      new LlamaModel(
+        arena,
+        getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD),
+        new LlamaModelParams(arena)
+      )
+    );
+    var context = track(
+      new LlamaContext(arena, model, new LlamaContextParams(arena).nCtx(512))
+    );
+    var vocab = new LlamaVocab(model);
+    var tokenizer = new LlamaTokenizer(vocab, context);
+
+    String prompt =
+      "Résumé — “quotes”, café, 東京, emoji 🚀. The tail must survive tokenization.";
+
+    var resp = tokenizer.tokenize(arena, prompt);
+    var bytes = new java.io.ByteArrayOutputStream();
+    for (int i = 0; i < resp.size(); i++) {
+      int id = resp.data().getAtIndex(JAVA_INT, i);
+      bytes.writeBytes(vocab.tokenToPiece(id));
+    }
+    String roundTrip = new String(
+      bytes.toByteArray(),
+      java.nio.charset.StandardCharsets.UTF_8
+    );
+
+    // The BOS/leading special tokens may prepend text, but the FULL prompt — most
+    // importantly its tail after the multi-byte characters — must be present.
+    assertThat(roundTrip).endsWith("The tail must survive tokenization.");
+    assertThat(roundTrip).contains("東京", "🚀", "café");
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/MultiToolCallBatchTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/MultiToolCallBatchTest.java
@@ -44,9 +44,10 @@ import org.junit.jupiter.api.Test;
  */
 class MultiToolCallBatchTest extends LlamaCppTest {
 
+  // Tool tag markers are engine-suppressed (pure syntax, never streamed), so tool calls
+  // are counted by their JSON payloads in the emitted text.
   private static final Pattern TOOL_CALL_PATTERN = Pattern.compile(
-    "<tool_call>\\s*\\{.*?}\\s*</tool_call>",
-    Pattern.DOTALL
+    "\"name\"\\s*:"
   );
 
   /**
@@ -149,7 +150,13 @@ class MultiToolCallBatchTest extends LlamaCppTest {
     System.out.println(fullOutput);
     System.out.println("=============================");
 
-    // Count <tool_call>...</tool_call> blocks in the output
+    // Tag markers must never leak into the streamed output (any channel).
+    assertThat(fullOutput).doesNotContain("<tool_call>");
+    assertThat(fullOutput).doesNotContain("</tool_call>");
+    assertThat(fullOutput).doesNotContain("<think>");
+    assertThat(fullOutput).doesNotContain("</think>");
+
+    // Count tool-call JSON payloads in the output
     int toolCallCount = 0;
     Matcher matcher = TOOL_CALL_PATTERN.matcher(fullOutput);
     while (matcher.find()) {

--- a/src/test/java/io/gravitee/llama/cpp/PrefixReuseTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/PrefixReuseTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static io.gravitee.llama.cpp.LlamaCppTest.MODEL_PATH;
+import static io.gravitee.llama.cpp.LlamaCppTest.MODEL_TO_DOWNLOAD;
+import static io.gravitee.llama.cpp.LlamaCppTest.getModelPath;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
+import java.lang.foreign.Arena;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * KV prefix reuse: {@code initialize(prompt, reusePrefixTokens)} + {@code setRetainKv} /
+ * {@code removeState(id, keepKv)} let a follow-up prompt sharing a token prefix with a previous
+ * one on the same sequence skip re-decoding the shared prefix.
+ *
+ * @author GraviteeSource Team
+ */
+@Tag("integration")
+class PrefixReuseTest extends LlamaCppTest {
+
+  private static final String PROMPT = "The capital of France is";
+  private static final String EXTENSION = " Paris. The capital of Germany is";
+  private static final int MAX_TOKENS = 16;
+
+  private static Arena arena;
+
+  @BeforeAll
+  static void beforeAll() {
+    arena = Arena.ofConfined();
+    String libPath = LlamaLibLoader.load();
+    LlamaRuntime.llama_backend_init();
+    LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    LlamaRuntime.llama_backend_free();
+    arena.close();
+    arena = null;
+  }
+
+  private static int[] tokensOf(LlamaTokenizer tokenizer, String prompt) {
+    var r = tokenizer.tokenize(arena, prompt);
+    int[] out = new int[r.size()];
+    for (int i = 0; i < r.size(); i++) {
+      out[i] = r.data().getAtIndex(JAVA_INT, i);
+    }
+    return out;
+  }
+
+  private static int lcp(int[] a, int[] b) {
+    int n = Math.min(a.length, b.length);
+    int i = 0;
+    while (i < n && a[i] == b[i]) {
+      i++;
+    }
+    return i;
+  }
+
+  private ConversationState newState(
+    LlamaContext ctx,
+    LlamaTokenizer tokenizer
+  ) {
+    return ConversationState.create(
+      arena,
+      ctx,
+      tokenizer,
+      track(new LlamaSampler(arena).greedy())
+    ).setMaxTokens(MAX_TOKENS);
+  }
+
+  private static List<LlamaOutput> collect(DefaultLlamaIterator it) {
+    List<LlamaOutput> out = new ArrayList<>();
+    it.stream().forEach(out::add);
+    return out;
+  }
+
+  private static String text(List<LlamaOutput> outputs) {
+    return outputs
+      .stream()
+      .map(LlamaOutput::content)
+      .reduce("", (a, b) -> a + b);
+  }
+
+  @Test
+  void prefix_reuse_matches_cold_prefill_and_clamps_identical_prompt() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var reuseCtx = track(new LlamaContext(arena, model, cp));
+    var refCtx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+    var reuseTok = new LlamaTokenizer(vocab, reuseCtx);
+    var refTok = new LlamaTokenizer(vocab, refCtx);
+
+    int[] tokensA = tokensOf(reuseTok, PROMPT);
+    String combined = PROMPT + EXTENSION;
+    int[] tokensAB = tokensOf(reuseTok, combined);
+    int prefix = lcp(tokensA, tokensAB);
+    assertThat(prefix).isGreaterThan(0);
+
+    // (a) Cold greedy run of prompt A on seq 0, retaining the KV on finish.
+    var stateA = newState(reuseCtx, reuseTok)
+      .setRetainKv(true)
+      .initialize(PROMPT);
+    List<LlamaOutput> outputsA = collect(new DefaultLlamaIterator(stateA));
+    String outA = text(outputsA);
+    assertThat(outA).isNotBlank();
+    // The committed history is exactly the KV-resident tokens: prompt + decoded generations.
+    assertThat(stateA.committedTokens()).hasSize(stateA.getNPast());
+    assertThat(stateA.committedTokens()).startsWith(tokensA);
+    String firstPieceA = outputsA.get(0).content();
+
+    // (c) Identical prompt with reuse == tokenized.size(): the clamp re-decodes only the last
+    // prompt token; the first sampled token must match the cold run's.
+    var stateC = newState(reuseCtx, reuseTok)
+      .setRetainKv(true)
+      .initialize(PROMPT, tokensA.length);
+    assertThat(stateC.getReusePrefixTokens()).isEqualTo(tokensA.length - 1);
+    try (var itC = new DefaultLlamaIterator(stateC)) {
+      assertThat(itC.hasNext()).isTrue();
+      assertThat(itC.next().content()).isEqualTo(firstPieceA);
+    }
+
+    // Reference: cold full prefill of the combined prompt on a fresh context.
+    var refState = newState(refCtx, refTok).initialize(combined);
+    String refOut = text(collect(new DefaultLlamaIterator(refState)));
+
+    // (b) Prefix reuse: same seq id, combined prompt, reuse the common token prefix.
+    var stateB = newState(reuseCtx, reuseTok)
+      .setRetainKv(true)
+      .initialize(combined, prefix);
+    assertThat(stateB.getReusePrefixTokens()).isEqualTo(
+      Math.min(prefix, tokensAB.length - 1)
+    );
+    String reuseOut = text(collect(new DefaultLlamaIterator(stateB)));
+
+    System.out.println("cold : " + refOut);
+    System.out.println("reuse: " + reuseOut);
+    assertThat(reuseOut).isEqualTo(refOut);
+    assertThat(stateB.committedTokens()).startsWith(tokensAB);
+    assertThat(stateB.committedTokens()).hasSize(stateB.getNPast());
+  }
+
+  @Test
+  void removeState_keepKv_controls_kv_residency() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var ctx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+    var tokenizer = new LlamaTokenizer(vocab, ctx);
+
+    // keepKv = true: the sequence's rows stay resident after removal.
+    try (var it = new BatchIterator(arena, ctx)) {
+      it.addState(newState(ctx, tokenizer).initialize(PROMPT));
+      for (int i = 0; i < 4 && it.hasNext(); i++) {
+        it.next();
+      }
+      assertThat(it.removeState(0, true)).isTrue();
+      assertThat(ctx.getMemory().posMax(0)).isGreaterThanOrEqualTo(0);
+    }
+    // A keepKv-removed sequence is unregistered, so iterator teardown (stop/free) does not
+    // touch it: its rows survive for a later prefix-reuse initialization.
+    assertThat(ctx.getMemory().posMax(0)).isGreaterThanOrEqualTo(0);
+    ctx.getMemory().seqRm(0, -1, -1);
+    assertThat(ctx.getMemory().posMax(0)).isEqualTo(-1);
+
+    // keepKv = false: forces the wipe even for a retainKv-marked state.
+    try (var it = new BatchIterator(arena, ctx)) {
+      it.addState(
+        newState(ctx, tokenizer).setRetainKv(true).initialize(PROMPT)
+      );
+      for (int i = 0; i < 4 && it.hasNext(); i++) {
+        it.next();
+      }
+      assertThat(it.removeState(0, false)).isTrue();
+      assertThat(ctx.getMemory().posMax(0)).isEqualTo(-1);
+    }
+  }
+
+  /**
+   * MTP-seed contract under partial prefill: the MTP flavour seeds its head from
+   * {@code context.getEmbeddingsIth(-1)} after {@code processPrompt} (the last output row —
+   * a positive index maps through {@code output_ids[token_index]} and is NOT the output row
+   * after a prompt prefill, where only the final token has an output). With prefix reuse only
+   * the suffix rows are decoded, but the last output row must still be the last prompt token's
+   * hidden — identical (within numeric tolerance) to a cold full prefill. An MTP-capable
+   * (nextn-headed) tiny model is not available in CI, so this verifies the seed-row property
+   * itself rather than an end-to-end MTP round.
+   */
+  @Test
+  void partial_prefill_keeps_last_prompt_token_embedding_row_0() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var coldCtx = track(new LlamaContext(arena, model, cp));
+    var reuseCtx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+    var coldTok = new LlamaTokenizer(vocab, coldCtx);
+    var reuseTok = new LlamaTokenizer(vocab, reuseCtx);
+    LlamaRuntime.llama_set_embeddings(coldCtx.segment, true);
+    LlamaRuntime.llama_set_embeddings(reuseCtx.segment, true);
+
+    String combined = PROMPT + EXTENSION;
+    int[] tokensA = tokensOf(reuseTok, PROMPT);
+    int[] tokensAB = tokensOf(reuseTok, combined);
+    int prefix = lcp(tokensA, tokensAB);
+
+    // Cold full prefill of the combined prompt: read row 0 right after prompt processing.
+    var coldState = newState(coldCtx, coldTok).initialize(combined);
+    float[] coldSeed;
+    String coldFirst;
+    try (var it = new DefaultLlamaIterator(coldState)) {
+      assertThat(it.hasNext()).isTrue();
+      coldSeed = coldCtx.getEmbeddingsIth(-1);
+      coldFirst = it.next().content();
+    }
+
+    // Warm the reuse context with prompt A, then partial-prefill the combined prompt.
+    var warm = newState(reuseCtx, reuseTok)
+      .setRetainKv(true)
+      .initialize(PROMPT);
+    collect(new DefaultLlamaIterator(warm));
+    var reuseState = newState(reuseCtx, reuseTok)
+      .setRetainKv(true)
+      .initialize(combined, prefix);
+    float[] reuseSeed;
+    String reuseFirst;
+    try (var it = new DefaultLlamaIterator(reuseState)) {
+      assertThat(it.hasNext()).isTrue();
+      reuseSeed = reuseCtx.getEmbeddingsIth(-1);
+      reuseFirst = it.next().content();
+    }
+
+    assertThat(reuseFirst).isEqualTo(coldFirst);
+    assertThat(reuseSeed).hasSameSizeAs(coldSeed);
+    // Cosine similarity ~1: same row content up to batch-shape numeric noise.
+    assertThat(cosine(coldSeed, reuseSeed)).isGreaterThan(0.999);
+  }
+
+  /**
+   * MTP warm turns must be O(suffix): the target keeps embeddings enabled for seed extraction,
+   * and llama.cpp forces every batch token to an output row when embeddings are on — before the
+   * fix this made every prefill pay O(prompt) lm_head + embedding extraction, and a warm turn's
+   * decode work was proportional to the full context. Assert (via the context's native decode
+   * counters, not wall-clock) that a warm MTP prefill decodes exactly the un-reused suffix.
+   * Uses the same fake-MTP-context trick as {@code MtpEagle3SpeculativeTest}: only the prefill
+   * step runs (a single {@code hasNext()}), which never touches the nextn head graph.
+   */
+  @Test
+  void mtp_warm_turn_prefill_work_is_proportional_to_suffix() {
+    org.junit.jupiter.api.Assumptions.assumeTrue(LlamaExt.available());
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena)
+      .nCtx(512)
+      .nBatch(512)
+      .nUBatch(512)
+      .noPerf(false);
+    var ctx = track(new LlamaContext(arena, model, cp));
+    var mtpish = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+    var tokenizer = new LlamaTokenizer(vocab, ctx);
+
+    String combined = PROMPT + EXTENSION;
+    int[] tokensA = tokensOf(tokenizer, PROMPT);
+    int[] tokensAB = tokensOf(tokenizer, combined);
+    int prefix = lcp(tokensA, tokensAB);
+    assertThat(prefix).isGreaterThan(0);
+
+    // Turn 1 (cold): MTP state, prefill only, KV retained.
+    var s1 = newState(ctx, tokenizer)
+      .setRetainKv(true)
+      .setMtp(mtpish, SpeculativeConfig.greedy(4))
+      .initialize(PROMPT);
+    long before1 = decodedTokens(ctx);
+    var it1 = new DefaultLlamaIterator(s1);
+    assertThat(it1.hasNext()).isTrue();
+    long cold = decodedTokens(ctx) - before1;
+    // llama_perf floors empty counters at 1 (max(1, n)), so the first delta on a fresh
+    // context under-reads by up to 1; subsequent deltas (the warm one below) are exact.
+    assertThat(cold).isBetween(
+      (long) tokensA.length - 1,
+      (long) tokensA.length
+    );
+
+    // Turn 2 (warm): same sequence, combined prompt, reuse the common prefix.
+    var s2 = newState(ctx, tokenizer)
+      .setRetainKv(true)
+      .setMtp(mtpish, SpeculativeConfig.greedy(4))
+      .initialize(combined, prefix);
+    long before2 = decodedTokens(ctx);
+    var it2 = new DefaultLlamaIterator(s2);
+    assertThat(it2.hasNext()).isTrue();
+    long warm = decodedTokens(ctx) - before2;
+    // O(suffix): only the un-reused prompt tokens are decoded, prefix reuse was honored.
+    assertThat(s2.isPrefixReuseHonored()).isTrue();
+    assertThat(warm).isEqualTo(tokensAB.length - prefix);
+    String warmFirst = s2.getPiece();
+
+    // Correctness of the split final-token MTP prefill: a plain cold greedy run of the
+    // combined prompt on a fresh context samples the same first token.
+    var refCtx = track(new LlamaContext(arena, model, cp));
+    var refState = newState(
+      refCtx,
+      new LlamaTokenizer(vocab, refCtx)
+    ).initialize(combined);
+    try (var refIt = new DefaultLlamaIterator(refState)) {
+      assertThat(refIt.hasNext()).isTrue();
+      assertThat(warmFirst).isEqualTo(refState.getPiece());
+    }
+    // And the MTP seed row is still readable (embeddings restored, last row = last prompt token).
+    assertThat(ctx.getEmbeddingsIth(-1)).hasSize(model.nEmbdOut());
+
+    s1.freeSpeculativeScratch();
+    s2.freeSpeculativeScratch();
+  }
+
+  /** Total tokens decoded on {@code ctx} so far (native perf counters: prompt + single-token). */
+  private static long decodedTokens(LlamaContext ctx) {
+    var p = ctx.getPerformance(arena);
+    return (long) p.promptTokensEvaluated() + p.tokensGenerated();
+  }
+
+  private static double cosine(float[] a, float[] b) {
+    double dot = 0,
+      na = 0,
+      nb = 0;
+    for (int i = 0; i < a.length; i++) {
+      dot += (double) a[i] * b[i];
+      na += (double) a[i] * a[i];
+      nb += (double) b[i] * b[i];
+    }
+    return dot / (Math.sqrt(na) * Math.sqrt(nb));
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/TokenHistoryStateTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/TokenHistoryStateTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static io.gravitee.llama.cpp.LlamaCppTest.MODEL_PATH;
+import static io.gravitee.llama.cpp.LlamaCppTest.MODEL_TO_DOWNLOAD;
+import static io.gravitee.llama.cpp.LlamaCppTest.getModelPath;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
+import java.lang.foreign.Arena;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Committed-token history invariant: {@code committedTokens().length == nPast} at all stable
+ * points, through autoregressive AND speculative generation (including speculative rejection
+ * rollbacks), single-stream and batched.
+ *
+ * @author GraviteeSource Team
+ */
+@Tag("integration")
+class TokenHistoryStateTest extends LlamaCppTest {
+
+  private static final String PROMPT = "The capital of France is";
+  private static final int MAX_TOKENS = 24;
+
+  private static Arena arena;
+
+  @BeforeAll
+  static void beforeAll() {
+    arena = Arena.ofConfined();
+    String libPath = LlamaLibLoader.load();
+    LlamaRuntime.llama_backend_init();
+    LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    LlamaRuntime.llama_backend_free();
+    arena.close();
+    arena = null;
+  }
+
+  private static int[] promptTokens(ConversationState state) {
+    var r = state.getTokenized();
+    int[] out = new int[r.size()];
+    for (int i = 0; i < r.size(); i++) {
+      out[i] = r.data().getAtIndex(JAVA_INT, i);
+    }
+    return out;
+  }
+
+  private static void assertHistoryInvariant(ConversationState state) {
+    assertThat(state.committedTokens())
+      .as("history.length == nPast")
+      .hasSize(state.getNPast());
+    assertThat(state.committedTokens()).startsWith(promptTokens(state));
+  }
+
+  @Test
+  void history_tracks_npast_autoregressive() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var ctx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+
+    var state = ConversationState.create(
+      arena,
+      ctx,
+      new LlamaTokenizer(vocab, ctx),
+      track(new LlamaSampler(arena).greedy())
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .initialize(PROMPT);
+
+    var it = new DefaultLlamaIterator(state);
+    while (it.hasNext()) {
+      it.next();
+      // Stable point between steps: every resident KV row is mirrored in the history.
+      assertHistoryInvariant(state);
+    }
+    assertHistoryInvariant(state);
+    assertThat(state.getNPast()).isGreaterThan(promptTokens(state).length);
+  }
+
+  @Test
+  void history_tracks_npast_speculative_ngram_with_rollbacks() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var ctx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+
+    // N-gram drafting: rounds routinely reject proposals, exercising the rollback truncation.
+    var state = ConversationState.create(
+      arena,
+      ctx,
+      new LlamaTokenizer(vocab, ctx),
+      track(new LlamaSampler(arena).greedy())
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .setNgram(SpeculativeConfig.ngramGreedy(4, 2))
+      .initialize(PROMPT);
+
+    var it = new DefaultLlamaIterator(state);
+    while (it.hasNext()) {
+      it.next();
+      assertHistoryInvariant(state);
+    }
+    assertHistoryInvariant(state);
+  }
+
+  @Test
+  void history_tracks_npast_speculative_model_draft() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var ctx = track(new LlamaContext(arena, model, cp));
+    var draftCtx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+
+    var state = ConversationState.create(
+      arena,
+      ctx,
+      new LlamaTokenizer(vocab, ctx),
+      track(new LlamaSampler(arena).greedy())
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .setDraft(draftCtx, SpeculativeConfig.greedy(4))
+      .initialize(PROMPT);
+
+    var it = new DefaultLlamaIterator(state);
+    while (it.hasNext()) {
+      it.next();
+      assertHistoryInvariant(state);
+    }
+    assertHistoryInvariant(state);
+  }
+
+  @Test
+  void history_tracks_npast_in_batch_iterator() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena)
+      .nCtx(512)
+      .nBatch(512)
+      .nUBatch(512)
+      .nSeqMax(2);
+    var ctx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+    String[] prompts = { "The capital of France is", "Water boils at" };
+
+    ConversationState[] states = new ConversationState[2];
+    try (var it = new BatchIterator(arena, ctx)) {
+      for (int i = 0; i < 2; i++) {
+        states[i] = ConversationState.create(
+          arena,
+          ctx,
+          new LlamaTokenizer(vocab, ctx),
+          track(new LlamaSampler(arena).greedy()),
+          i
+        )
+          .setMaxTokens(MAX_TOKENS)
+          .initialize(prompts[i]);
+        it.addState(states[i]);
+      }
+      while (it.hasNext()) {
+        it.next();
+      }
+    }
+    for (ConversationState s : states) {
+      assertHistoryInvariant(s);
+    }
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/modules/StateEvaluationTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/modules/StateEvaluationTest.java
@@ -33,6 +33,14 @@ class StateEvaluationTest {
     return eval;
   }
 
+  /**
+   * Text-based streaming matching: token ids are irrelevant, only piece text matters.
+   * Same initialization as {@link #of} — evaluateToken is always text-aware.
+   */
+  private static StateEvaluation tokenAware(StateBounds... bounds) {
+    return of(bounds);
+  }
+
   private static GenerationState step(
     StateEvaluation eval,
     GenerationState current,
@@ -160,5 +168,331 @@ class StateEvaluationTest {
     assertThat(step(eval, state, "pondering")).isEqualTo(REASONING);
     assertThat(step(eval, REASONING, "</think>")).isEqualTo(ANSWER);
     assertThat(step(eval, ANSWER, "<think>")).isEqualTo(ANSWER);
+  }
+
+  /* ----- token-sequence matching (evaluateToken) ----- */
+
+  @Test
+  void token_aware_single_token_markers_behave_as_before() {
+    var eval = tokenAware(new StateBounds(REASONING, "<think>", "</think>"));
+
+    var hello = eval.evaluateToken(ANSWER, 5, "Hello");
+    assertThat(hello.state()).isEqualTo(ANSWER);
+    assertThat(hello.emit()).isEqualTo("Hello");
+    assertThat(hello.emitTokens()).isEqualTo(1);
+
+    var open = eval.evaluateToken(ANSWER, 100, "<think>");
+    assertThat(open.state()).isEqualTo(REASONING);
+    assertThat(open.emit()).isEmpty(); // marker text suppressed
+    assertThat(open.emitTokens()).isEqualTo(1);
+
+    var inner = eval.evaluateToken(REASONING, 6, "pondering");
+    assertThat(inner.state()).isEqualTo(REASONING);
+
+    var close = eval.evaluateToken(REASONING, 101, "</think>");
+    assertThat(close.state()).isEqualTo(ANSWER);
+    assertThat(close.emit()).isEmpty(); // marker text suppressed
+
+    // reasoning occurs at most once
+    assertThat(eval.evaluateToken(ANSWER, 100, "<think>").state()).isEqualTo(
+      ANSWER
+    );
+  }
+
+  @Test
+  void token_aware_single_token_marker_matches_by_piece_when_id_differs() {
+    var eval = tokenAware(new StateBounds(REASONING, "<think>", "</think>"));
+
+    // Model emitted a token with a different id whose text equals the marker.
+    var open = eval.evaluateToken(ANSWER, 999, "<think>");
+    assertThat(open.state()).isEqualTo(REASONING);
+  }
+
+  @Test
+  void two_token_open_marker_buffers_then_stamps_reasoning() {
+    var eval = tokenAware(
+      new StateBounds(REASONING, "<|channel>thought", "<|channel>end")
+    );
+
+    // First marker token: buffered, nothing emitted, still ANSWER.
+    var first = eval.evaluateToken(ANSWER, 200, "<|channel>");
+    assertThat(first.state()).isEqualTo(ANSWER);
+    assertThat(first.emit()).isEmpty();
+    assertThat(first.emitTokens()).isZero();
+    assertThat(eval.hasPending()).isTrue();
+
+    // Second marker token: full sequence confirmed — whole marker emitted in REASONING.
+    var second = eval.evaluateToken(ANSWER, 201, "thought");
+    assertThat(second.state()).isEqualTo(REASONING);
+    // marker text never leaks into any channel; tokens still counted post-flip
+    assertThat(second.emit()).isEmpty();
+    assertThat(second.emitTokens()).isEqualTo(2);
+    assertThat(eval.hasPending()).isFalse();
+
+    // Reasoning content flows in REASONING.
+    assertThat(eval.evaluateToken(REASONING, 7, "hmm").state()).isEqualTo(
+      REASONING
+    );
+
+    // Two-token close marker: buffer then back to ANSWER with the full close text.
+    var closeFirst = eval.evaluateToken(REASONING, 200, "<|channel>");
+    assertThat(closeFirst.state()).isEqualTo(REASONING);
+    assertThat(closeFirst.emitTokens()).isZero();
+    var closeSecond = eval.evaluateToken(REASONING, 202, "end");
+    assertThat(closeSecond.state()).isEqualTo(ANSWER);
+    assertThat(closeSecond.emit()).isEmpty(); // marker text suppressed
+    assertThat(closeSecond.emitTokens()).isEqualTo(2);
+
+    // Reasoning does not re-enter once closed.
+    var reOpen = eval.evaluateToken(ANSWER, 200, "<|channel>");
+    assertThat(reOpen.state()).isEqualTo(ANSWER);
+    assertThat(reOpen.emit()).isEqualTo("<|channel>");
+    assertThat(reOpen.emitTokens()).isEqualTo(1);
+    assertThat(eval.evaluateToken(ANSWER, 201, "thought").state()).isEqualTo(
+      ANSWER
+    );
+  }
+
+  @Test
+  void refuted_prefix_is_emitted_in_current_channel() {
+    var eval = tokenAware(
+      new StateBounds(REASONING, "<|channel>thought", "<|channel>end")
+    );
+
+    var first = eval.evaluateToken(ANSWER, 200, "<|channel>");
+    assertThat(first.emitTokens()).isZero();
+
+    var refuted = eval.evaluateToken(ANSWER, 42, "Hello");
+    assertThat(refuted.state()).isEqualTo(ANSWER);
+    assertThat(refuted.emit()).isEqualTo("<|channel>Hello");
+    assertThat(refuted.emitTokens()).isEqualTo(2);
+    assertThat(eval.hasPending()).isFalse();
+  }
+
+  @Test
+  void refuting_token_can_itself_restart_a_marker_prefix() {
+    var eval = tokenAware(
+      new StateBounds(REASONING, "<|channel>thought", "<|channel>end")
+    );
+
+    eval.evaluateToken(ANSWER, 200, "<|channel>");
+    // Same first marker token again: previous prefix refuted (flushed), new prefix buffered.
+    var again = eval.evaluateToken(ANSWER, 200, "<|channel>");
+    assertThat(again.state()).isEqualTo(ANSWER);
+    assertThat(again.emit()).isEqualTo("<|channel>");
+    assertThat(again.emitTokens()).isEqualTo(1);
+    assertThat(eval.hasPending()).isTrue();
+
+    var confirmed = eval.evaluateToken(ANSWER, 201, "thought");
+    assertThat(confirmed.state()).isEqualTo(REASONING);
+    assertThat(confirmed.emit()).isEmpty(); // marker text suppressed
+    assertThat(confirmed.emitTokens()).isEqualTo(2);
+  }
+
+  @Test
+  void flush_pending_returns_buffered_prefix_in_current_channel() {
+    var eval = tokenAware(
+      new StateBounds(REASONING, "<|channel>thought", "<|channel>end")
+    );
+
+    eval.evaluateToken(ANSWER, 200, "<|channel>");
+    var flush = eval.flushPending(ANSWER);
+    assertThat(flush.state()).isEqualTo(ANSWER);
+    assertThat(flush.emit()).isEqualTo("<|channel>");
+    assertThat(flush.emitTokens()).isEqualTo(1);
+    assertThat(eval.hasPending()).isFalse();
+
+    // Flushing with nothing pending is a no-op.
+    var empty = eval.flushPending(ANSWER);
+    assertThat(empty.emitTokens()).isZero();
+  }
+
+  @Test
+  void two_token_tool_markers_enter_and_exit_tools() {
+    var eval = tokenAware(new StateBounds(TOOLS, "<|tool>call", "<|tool>end"));
+
+    assertThat(
+      eval.evaluateToken(ANSWER, 210, "<|tool>").emitTokens()
+    ).isZero();
+    var open = eval.evaluateToken(ANSWER, 211, "call");
+    assertThat(open.state()).isEqualTo(TOOLS);
+    assertThat(open.emit()).isEmpty(); // marker text suppressed
+
+    assertThat(
+      eval.evaluateToken(TOOLS, 8, "{\"name\":\"x\"}").state()
+    ).isEqualTo(TOOLS);
+
+    assertThat(eval.evaluateToken(TOOLS, 210, "<|tool>").emitTokens()).isZero();
+    var close = eval.evaluateToken(TOOLS, 212, "end");
+    assertThat(close.state()).isEqualTo(ANSWER);
+    assertThat(close.emit()).isEmpty(); // marker text suppressed
+
+    // tools can reoccur
+    eval.evaluateToken(ANSWER, 210, "<|tool>");
+    assertThat(eval.evaluateToken(ANSWER, 211, "call").state()).isEqualTo(
+      TOOLS
+    );
+  }
+
+  @Test
+  void mixed_single_and_multi_token_markers_coexist() {
+    var eval = tokenAware(
+      new StateBounds(REASONING, "<think>", "</think>"),
+      new StateBounds(TOOLS, "<|tool>call", "<|tool>end")
+    );
+
+    assertThat(eval.evaluateToken(ANSWER, 100, "<think>").state()).isEqualTo(
+      REASONING
+    );
+    assertThat(
+      eval.evaluateToken(REASONING, 101, "</think>").state()
+    ).isEqualTo(ANSWER);
+
+    assertThat(
+      eval.evaluateToken(ANSWER, 210, "<|tool>").emitTokens()
+    ).isZero();
+    assertThat(eval.evaluateToken(ANSWER, 211, "call").state()).isEqualTo(
+      TOOLS
+    );
+  }
+
+  /* ----- tokenization variants of the same marker text ----- */
+
+  @Test
+  void fused_single_piece_marker_confirms() {
+    var eval = tokenAware(
+      new StateBounds(REASONING, "<|channel>thought", "<|channel>end")
+    );
+
+    // The whole marker arrives as ONE piece.
+    var fused = eval.evaluateToken(ANSWER, 1, "<|channel>thought");
+    assertThat(fused.state()).isEqualTo(REASONING);
+    assertThat(fused.emit()).isEmpty();
+    assertThat(fused.emitTokens()).isEqualTo(1);
+  }
+
+  @Test
+  void boundary_spanning_piece_confirms_and_emits_remainder_post_flip() {
+    var eval = tokenAware(
+      new StateBounds(REASONING, "<|channel>thought", "<|channel>end")
+    );
+
+    assertThat(
+      eval.evaluateToken(ANSWER, 1, "<|channel>").emitTokens()
+    ).isZero();
+    // Piece completes the marker AND carries trailing text: the remainder is the first
+    // text of the post-flip channel; marker text stays suppressed.
+    var spanning = eval.evaluateToken(ANSWER, 2, "thought\nThe");
+    assertThat(spanning.state()).isEqualTo(REASONING);
+    assertThat(spanning.emit()).isEqualTo("\nThe");
+    assertThat(spanning.emitTokens()).isEqualTo(2);
+  }
+
+  @Test
+  void single_piece_spanning_single_token_marker_splits() {
+    var eval = tokenAware(new StateBounds(REASONING, "<think>", "</think>"));
+
+    var spanning = eval.evaluateToken(ANSWER, 1, "<think>Okay");
+    assertThat(spanning.state()).isEqualTo(REASONING);
+    assertThat(spanning.emit()).isEqualTo("Okay");
+    assertThat(spanning.emitTokens()).isEqualTo(1);
+  }
+
+  @Test
+  void subword_split_marker_confirms_identically() {
+    var eval = tokenAware(
+      new StateBounds(REASONING, "<|channel>thought", "<|channel>end")
+    );
+
+    // Same marker text, split at a non-token boundary.
+    assertThat(eval.evaluateToken(ANSWER, 1, "<|chan").emitTokens()).isZero();
+    var confirmed = eval.evaluateToken(ANSWER, 2, "nel>thought");
+    assertThat(confirmed.state()).isEqualTo(REASONING);
+    assertThat(confirmed.emit()).isEmpty();
+    assertThat(confirmed.emitTokens()).isEqualTo(2);
+  }
+
+  @Test
+  void three_way_split_marker_confirms() {
+    var eval = tokenAware(
+      new StateBounds(REASONING, "<|channel>thought", "<|channel>end")
+    );
+
+    assertThat(eval.evaluateToken(ANSWER, 1, "<|ch").emitTokens()).isZero();
+    assertThat(eval.evaluateToken(ANSWER, 2, "annel>th").emitTokens()).isZero();
+    var confirmed = eval.evaluateToken(ANSWER, 3, "ought");
+    assertThat(confirmed.state()).isEqualTo(REASONING);
+    assertThat(confirmed.emit()).isEmpty();
+    assertThat(confirmed.emitTokens()).isEqualTo(3);
+  }
+
+  @Test
+  void text_divergence_refutes_and_flushes_current_channel() {
+    var eval = tokenAware(
+      new StateBounds(REASONING, "<|channel>thought", "<|channel>end")
+    );
+
+    assertThat(eval.evaluateToken(ANSWER, 1, "<|chan").emitTokens()).isZero();
+    // Diverges from the marker text mid-way.
+    var refuted = eval.evaluateToken(ANSWER, 2, "xyz");
+    assertThat(refuted.state()).isEqualTo(ANSWER);
+    assertThat(refuted.emit()).isEqualTo("<|chanxyz");
+    assertThat(refuted.emitTokens()).isEqualTo(2);
+    assertThat(eval.hasPending()).isFalse();
+  }
+
+  @Test
+  void boundary_spanning_close_marker_returns_remainder_to_answer() {
+    var eval = tokenAware(
+      new StateBounds(REASONING, "<|channel>thought", "<|channel>end")
+    );
+
+    eval.evaluateToken(ANSWER, 1, "<|channel>thought");
+    assertThat(eval.evaluateToken(REASONING, 2, "pondering").state()).isEqualTo(
+      REASONING
+    );
+    assertThat(
+      eval.evaluateToken(REASONING, 3, "<|channel>").emitTokens()
+    ).isZero();
+    var close = eval.evaluateToken(REASONING, 4, "end The answer");
+    assertThat(close.state()).isEqualTo(ANSWER);
+    assertThat(close.emit()).isEqualTo(" The answer");
+    assertThat(close.emitTokens()).isEqualTo(2);
+  }
+
+  /* ----- input-side: prompt ending inside an unfinished span ----- */
+
+  @Test
+  void initial_state_enters_reasoning_when_prompt_ends_inside_open_span() {
+    var eval = of(new StateBounds(REASONING, "<think>", "</think>"));
+
+    assertThat(
+      eval.initialState(
+        "<|im_start|>assistant\n<think>partial reasoning so far"
+      )
+    ).isEqualTo(REASONING);
+  }
+
+  @Test
+  void initial_state_is_answer_when_last_span_is_closed() {
+    var eval = of(new StateBounds(REASONING, "<think>", "</think>"));
+
+    assertThat(eval.initialState("<think>done</think>The answer is")).isEqualTo(
+      ANSWER
+    );
+  }
+
+  @Test
+  void initial_state_detects_multi_token_marker_span_textually() {
+    var eval = of(
+      new StateBounds(REASONING, "<|channel>thought", "<|channel>end")
+    );
+
+    assertThat(
+      eval.initialState("prompt\n<|channel>thought partial")
+    ).isEqualTo(REASONING);
+    assertThat(
+      eval.initialState("prompt\n<|channel>thought done<|channel>end answer")
+    ).isEqualTo(ANSWER);
   }
 }

--- a/src/test/java/io/gravitee/llama/cpp/modules/StateEvaluationTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/modules/StateEvaluationTest.java
@@ -460,6 +460,165 @@ class StateEvaluationTest {
     assertThat(close.emitTokens()).isEqualTo(2);
   }
 
+  /* ----- Harmony-style chained channels (gpt-oss) ----- */
+
+  private static final String ANALYSIS_OPEN = "<|channel|>analysis<|message|>";
+  private static final String FINAL_FOLD =
+    "<|end|><|start|>assistant<|channel|>final<|message|>";
+  private static final String TOOL_OPEN =
+    "<|end|><|start|>assistant<|channel|>commentary to=functions.";
+  private static final String TOOL_CLOSE = "<|call|>";
+
+  private static StateEvaluation harmony() {
+    return tokenAware(
+      new StateBounds(REASONING, ANALYSIS_OPEN, FINAL_FOLD),
+      new StateBounds(TOOLS, TOOL_OPEN, TOOL_CLOSE)
+    );
+  }
+
+  @Test
+  void harmony_analysis_to_final_via_folded_close() {
+    var eval = harmony();
+
+    assertThat(eval.evaluateToken(ANSWER, 1, ANALYSIS_OPEN).state()).isEqualTo(
+      REASONING
+    );
+    assertThat(
+      eval.evaluateToken(REASONING, 2, "thinking...").state()
+    ).isEqualTo(REASONING);
+
+    // Folded close spelled over several pieces sharing a prefix with the tool open.
+    assertThat(
+      eval.evaluateToken(REASONING, 3, "<|end|>").emitTokens()
+    ).isZero();
+    assertThat(
+      eval.evaluateToken(REASONING, 4, "<|start|>").emitTokens()
+    ).isZero();
+    assertThat(
+      eval.evaluateToken(REASONING, 5, "assistant").emitTokens()
+    ).isZero();
+    assertThat(
+      eval.evaluateToken(REASONING, 6, "<|channel|>").emitTokens()
+    ).isZero();
+    // "final" disambiguates towards the close; still buffering.
+    assertThat(eval.evaluateToken(REASONING, 7, "final").emitTokens()).isZero();
+    var closed = eval.evaluateToken(REASONING, 8, "<|message|>");
+    assertThat(closed.state()).isEqualTo(ANSWER);
+    assertThat(closed.emit()).isEmpty();
+    assertThat(closed.emitTokens()).isEqualTo(6);
+
+    assertThat(eval.evaluateToken(ANSWER, 9, "London.").state()).isEqualTo(
+      ANSWER
+    );
+  }
+
+  @Test
+  void harmony_analysis_chains_directly_into_tool_call() {
+    var eval = harmony();
+
+    eval.evaluateToken(ANSWER, 1, ANALYSIS_OPEN);
+    eval.evaluateToken(REASONING, 2, "need the weather tool");
+
+    // Cross-transition: the tool OPEN matches while in REASONING (implicit close).
+    assertThat(
+      eval
+        .evaluateToken(REASONING, 3, "<|end|><|start|>assistant<|channel|>")
+        .emitTokens()
+    ).isZero();
+    var cross = eval.evaluateToken(
+      REASONING,
+      4,
+      "commentary to=functions.get_weather"
+    );
+    assertThat(cross.state()).isEqualTo(TOOLS);
+    // Marker suppressed; boundary-spanning remainder (the function name) lands post-flip.
+    assertThat(cross.emit()).isEqualTo("get_weather");
+    assertThat(cross.emitTokens()).isEqualTo(2);
+
+    assertThat(
+      eval.evaluateToken(TOOLS, 5, " {\"city\":\"Paris\"}").state()
+    ).isEqualTo(TOOLS);
+
+    // Tool close, then final text streams as ANSWER.
+    var toolClosed = eval.evaluateToken(TOOLS, 6, TOOL_CLOSE);
+    assertThat(toolClosed.state()).isEqualTo(ANSWER);
+    assertThat(toolClosed.emit()).isEmpty();
+    assertThat(eval.evaluateToken(ANSWER, 7, "It is sunny.").state()).isEqualTo(
+      ANSWER
+    );
+  }
+
+  @Test
+  void harmony_tool_chains_into_analysis_then_final() {
+    var eval = harmony();
+
+    // Straight into a tool call from ANSWER.
+    var open = eval.evaluateToken(ANSWER, 1, TOOL_OPEN + "get_capital");
+    assertThat(open.state()).isEqualTo(TOOLS);
+    assertThat(open.emit()).isEqualTo("get_capital");
+
+    // Cross-transition TOOLS → REASONING on the analysis open.
+    var cross = eval.evaluateToken(TOOLS, 2, ANALYSIS_OPEN);
+    assertThat(cross.state()).isEqualTo(REASONING);
+    assertThat(cross.emit()).isEmpty();
+    assertThat(cross.emitTokens()).isEqualTo(1);
+
+    assertThat(eval.evaluateToken(REASONING, 3, "got it").state()).isEqualTo(
+      REASONING
+    );
+
+    // Folded close (fused in one piece, with remainder) ends reasoning into ANSWER.
+    var closed = eval.evaluateToken(REASONING, 4, FINAL_FOLD + "Paris");
+    assertThat(closed.state()).isEqualTo(ANSWER);
+    assertThat(closed.emit()).isEqualTo("Paris");
+    assertThat(closed.emitTokens()).isEqualTo(1);
+  }
+
+  @Test
+  void shared_prefix_longest_match_prefers_longer_candidate() {
+    var eval = tokenAware(
+      new StateBounds(REASONING, "<r>", "<|end|>"),
+      new StateBounds(TOOLS, "<|end|><|tool|>", "<|call|>")
+    );
+
+    eval.evaluateToken(ANSWER, 1, "<r>");
+    // The fused piece covers BOTH the reasoning close "<|end|>" and the tool open
+    // "<|end|><|tool|>" — the longest candidate wins, transitioning directly to TOOLS.
+    var cross = eval.evaluateToken(REASONING, 2, "<|end|><|tool|>{");
+    assertThat(cross.state()).isEqualTo(TOOLS);
+    assertThat(cross.emit()).isEqualTo("{");
+    assertThat(cross.emitTokens()).isEqualTo(1);
+  }
+
+  @Test
+  void cross_transition_marks_reasoning_occurred() {
+    var eval = harmony();
+
+    eval.evaluateToken(ANSWER, 1, ANALYSIS_OPEN);
+    eval.evaluateToken(REASONING, 2, TOOL_OPEN + "f");
+    eval.evaluateToken(TOOLS, 3, TOOL_CLOSE);
+
+    // Reasoning implicitly closed by the cross-transition: it must not re-enter.
+    var reOpen = eval.evaluateToken(ANSWER, 4, ANALYSIS_OPEN);
+    assertThat(reOpen.state()).isEqualTo(ANSWER);
+    assertThat(reOpen.emit()).isEqualTo(ANALYSIS_OPEN);
+  }
+
+  @Test
+  void single_state_config_ignores_cross_transitions() {
+    var eval = tokenAware(new StateBounds(REASONING, "<think>", "</think>"));
+
+    eval.evaluateToken(ANSWER, 1, "<think>");
+    // With only one state configured there are no cross candidates: unrelated tag-like
+    // text streams through REASONING untouched, close still works — exactly as before.
+    var inner = eval.evaluateToken(REASONING, 2, "<tool_call>");
+    assertThat(inner.state()).isEqualTo(REASONING);
+    assertThat(inner.emit()).isEqualTo("<tool_call>");
+    assertThat(eval.evaluateToken(REASONING, 3, "</think>").state()).isEqualTo(
+      ANSWER
+    );
+  }
+
   /* ----- input-side: prompt ending inside an unfinished span ----- */
 
   @Test


### PR DESCRIPTION
Three features aimed at agentic serving, where consecutive requests share a
long prompt prefix and models mark reasoning/tool spans with grammar-specific
markers.

## Cross-request KV prefix reuse
`ConversationState.initialize(prompt, reusePrefixTokens)` + `setRetainKv` keep
a sequence's KV resident across requests (`TokenHistory` tracks the resident
token ids), so a warm turn prefills only its unshared suffix. A partial
`llama_memory_seq_rm` rejection (hybrid/recurrent architectures can only
rewind within their snapshot ring) falls back to a cold prefill and is
surfaced via `isPrefixReuseHonored()` so callers can report actual rather than
requested reuse. `PrefixReuseTest` asserts warm-turn decode work is
proportional to the suffix using native decode counters.

## MTP prefill fixes
MTP previously forced embeddings mode on the target context, which made
llama.cpp mark every prompt token as an output — an O(prompt) lm_head +
embedding-extraction tax on each prefill. The prompt bulk now decodes with
embeddings disabled and only the final token pays extraction; the draft seed
reads the last logits row (`ith = -1`). Failed prompt decodes are terminal for
their sequence instead of hot-looping.

## Text-based, channel-aware tag matching
`StateEvaluation` replaces single-piece marker equality with a streaming
text-prefix machine: markers match regardless of tokenization (fused pieces,
subword splits, boundary-spanning tokens are split across channels), marker
text is suppressed from all channels, and token counts attribute to the
post-flip channel. Channels may chain rather than nest — in any state the
matcher considers the current close marker and other states' open markers with
longest-match disambiguation — which is exactly the shape of gpt-oss Harmony
(`analysis → final` or `analysis → tool call`) and Gemma 4's channel grammar.
Single-token configs (`<think>…</think>`) are behavior-identical.

## Post-review additions

Two fixes landed while validating additional model families against the
branch:

**Chained (non-nested) channel grammars** — some models end a span by
opening the next one rather than closing back to the answer stream (gpt-oss
Harmony: an analysis span flows either into the final answer or directly
into a tool call). In any state the matcher now also considers the other
states' open markers, with longest-match disambiguation across shared
prefixes; confirming a foreign open transitions directly and implicitly
closes the current span. Tool-call finish is marked on leaving the tool
state regardless of destination. Single-state configs
(`<think>…</think>`) are behavior-identical by construction.

**UTF-8 tokenization length fix** — `LlamaTokenizer` passed
`String.length()` (UTF-16 char count) as `text_len` to `llama_tokenize`,
which treats it as a byte count over the UTF-8 native segment: any prompt
containing multi-byte characters was silently truncated at the tail by
(utf8Bytes − chars) bytes. With enough non-ASCII content (e.g. GLM-4's
Chinese template instructions) the truncation consumed the generation
header and the final user turn, producing deterministic off-topic,
mid-word output that was easy to misattribute to the model or its GGUF.
Now passes the segment's byte size; a model-generic multi-byte round-trip
regression test (accents, CJK, emoji) guards it.