### PR TITLE
feat: cross-sequence KV prefix publishing, plus two fixes found on the way

### DIFF
--- a/src/main/java/io/gravitee/llama/cpp/LlamaContext.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaContext.java
@@ -36,6 +36,7 @@ public final class LlamaContext extends MemorySegmentAware implements Freeable {
   private final int nBatch;
   private final int nUBatch;
   private final int nSeqMax;
+  private final boolean kvUnified;
   private final LlamaMemory memory;
 
   public LlamaContext(
@@ -53,6 +54,9 @@ public final class LlamaContext extends MemorySegmentAware implements Freeable {
     this.nBatch = LlamaRuntime.llama_n_batch(segment);
     this.nUBatch = LlamaRuntime.llama_n_ubatch(segment);
     this.nSeqMax = LlamaRuntime.llama_n_seq_max(segment);
+    // Recorded from the params: there is no native getter, and it decides whether KV cells can be
+    // shared between sequences at all (see LlamaMemory#copyPrefix).
+    this.kvUnified = params.kvUnified();
     this.memory = new LlamaMemory(this);
   }
 
@@ -105,6 +109,15 @@ public final class LlamaContext extends MemorySegmentAware implements Freeable {
 
   public int nSeqMax() {
     return nSeqMax;
+  }
+
+  /**
+   * Whether this context's KV cache is one unified buffer shared by every sequence. When
+   * {@code false} (llama.cpp's default) each sequence has its own stream and KV cells cannot be
+   * shared — see {@link LlamaContextParams#kvUnified(boolean)}.
+   */
+  public boolean isKvUnified() {
+    return kvUnified;
   }
 
   public int nVocab() {

--- a/src/main/java/io/gravitee/llama/cpp/LlamaContextParams.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaContextParams.java
@@ -57,6 +57,30 @@ public final class LlamaContextParams extends MemorySegmentAware {
     return this;
   }
 
+  /**
+   * Whether the KV cache is one unified buffer shared by every sequence, rather than one buffer
+   * per sequence. Defaults to {@code false} in llama.cpp.
+   *
+   * <p>This decides whether KV cells can be <em>shared</em> between sequences. Unified means a
+   * single stream ({@code n_stream == 1}), so all sequences index the same cell pool and a cell
+   * carries a set of sequence ids: {@link LlamaMemory#copyPrefix} is then pure metadata, and a
+   * partial range works. Non-unified gives each sequence its own stream, and
+   * {@code llama_memory_seq_cp} must physically copy buffer data — it then supports only whole
+   * sequences and <b>aborts the process</b> on a partial range
+   * ({@code GGML_ASSERT(is_full && "seq_cp() is only supported for full KV buffers")}).
+   *
+   * <p>Enable it for cross-sequence prefix sharing. The trade-off is that a unified cache is a
+   * single pool of {@code n_ctx} cells for all sequences to share, rather than {@code n_ctx} each.
+   */
+  public boolean kvUnified() {
+    return kv_unified(this.segment);
+  }
+
+  public LlamaContextParams kvUnified(boolean kvUnified) {
+    kv_unified(this.segment, kvUnified);
+    return this;
+  }
+
   public int nSeqMax() {
     return n_seq_max(this.segment);
   }

--- a/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
@@ -288,9 +288,18 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
 
     // Mark tool call as finished once we leave the tools section — via its close marker
     // (→ ANSWER) or a chained cross-transition directly into another state (Harmony-style).
+    //
+    // Only when something was actually captured in there. With a chained grammar whose markers
+    // share a prefix — Harmony's reasoning-close and tool-open agree for 34 characters
+    // ("<|end|><|start|>assistant<|channel|>") — the shared run buffers, the machine provisionally
+    // enters TOOLS, and the text then resolves to the OTHER marker and transitions straight back
+    // out. That round trip emits no tool tokens, so reporting TOOL_CALL would announce a tool call
+    // the model never made. Downstream that is not a harmless label: a tool_calls finish with an
+    // empty span invites callers to hunt for a call in the plain answer text and manufacture one.
     if (
       previousState == GenerationState.TOOLS &&
-      emission.state() != GenerationState.TOOLS
+      emission.state() != GenerationState.TOOLS &&
+      state.getTokenTracking().getOutputTokenCount(GenerationState.TOOLS) > 0
     ) {
       state.setFinishReason(FinishReason.TOOL_CALL);
     }

--- a/src/main/java/io/gravitee/llama/cpp/LlamaMemory.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaMemory.java
@@ -47,8 +47,16 @@ import static io.gravitee.llama.cpp.LlamaRuntime.*;
  */
 public class LlamaMemory extends MemorySegmentAware {
 
+  /**
+   * Whether the owning context shares one KV buffer across sequences. Recorded here because
+   * {@link #copyPrefix} is only legal when it is {@code true}, and violating that aborts the
+   * process rather than throwing.
+   */
+  private final boolean kvUnified;
+
   public LlamaMemory(LlamaContext context) {
     super(llama_get_memory(context.segment));
+    this.kvUnified = context.isKvUnified();
   }
 
   /**
@@ -147,12 +155,21 @@ public class LlamaMemory extends MemorySegmentAware {
    * {@code seqIdDst}, and returns the prefix length the destination may then reuse — the value to
    * pass to {@link ConversationState#initialize(String, int)}.
    *
-   * <p>This is the cross-request prefix cache in one call. A KV cell in llama.cpp carries a
-   * <em>set</em> of sequence ids rather than belonging to one, so the copy adds {@code seqIdDst}
-   * to the cells at positions {@code [0, matchedTokens)} and moves no tensor data: publishing a
-   * 2000-token system prompt to a second conversation costs microseconds and no extra VRAM. The
-   * source may still be generating — cells it shares are not disturbed, and it never rewinds into
-   * its own prompt.
+   * <p>This is the cross-request prefix cache in one call, and it <b>requires a unified KV
+   * cache</b> ({@link LlamaContextParams#kvUnified(boolean)}). Under a unified cache there is a
+   * single stream, so every sequence indexes the same cell pool and a cell carries a <em>set</em>
+   * of sequence ids: the copy adds {@code seqIdDst} to the cells at {@code [0, matchedTokens)} and
+   * moves no tensor data. Publishing a 2000-token system prompt to a second conversation then
+   * costs microseconds and no extra VRAM, and the source may still be generating — cells it shares
+   * are not disturbed, and it never rewinds into its own prompt.
+   *
+   * <p>Without a unified cache each sequence owns its own stream and llama.cpp must physically
+   * copy buffer data, which it supports only for a whole sequence: a partial range trips
+   * {@code GGML_ASSERT(is_full && "seq_cp() is only supported for full KV buffers")}, and a failed
+   * GGML assert calls {@code abort()} — it takes the JVM down with SIGABRT, uncatchably. This
+   * method therefore refuses up front with a {@link LlamaException} rather than letting the process
+   * die. Copying the whole sequence and trimming afterwards is not a workaround: on that path the
+   * copy is real, so it would cost full KV memory and full copy time, defeating the purpose.
    *
    * <p>The two rules this method exists to enforce:
    * <ul>
@@ -201,6 +218,15 @@ public class LlamaMemory extends MemorySegmentAware {
     if (seqIdSrc == seqIdDst) {
       throw new LlamaException(
         "copyPrefix source and destination must differ (got " + seqIdSrc + ")"
+      );
+    }
+    if (!kvUnified) {
+      // Refuse rather than let GGML_ASSERT abort() the JVM on the cross-stream path.
+      throw new LlamaException(
+        "copyPrefix requires a unified KV cache: build the context with " +
+          "LlamaContextParams.kvUnified(true). Without it each sequence owns its own KV stream, " +
+          "llama_memory_seq_cp has to copy buffer data and only supports whole sequences, and a " +
+          "partial range aborts the process instead of failing."
       );
     }
     int reuse = Math.min(matchedTokens, promptTokens - 1);

--- a/src/main/java/io/gravitee/llama/cpp/LlamaMemory.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaMemory.java
@@ -143,6 +143,76 @@ public class LlamaMemory extends MemorySegmentAware {
   }
 
   /**
+   * Republishes the leading {@code matchedTokens} KV rows of {@code seqIdSrc} onto
+   * {@code seqIdDst}, and returns the prefix length the destination may then reuse — the value to
+   * pass to {@link ConversationState#initialize(String, int)}.
+   *
+   * <p>This is the cross-request prefix cache in one call. A KV cell in llama.cpp carries a
+   * <em>set</em> of sequence ids rather than belonging to one, so the copy adds {@code seqIdDst}
+   * to the cells at positions {@code [0, matchedTokens)} and moves no tensor data: publishing a
+   * 2000-token system prompt to a second conversation costs microseconds and no extra VRAM. The
+   * source may still be generating — cells it shares are not disturbed, and it never rewinds into
+   * its own prompt.
+   *
+   * <p>The two rules this method exists to enforce:
+   * <ul>
+   *   <li>The destination is wiped first. {@code seq_cp} adds rows rather than replacing them, so
+   *       copying onto a sequence that still holds cells would stack one prefix on another.</li>
+   *   <li>The result is clamped to {@code promptTokens - 1}. The final prompt token must always be
+   *       re-decoded to produce the logits its first output token is sampled from, so claiming it
+   *       as reused is never useful. {@code initialize} clamps too, but clamping here keeps the
+   *       rows we copy and the prefill we ask for in agreement.</li>
+   * </ul>
+   *
+   * <p><b>Caller invariant.</b> Whatever tracks which tokens a sequence holds must never advertise
+   * more than is provably resident, or a later copy reads cells that no longer exist. A sequence
+   * being prefilled holds only what was copied onto it; widen the record to
+   * {@link ConversationState#committedTokens()} — exactly positions {@code [0, nPast)} — only once
+   * the prefill has run. Retaining the source's KV is the caller's job too: mark its state
+   * {@link ConversationState#setRetainKv(boolean)} or remove it with {@code keepKv}, otherwise the
+   * rows are wiped when it finishes and the advertised prefix becomes a dangling claim.
+   *
+   * <p>Prefix reuse can still be refused at prefill time by recurrent and hybrid models, which
+   * cannot always rewind far enough for the partial trim; that path falls back to a cold full
+   * prefill and reports {@link ConversationState#isPrefixReuseHonored()} {@code == false}. Correct,
+   * just slower.
+   *
+   * @param seqIdSrc      Sequence holding the prefix
+   * @param seqIdDst      Sequence to publish it onto; its existing rows are discarded
+   * @param matchedTokens Leading tokens the two prompts share
+   * @param promptTokens  Length of the destination's tokenized prompt
+   * @return Prefix tokens the destination may reuse, {@code 0} when nothing was worth copying
+   *
+   * <p>Example — serve a prompt that shares a system prompt with a busy conversation:
+   * <pre>{@code
+   * int shared = commonPrefixLength(donorTokens, promptTokens);
+   * int reuse = memory.copyPrefix(donorSeqId, freeSeqId, shared, promptTokens.length);
+   * ConversationState.create(arena, ctx, tokenizer, sampler, freeSeqId)
+   *   .setRetainKv(true)
+   *   .initialize(prompt, reuse);   // prefills only the suffix
+   * }</pre>
+   */
+  public int copyPrefix(
+    int seqIdSrc,
+    int seqIdDst,
+    int matchedTokens,
+    int promptTokens
+  ) {
+    if (seqIdSrc == seqIdDst) {
+      throw new LlamaException(
+        "copyPrefix source and destination must differ (got " + seqIdSrc + ")"
+      );
+    }
+    int reuse = Math.min(matchedTokens, promptTokens - 1);
+    seqRm(seqIdDst, -1, -1);
+    if (reuse <= 0) {
+      return 0;
+    }
+    seqCp(seqIdSrc, seqIdDst, 0, reuse);
+    return reuse;
+  }
+
+  /**
    * Removes all tokens that do not belong to the specified sequence.
    * @param seqId The sequence ID to keep
    */

--- a/src/main/java/io/gravitee/llama/cpp/LlamaRuntime.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaRuntime.java
@@ -23,7 +23,9 @@ import java.lang.foreign.ValueLayout;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
@@ -37,6 +39,77 @@ public final class LlamaRuntime {
   private static final String runtime = PlatformResolver.platform().runtime();
   private static final String basePackage =
     "io.gravitee.llama.cpp.%s.".formatted(pkg);
+
+  /**
+   * Resolved jextract methods, keyed by class + name + signature.
+   *
+   * <p>Every native call funnels through {@link #invoke}, and resolving it means a
+   * {@code Class.forName} plus a {@code getMethod} scan that allocates a fresh defensive
+   * {@link Method} copy — on a generated binding class with hundreds of static methods, on every
+   * single call. The per-token path alone does roughly six of these per sequence.
+   *
+   * <p>The cache can never go stale: {@link #basePackage} is resolved once at class initialization
+   * from {@link PlatformResolver}, so a key always maps to the same method. {@code Method} is safe
+   * to share across threads as long as it is not mutated, and nothing here calls
+   * {@code setAccessible}. Size is bounded by the number of distinct bindings — a few hundred.
+   *
+   * <p>Deliberately not {@code MethodHandle}: the cost being removed is the <em>lookup</em>, not the
+   * call. {@code Method.invoke} is intrinsified after warmup, whereas a non-constant handle pulled
+   * from a map cannot be inlined and {@code invokeWithArguments} adds runtime {@code asType}
+   * adaptation — usually slower than cached reflection.
+   */
+  private static final ConcurrentHashMap<MethodKey, Method> METHOD_CACHE =
+    new ConcurrentHashMap<>();
+
+  /** Resolved bindings currently cached. Visible for tests. */
+  static int methodCacheSize() {
+    return METHOD_CACHE.size();
+  }
+
+  /**
+   * Cache key. Not a record: records compare array components by identity, so the
+   * {@code Class<?>[]} signature would never match and every lookup would silently miss.
+   *
+   * <p>Package-private so that equality can be unit-tested without loading native libraries —
+   * a broken {@code equals} here is invisible at runtime, costing only performance.
+   */
+  static final class MethodKey {
+
+    private final String className;
+    private final String methodName;
+    private final Class<?>[] parameterTypes;
+    private final int hash;
+
+    MethodKey(String className, String methodName, Class<?>[] parameterTypes) {
+      this.className = className;
+      this.methodName = methodName;
+      this.parameterTypes = parameterTypes;
+      this.hash =
+        31 * (31 * className.hashCode() + methodName.hashCode()) +
+        Arrays.hashCode(parameterTypes);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof MethodKey other)) {
+        return false;
+      }
+      return (
+        hash == other.hash &&
+        className.equals(other.className) &&
+        methodName.equals(other.methodName) &&
+        Arrays.equals(parameterTypes, other.parameterTypes)
+      );
+    }
+
+    @Override
+    public int hashCode() {
+      return hash;
+    }
+  }
 
   private LlamaRuntime() {}
 
@@ -2784,9 +2857,21 @@ public final class LlamaRuntime {
     Object... args
   ) {
     try {
-      String fullClassName = basePackage + classNameSuffix;
-      Class<?> targetClass = Class.forName(fullClassName);
-      Method method = targetClass.getMethod(methodName, parameterTypes);
+      MethodKey key = new MethodKey(
+        classNameSuffix,
+        methodName,
+        parameterTypes
+      );
+      Method method = METHOD_CACHE.get(key);
+      if (method == null) {
+        // Plain get/put rather than computeIfAbsent: two threads racing a miss resolve the same
+        // method and one harmlessly overwrites the other, and the hit path stays free of the
+        // mapping-function indirection.
+        String fullClassName = basePackage + classNameSuffix;
+        Class<?> targetClass = Class.forName(fullClassName);
+        method = targetClass.getMethod(methodName, parameterTypes);
+        METHOD_CACHE.put(key, method);
+      }
       return (T) method.invoke(null, args); // Invoke static method, so obj is null
     } catch (ClassNotFoundException e) {
       throw new IllegalStateException(

--- a/src/main/java/io/gravitee/llama/cpp/LlamaRuntime.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaRuntime.java
@@ -1671,6 +1671,23 @@ public final class LlamaRuntime {
     );
   }
 
+  public static boolean kv_unified(MemorySegment segment) {
+    return llama_context_params(
+      "kv_unified",
+      new Class<?>[] { MEM_SEG_CLASS },
+      segment
+    );
+  }
+
+  public static void kv_unified(MemorySegment segment, boolean kvUnified) {
+    llama_context_params(
+      "kv_unified",
+      new Class<?>[] { MEM_SEG_CLASS, boolean.class },
+      segment,
+      kvUnified
+    );
+  }
+
   public static int flash_attn_type(MemorySegment segment) {
     return llama_context_params(
       "flash_attn_type",

--- a/src/test/java/io/gravitee/llama/cpp/KvPrefixCopyTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/KvPrefixCopyTest.java
@@ -157,8 +157,35 @@ class KvPrefixCopyTest extends LlamaCppTest {
       .nBatch(512)
       .nUBatch(512)
       .nSeqMax(4)
+      // REQUIRED for copyPrefix: one shared cell pool, so cells carry a set of sequence ids and
+      // seq_cp is metadata-only. Without it each sequence owns a stream, seq_cp must copy buffer
+      // data, and a partial range aborts the process.
+      .kvUnified(true)
       .noPerf(false);
     return track(new LlamaContext(arena, model, params));
+  }
+
+  /**
+   * The guard that keeps a misconfiguration from killing the JVM. On a non-unified context
+   * llama.cpp would trip GGML_ASSERT(is_full) inside seq_cp and abort() the process; copyPrefix
+   * must refuse first.
+   */
+  @Test
+  void a_non_unified_context_is_refused_rather_than_aborting() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var params = new LlamaContextParams(arena)
+      .nCtx(512)
+      .nBatch(256)
+      .nUBatch(256)
+      .nSeqMax(2)
+      .kvUnified(false);
+    var ctx = track(new LlamaContext(arena, model, params));
+
+    assertThat(ctx.isKvUnified()).isFalse();
+    assertThatThrownBy(() -> ctx.getMemory().copyPrefix(0, 1, 4, 10))
+      .isInstanceOf(LlamaException.class)
+      .hasMessageContaining("unified KV cache");
   }
 
   private ConversationState newState(

--- a/src/test/java/io/gravitee/llama/cpp/KvPrefixCopyTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/KvPrefixCopyTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static io.gravitee.llama.cpp.LlamaCppTest.MODEL_PATH;
+import static io.gravitee.llama.cpp.LlamaCppTest.MODEL_TO_DOWNLOAD;
+import static io.gravitee.llama.cpp.LlamaCppTest.getModelPath;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.llama.cpp.nativelib.LlamaLibLoader;
+import java.lang.foreign.Arena;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Cross-sequence KV prefix publishing: {@link LlamaMemory#copyPrefix(int, int, int, int)} shares a
+ * resident prefix with a second sequence so it prefills only the suffix.
+ *
+ * <p>Where {@code PrefixReuseTest} covers reuse across turns of the <em>same</em> sequence, this
+ * covers reuse across <em>different</em> ones — including copying from a sequence that is still
+ * generating, which is what lets concurrent conversations behind a shared system prompt prefill it
+ * once between them. Policy (which sequence, eviction, cache keys) lives in the serving layer;
+ * this is the mechanism it stands on.
+ *
+ * @author GraviteeSource Team
+ */
+@Tag("integration")
+class KvPrefixCopyTest extends LlamaCppTest {
+
+  private static final String PROMPT = "The capital of France is";
+  private static final int MAX_TOKENS = 8;
+
+  private static Arena arena;
+
+  @BeforeAll
+  static void beforeAll() {
+    arena = Arena.ofConfined();
+    String libPath = LlamaLibLoader.load();
+    LlamaRuntime.llama_backend_init();
+    LlamaRuntime.ggml_backend_load_all_from_path(arena, libPath);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    LlamaRuntime.llama_backend_free();
+    arena.close();
+    arena = null;
+  }
+
+  /**
+   * The core claim: with sequence 0 mid-generation, an identical prompt on sequence 1 decodes
+   * exactly one prompt token — the final one, always re-decoded for its logits — instead of the
+   * whole prompt, and produces byte-identical greedy output. The donor is left untouched.
+   */
+  @Test
+  void prefix_copied_from_a_generating_sequence_prefills_only_the_suffix() {
+    var ctx = newContext();
+    var tokenizer = new LlamaTokenizer(new LlamaVocab(ctx.getModel()), ctx);
+    int[] tokens = tokensOf(tokenizer, PROMPT);
+
+    // Sequence 0 — cold, and deliberately left mid-generation so the copy reads a live sequence.
+    var donor = newState(ctx, tokenizer, 0).initialize(PROMPT);
+    var donorIterator = new DefaultLlamaIterator(donor);
+    List<String> donorPieces = new ArrayList<>();
+    for (int i = 0; i < 3 && donorIterator.hasNext(); i++) {
+      donorPieces.add(donorIterator.next().content());
+    }
+    assertThat(donor.isFinished()).isFalse();
+    int donorSpan = ctx.getMemory().posMax(0);
+    assertThat(donorSpan).isGreaterThanOrEqualTo(tokens.length - 1);
+
+    // Publish its prompt prefix onto sequence 1. committedTokens() is exactly what is resident.
+    int[] committed = donor.committedTokens();
+    int shared = commonPrefix(committed, tokens);
+    int reuse = ctx.getMemory().copyPrefix(0, 1, shared, tokens.length);
+
+    assertThat(reuse).isEqualTo(tokens.length - 1);
+    assertThat(ctx.getMemory().posMax(1)).isEqualTo(reuse - 1);
+    // Zero-copy: publishing to sequence 1 did not disturb sequence 0.
+    assertThat(ctx.getMemory().posMax(0)).isEqualTo(donorSpan);
+
+    // Sequence 1 — warm: only the final prompt token is decoded.
+    var warm = newState(ctx, tokenizer, 1).initialize(PROMPT, reuse);
+    var warmIterator = new DefaultLlamaIterator(warm);
+    long before = decodedTokens(ctx);
+    boolean hasNext = warmIterator.hasNext();
+    long warmPrefill = decodedTokens(ctx) - before;
+    String warmText = drain(warmIterator, hasNext);
+
+    assertThat(warm.isPrefixReuseHonored()).isTrue();
+    assertThat(warmPrefill).isEqualTo(1);
+
+    // The donor keeps generating correctly after having been copied from.
+    while (donorIterator.hasNext()) {
+      donorPieces.add(donorIterator.next().content());
+    }
+    String donorText = String.join("", donorPieces);
+
+    // A cold run of the same prompt on a fresh context is the reference for both.
+    String coldText = runCold(PROMPT);
+    assertThat(warmText).isEqualTo(coldText);
+    assertThat(donorText).isEqualTo(coldText);
+  }
+
+  /** A copy too short to be worth anything still leaves the destination clean and empty. */
+  @Test
+  void trivial_match_copies_nothing_and_clears_the_destination() {
+    var ctx = newContext();
+    var tokenizer = new LlamaTokenizer(new LlamaVocab(ctx.getModel()), ctx);
+
+    var donor = newState(ctx, tokenizer, 0).initialize(PROMPT);
+    assertThat(new DefaultLlamaIterator(donor).hasNext()).isTrue();
+
+    // Seed sequence 1 with unrelated rows, then publish a zero-length prefix onto it.
+    var stale = newState(ctx, tokenizer, 1).initialize("Once upon a time in");
+    assertThat(new DefaultLlamaIterator(stale).hasNext()).isTrue();
+    assertThat(ctx.getMemory().posMax(1)).isGreaterThanOrEqualTo(0);
+
+    assertThat(ctx.getMemory().copyPrefix(0, 1, 0, 12)).isZero();
+    assertThat(ctx.getMemory().posMax(1)).isEqualTo(-1);
+
+    // A single-token prompt can never reuse anything: its only token needs re-decoding.
+    assertThat(ctx.getMemory().copyPrefix(0, 1, 5, 1)).isZero();
+
+    assertThatThrownBy(() -> ctx.getMemory().copyPrefix(0, 0, 4, 10))
+      .isInstanceOf(LlamaException.class)
+      .hasMessageContaining("must differ");
+  }
+
+  // ---------------------------------------------------------------------------------------
+
+  private LlamaContext newContext() {
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var params = new LlamaContextParams(arena)
+      .nCtx(2048)
+      .nBatch(512)
+      .nUBatch(512)
+      .nSeqMax(4)
+      .noPerf(false);
+    return track(new LlamaContext(arena, model, params));
+  }
+
+  private ConversationState newState(
+    LlamaContext ctx,
+    LlamaTokenizer tokenizer,
+    int sequenceId
+  ) {
+    return ConversationState.create(
+      arena,
+      ctx,
+      tokenizer,
+      track(new LlamaSampler(arena).greedy()),
+      sequenceId
+    )
+      .setMaxTokens(MAX_TOKENS)
+      // Without this the iterator wipes the sequence on finish and the published prefix becomes
+      // a dangling claim.
+      .setRetainKv(true);
+  }
+
+  private String runCold(String prompt) {
+    var ctx = newContext();
+    var tokenizer = new LlamaTokenizer(new LlamaVocab(ctx.getModel()), ctx);
+    var state = newState(ctx, tokenizer, 0).initialize(prompt);
+    var iterator = new DefaultLlamaIterator(state);
+    return drain(iterator, iterator.hasNext());
+  }
+
+  private static String drain(DefaultLlamaIterator iterator, boolean hasNext) {
+    List<String> pieces = new ArrayList<>();
+    while (hasNext) {
+      pieces.add(iterator.next().content());
+      hasNext = iterator.hasNext();
+    }
+    return String.join("", pieces);
+  }
+
+  private static int commonPrefix(int[] a, int[] b) {
+    int n = Math.min(a.length, b.length);
+    int i = 0;
+    while (i < n && a[i] == b[i]) {
+      i++;
+    }
+    return i;
+  }
+
+  private static int[] tokensOf(LlamaTokenizer tokenizer, String prompt) {
+    var response = tokenizer.tokenize(arena, prompt);
+    int[] out = new int[response.size()];
+    for (int i = 0; i < response.size(); i++) {
+      out[i] = response.data().getAtIndex(JAVA_INT, i);
+    }
+    return out;
+  }
+
+  private static long decodedTokens(LlamaContext ctx) {
+    var p = ctx.getPerformance(arena);
+    return (long) p.promptTokensEvaluated() + p.tokensGenerated();
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/LlamaRuntimeMethodCacheTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/LlamaRuntimeMethodCacheTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.llama.cpp.LlamaRuntime.MethodKey;
+import java.lang.foreign.MemorySegment;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Cache-key semantics for the resolved-binding cache in {@link LlamaRuntime}.
+ *
+ * <p>The cache is keyed partly on a {@code Class<?>[]} signature, and every call site builds a
+ * <em>fresh</em> array. If equality compared those by identity — as a {@code record} would — every
+ * lookup would miss, the cache would grow without bound and the reflection cost it exists to remove
+ * would still be paid on every native call. Nothing at runtime would fail; it would just be slower.
+ * That silent failure is what these tests pin down.
+ *
+ * <p>No native libraries required.
+ *
+ * @author GraviteeSource Team
+ */
+class LlamaRuntimeMethodCacheTest {
+
+  @Test
+  void distinct_but_equal_signature_arrays_are_the_same_key() {
+    var first = new MethodKey(
+      "llama_h",
+      "llama_decode",
+      new Class<?>[] { MemorySegment.class, MemorySegment.class }
+    );
+    var second = new MethodKey(
+      "llama_h",
+      "llama_decode",
+      new Class<?>[] { MemorySegment.class, MemorySegment.class }
+    );
+
+    assertThat(first).isEqualTo(second);
+    assertThat(first.hashCode()).isEqualTo(second.hashCode());
+
+    // The property that actually matters: a second lookup hits rather than inserting.
+    var map = new HashMap<MethodKey, String>();
+    map.put(first, "resolved");
+    assertThat(map).containsKey(second).hasSize(1);
+    map.put(second, "resolved");
+    assertThat(map).hasSize(1);
+  }
+
+  @Test
+  void empty_signatures_match() {
+    assertThat(
+      new MethodKey("llama_h", "llama_backend_init", new Class<?>[] {})
+    ).isEqualTo(
+      new MethodKey("llama_h", "llama_backend_init", new Class<?>[] {})
+    );
+  }
+
+  @Test
+  void a_different_class_name_method_or_signature_is_a_different_key() {
+    var base = new MethodKey(
+      "llama_h",
+      "llama_decode",
+      new Class<?>[] { MemorySegment.class }
+    );
+
+    assertThat(base).isNotEqualTo(
+      new MethodKey(
+        "llama_model_params",
+        "llama_decode",
+        new Class<?>[] { MemorySegment.class }
+      )
+    );
+    assertThat(base).isNotEqualTo(
+      new MethodKey(
+        "llama_h",
+        "llama_encode",
+        new Class<?>[] { MemorySegment.class }
+      )
+    );
+    // Overloads differ only by signature — conflating them would dispatch to the wrong binding.
+    assertThat(base).isNotEqualTo(
+      new MethodKey(
+        "llama_h",
+        "llama_decode",
+        new Class<?>[] { MemorySegment.class, int.class }
+      )
+    );
+    assertThat(base).isNotEqualTo(
+      new MethodKey("llama_h", "llama_decode", new Class<?>[] { int.class })
+    );
+    assertThat(base).isNotEqualTo(null);
+    assertThat(base).isNotEqualTo("not a key");
+  }
+
+  @Test
+  void argument_order_is_significant() {
+    assertThat(
+      new MethodKey(
+        "llama_h",
+        "f",
+        new Class<?>[] { MemorySegment.class, int.class }
+      )
+    ).isNotEqualTo(
+      new MethodKey(
+        "llama_h",
+        "f",
+        new Class<?>[] { int.class, MemorySegment.class }
+      )
+    );
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/modules/SharedPrefixMarkerTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/modules/SharedPrefixMarkerTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.modules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.llama.cpp.GenerationState;
+import io.gravitee.llama.cpp.StateBounds;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Chained grammars whose markers share a leading run — the Harmony (gpt-oss) case.
+ *
+ * <p>Reasoning-close and tool-open agree for 34 characters:
+ * <pre>
+ *   reasoning_close: &lt;|end|&gt;&lt;|start|&gt;assistant&lt;|channel|&gt;final&lt;|message|&gt;
+ *   tool_open:       &lt;|end|&gt;&lt;|start|&gt;assistant&lt;|channel|&gt;commentary to=functions.
+ *                    └──────────── identical ────────────┘
+ * </pre>
+ *
+ * <p>While that shared run is buffered the machine cannot yet know which marker it is looking at.
+ * What matters downstream is that a run which resolves to the reasoning-close emits <b>no tool
+ * tokens</b> — a caller that reports a tool call on a zero-token span invites the response layer to
+ * go looking for a call in the plain answer and invent one from the first word it finds.
+ *
+ * <p>No model or native libraries required.
+ *
+ * @author GraviteeSource Team
+ */
+class SharedPrefixMarkerTest {
+
+  private static final String REASON_OPEN = "<|channel|>analysis<|message|>";
+  private static final String REASON_CLOSE =
+    "<|end|><|start|>assistant<|channel|>final<|message|>";
+  private static final String TOOL_OPEN =
+    "<|end|><|start|>assistant<|channel|>commentary to=functions.";
+  private static final String TOOL_CLOSE = "<|call|>";
+
+  /** Mirrors TokenTracking: accumulates emitted tokens per channel. */
+  private record Run(
+    Map<GenerationState, Integer> tokens,
+    String answer,
+    String reasoning
+  ) {}
+
+  /**
+   * Drives the real state machine over {@code pieces}, one token each, exactly as
+   * {@code LlamaIterator.processSampledToken} does.
+   */
+  private static Run drive(List<String> pieces) {
+    var evaluation = new StateEvaluation();
+    evaluation.initialize(
+      new StateEvaluation.Config(
+        List.of(
+          new StateBounds(GenerationState.REASONING, REASON_OPEN, REASON_CLOSE),
+          new StateBounds(GenerationState.TOOLS, TOOL_OPEN, TOOL_CLOSE)
+        )
+      )
+    );
+
+    Map<GenerationState, Integer> tokens = new EnumMap<>(GenerationState.class);
+    for (GenerationState s : GenerationState.values()) {
+      tokens.put(s, 0);
+    }
+    var answer = new StringBuilder();
+    var reasoning = new StringBuilder();
+
+    GenerationState state = GenerationState.ANSWER;
+    for (String piece : pieces) {
+      var emission = evaluation.evaluateToken(state, 0, piece);
+      state = emission.state();
+      tokens.merge(state, emission.emitTokens(), Integer::sum);
+      if (!emission.emit().isEmpty()) {
+        (state == GenerationState.REASONING ? reasoning : answer).append(
+          emission.emit()
+        );
+      }
+    }
+    var flushed = evaluation.flushPending(state);
+    if (!flushed.emit().isEmpty()) {
+      tokens.merge(flushed.state(), flushed.emitTokens(), Integer::sum);
+      (flushed.state() == GenerationState.REASONING
+          ? reasoning
+          : answer).append(flushed.emit());
+    }
+    return new Run(tokens, answer.toString(), reasoning.toString());
+  }
+
+  /** Splits text into small pieces so markers straddle token boundaries, as they really do. */
+  private static List<String> tokenize(String... chunks) {
+    List<String> out = new ArrayList<>();
+    for (String chunk : chunks) {
+      for (int i = 0; i < chunk.length(); i += 3) {
+        out.add(chunk.substring(i, Math.min(i + 3, chunk.length())));
+      }
+    }
+    return out;
+  }
+
+  /**
+   * The reported bug: the model reasons, decides to ASK the user rather than call a tool, and
+   * ends its analysis into the final channel. Nothing may be attributed to TOOLS.
+   */
+  @Test
+  void reasoning_that_ends_into_the_final_channel_emits_no_tool_tokens() {
+    var run = drive(
+      tokenize(
+        REASON_OPEN,
+        "User wants to send an email. We don't have Jamie's address. Let's ask.",
+        REASON_CLOSE,
+        "Could you give me Jamie's email address?"
+      )
+    );
+
+    assertThat(run.tokens().get(GenerationState.TOOLS))
+      .as("a refuted shared prefix must not be billed to TOOLS")
+      .isZero();
+    assertThat(run.answer()).isEqualTo(
+      "Could you give me Jamie's email address?"
+    );
+    assertThat(run.reasoning()).contains("Let's ask.");
+  }
+
+  /** The genuine tool call still registers — the guard must not suppress real spans. */
+  @Test
+  void reasoning_that_chains_into_a_tool_call_does_emit_tool_tokens() {
+    var run = drive(
+      tokenize(
+        REASON_OPEN,
+        "Jamie's address is known. Call send_email.",
+        TOOL_OPEN,
+        "send_email<|constrain|>json<|message|>{\"to\":\"jamie@example.com\"}",
+        TOOL_CLOSE
+      )
+    );
+
+    assertThat(run.tokens().get(GenerationState.TOOLS))
+      .as("a resolved tool span must be billed to TOOLS")
+      .isPositive();
+  }
+
+  /** A tool call with no marker prefix ambiguity behaves the same. */
+  @Test
+  void plain_answer_never_touches_tools() {
+    var run = drive(tokenize("The capital of France is Paris."));
+
+    assertThat(run.tokens().get(GenerationState.TOOLS)).isZero();
+    assertThat(run.answer()).isEqualTo("The capital of France is Paris.");
+  }
+}


### PR DESCRIPTION
## 1. `LlamaMemory.copyPrefix` — publish a KV prefix onto another sequence

Under a **unified** KV cache a llama.cpp cell carries a *set* of sequence ids
rather than belonging to one, so `llama_memory_seq_cp` shares a resident prefix
with a second sequence without moving tensor data: a 2000-token system prompt is
published in microseconds and costs no extra VRAM. `seq_cp` was already bound but
unused — prefix reuse was scoped to a single sequence across turns, so a prompt
resident on one sequence was prefilled again for the next.

That "unified" qualifier is load-bearing, and the first cut of this work missed
it. `seq_cp` has two implementations, selected by `n_stream(unified ? 1 : n_seq_max)`
at `llama-kv-cache.cpp:98`:

- **Unified** — a single stream, every sequence indexes the same cell pool, and
  `seq_cp` takes the metadata path: it honours `p0`/`p1` and just adds the
  destination id to the cells. This is the zero-copy sharing the PR is built on.
- **Non-unified (llama.cpp's default)** — each sequence owns its own stream,
  `seq_cp` must physically copy buffer data, and it supports only whole sequences.
  A partial range trips
  `GGML_ASSERT(is_full && "seq_cp() is only supported for full KV buffers")`.

`kv_unified` was never exposed by llamaj.cpp, so every context we built took the
aborting path — and a failed GGML assert is `abort()`, which no Java `catch` can
intercept. The JVM died with SIGABRT rather than throwing. So this PR also binds
`kv_unified` on `LlamaContextParams`, records it on `LlamaContext` (there is no
native getter), and has `copyPrefix` refuse a non-unified context with a
`LlamaException` naming the fix.

Copying the whole sequence and trimming afterwards is not a workaround: on the
cross-stream path the copy is real, so it would cost full KV memory and full copy
time. Callers opting into `kvUnified(true)` accept that the cache becomes one
shared pool of `n_ctx` cells rather than `n_ctx` per sequence.

`copyPrefix` encodes the two rules the operation needs:

- the destination is wiped first, since `seq_cp` **adds** rows rather than
  replacing them and would otherwise stack one prefix on another;
- the count is clamped below the prompt length, because the final prompt token
  must be re-decoded for the logits its first output token is sampled from — so
  the rows copied and the prefill requested agree on one number.

The javadoc carries the caller invariant, which is the part that bites: never
advertise more tokens than are provably resident, or a later copy shares cells
that no longer exist.

## 2. Only report `TOOL_CALL` when a tool span was captured

Leaving `TOOLS` set `FinishReason.TOOL_CALL` unconditionally. With a chained
grammar whose markers share a prefix that is wrong — Harmony's reasoning-close and
tool-open agree for 34 characters — so the shared run buffers, the machine
provisionally enters `TOOLS`, the text resolves to the *other* marker, and it
transitions straight back out having captured nothing.

Guarded on having actually emitted tokens in `TOOLS`. Token accounting makes this
exact: each token is billed to the state it resolves to, so at the moment of exit
the counter holds precisely what the span contained — zero for a refuted round trip.

## 3. Cache resolved jextract bindings in `LlamaRuntime.invoke`

Every native call re-resolved its binding: a string concat, a `Class.forName`, and
a `getMethod` that scans a generated class of hundreds of static methods and
allocates a fresh defensive `Method` copy. Nothing was memoized — roughly six such
lookups per token per sequence.

Deliberately `Method`, not `MethodHandle`: the cost removed is the *lookup*, not the
call. `Method.invoke` is intrinsified after warmup, whereas a non-constant handle
pulled from a map cannot be inlined and `invokeWithArguments` adds runtime `asType`
adaptation.