### PR TITLE
feat: Budget-aware EOG bias, multi-marker channels, special-token introspection

### DIFF
--- a/docs/text-generation/README.md
+++ b/docs/text-generation/README.md
@@ -123,10 +123,12 @@ it happens to overtake the next word, which is mid-clause, so the output is seve
 exactly as before, only earlier. Gated, the bias can only take an exit the text had
 already reached.
 
-**Size `maxBias` generously.** Mid-answer, EOG sits far below the running text in raw
-logits — much further than probabilities suggest. Measured on a 20B model, `24` and
-`48` never won a single step (the feature is then silently inert, indistinguishable
-from disabled); `100` lands the ending. Start there.
+**`maxBias` sets how early it lands.** Mid-answer, EOG sits far below the running text
+in raw logits — much further than probabilities suggest — so a small boost is simply
+inert, and an inert ramp is indistinguishable from a disabled one. Measured on a
+35B-A3B model at a 200-token budget: `12` never won a step (ran to the cap, severed),
+`24` landed at 191, `100` landed at 169. Larger means more margin, not a different
+ending; `100` is a sane default.
 
 Effects to expect:
 

--- a/docs/text-generation/README.md
+++ b/docs/text-generation/README.md
@@ -87,6 +87,7 @@ LlamaRuntime.llama_backend_free();
 | --- | --- |
 | `setMaxTokens(int n)` | Cap generated answer tokens; `-1` (default) means unlimited (until EOG/context full). Triggers `FinishReason.LENGTH`. |
 | `setStopStrings(List<String> stops)` | Stop as soon as the decoded tail matches any string; triggers `FinishReason.STOP`. |
+| `setEogRamp(float startFraction, float maxBias)` | Budget-aware soft landing: bias end-of-generation as `maxTokens` nears, so the answer finishes a sentence instead of being severed. Off by default. See below. |
 | `setTopLogprobs(int n)` | Attach top-`n` logprobs to each `LlamaOutput` (`0` = off). See the Log Probabilities doc. |
 | `initialize(String prompt)` | Tokenize the prompt and (re)set all generation state — call last. |
 
@@ -96,6 +97,52 @@ LlamaRuntime.llama_backend_free();
 | `EOS` / `STOP` | Model emitted an end-of-generation token or matched a stop string. |
 | `LENGTH` | `maxTokens` reached, or the context window filled. |
 | `TOOL_CALL` | A tool-call section completed (see Reasoning & Tool Calls). |
+
+## Budget-aware EOG ramp (soft landing)
+
+`setMaxTokens(n)` alone is a guillotine: generation runs at full speed until the
+counter trips, then stops mid-word. `setEogRamp(startFraction, maxBias)` turns the
+budget into a pressure instead.
+
+```java
+state.setMaxTokens(250).setEogRamp(0.75f, 100f);
+```
+
+Past `startFraction * maxTokens`, every end-of-generation token's logit is raised
+on a quadratic curve reaching `maxBias` at the cap. The boost is written into the
+logits row immediately before sampling, so it behaves exactly like a `logit_bias`
+sampler at the head of the chain and composes with temperature/top-k/top-p/penalties
+downstream. Below the threshold nothing is written, so most of a run is bit-identical
+to one without the ramp.
+
+**The bias only applies where the text can stop.** After sentence-terminating
+punctuation or a line break; from halfway up the ramp, also after clause punctuation
+(`, ; : — )`); at the cap, anywhere. This gate is not an optimisation — without it the
+ramp does not do what it looks like it does. Biasing every step makes EOG win wherever
+it happens to overtake the next word, which is mid-clause, so the output is severed
+exactly as before, only earlier. Gated, the bias can only take an exit the text had
+already reached.
+
+**Size `maxBias` generously.** Mid-answer, EOG sits far below the running text in raw
+logits — much further than probabilities suggest. Measured on a 20B model, `24` and
+`48` never won a single step (the feature is then silently inert, indistinguishable
+from disabled); `100` lands the ending. Start there.
+
+Effects to expect:
+
+- Completions end **short** of the budget on a finished sentence — `max_tokens`
+  becomes a target rather than a ceiling.
+- The hard cap still applies as a backstop, for answers with no boundary anywhere in
+  the ramp window (one long unbroken sentence, for instance).
+- `FinishReason` is `LENGTH`, not `STOP`, when an EOG is produced while the ramp is
+  active — the budget caused it, and agent loops rely on that to know the answer was
+  cut short.
+- Requires `maxTokens > 0`; with no budget the ramp is inert.
+- Applies under speculative decoding too. Rejection sampling is exact for any target
+  distribution provided the acceptance test and the residual draw see the same one,
+  and both derive from the biased row. Verify rows are biased at their projected
+  budget positions. The draft does not know about the bias, so acceptance dips for
+  the last few tokens — a throughput cost, not a correctness one.
 
 ## Notes
 - Call the fluent setters (`setMaxTokens`, `setStopStrings`, `setTopLogprobs`, ...) *before* `initialize(prompt)`; `initialize` resets generation state (and clears media) and tokenizes the prompt.

--- a/src/main/java/io/gravitee/llama/cpp/BatchIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/BatchIterator.java
@@ -713,6 +713,18 @@ public final class BatchIterator
     int matched = 0;
     int extra = -1;
     for (int i = 0; i < m; i++) {
+      // Row i is the distribution after i more tokens, so the budget ramp is evaluated at that
+      // projected position. Biasing the row before it is read keeps the acceptance test and the
+      // residual draw on the same target, which is what makes the round exact.
+      if (
+        biasEogRow(
+          s,
+          logitsRow(context, base + i, nVocab),
+          s.getAnswerTokens() + i
+        )
+      ) {
+        s.setEogRampApplied(true);
+      }
       if (spec.isGreedy()) {
         int t = chain.sample(context, base + i);
         if (t == drafted[i]) {
@@ -743,6 +755,16 @@ public final class BatchIterator
       }
     }
     if (matched == m) {
+      // Bonus token: every draft was accepted, so this row sits m tokens further along.
+      if (
+        biasEogRow(
+          s,
+          logitsRow(context, base + m, nVocab),
+          s.getAnswerTokens() + m
+        )
+      ) {
+        s.setEogRampApplied(true);
+      }
       extra = spec.isGreedy()
         ? chain.sample(context, base + m)
         : spec.targetSelect(chain, logitsRow(context, base + m, nVocab));

--- a/src/main/java/io/gravitee/llama/cpp/BatchIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/BatchIterator.java
@@ -965,6 +965,8 @@ public final class BatchIterator
     // enters the committed history when nPast is incremented below.
     int decodedToken = state.getNewTokenId();
     int batchPos = seqIdToBatchPos.get(state.getSequenceId());
+    // Budget-aware EOG boost, written into the logits this sample() is about to read.
+    applyEogRamp(state, batchPos);
     int newToken = state.getSampler().sample(context, batchPos);
     String tokenPiece = decodeTokenPiece(state, newToken);
 
@@ -975,7 +977,10 @@ public final class BatchIterator
     // multi-token marker prefix (if any) is flushed to the current channel.
     if (state.getTokenizer().isEog(newToken)) {
       if (state.getFinishReason() != FinishReason.TOOL_CALL) {
-        state.setFinishReason(FinishReason.STOP);
+        // Budget-driven EOG stays LENGTH: the cap produced it, not the model finishing.
+        state.setFinishReason(
+          state.isEogRampApplied() ? FinishReason.LENGTH : FinishReason.STOP
+        );
       }
       state.setFinished(true);
       flushPendingMarker(state, currentOutputs);

--- a/src/main/java/io/gravitee/llama/cpp/BatchIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/BatchIterator.java
@@ -712,19 +712,19 @@ public final class BatchIterator
 
     int matched = 0;
     int extra = -1;
+    // Per-position record of which rows the ramp biased. A flag on the state would be sticky for
+    // the whole round and would blame the budget for an EOG drawn from an unbiased row.
+    boolean[] rowBiased = new boolean[m + 1];
     for (int i = 0; i < m; i++) {
       // Row i is the distribution after i more tokens, so the budget ramp is evaluated at that
       // projected position. Biasing the row before it is read keeps the acceptance test and the
       // residual draw on the same target, which is what makes the round exact.
-      if (
-        biasEogRow(
-          s,
-          logitsRow(context, base + i, nVocab),
-          s.getAnswerTokens() + i
-        )
-      ) {
-        s.setEogRampApplied(true);
-      }
+      rowBiased[i] = biasEogRow(
+        s,
+        logitsRow(context, base + i, nVocab),
+        s.getAnswerTokens() + i,
+        projectBoundary(s, drafted, i)
+      );
       if (spec.isGreedy()) {
         int t = chain.sample(context, base + i);
         if (t == drafted[i]) {
@@ -756,15 +756,12 @@ public final class BatchIterator
     }
     if (matched == m) {
       // Bonus token: every draft was accepted, so this row sits m tokens further along.
-      if (
-        biasEogRow(
-          s,
-          logitsRow(context, base + m, nVocab),
-          s.getAnswerTokens() + m
-        )
-      ) {
-        s.setEogRampApplied(true);
-      }
+      rowBiased[m] = biasEogRow(
+        s,
+        logitsRow(context, base + m, nVocab),
+        s.getAnswerTokens() + m,
+        projectBoundary(s, drafted, m)
+      );
       extra = spec.isGreedy()
         ? chain.sample(context, base + m)
         : spec.targetSelect(chain, logitsRow(context, base + m, nVocab));
@@ -779,10 +776,10 @@ public final class BatchIterator
 
     boolean cont = true;
     for (int i = 0; i < matched && cont; i++) {
-      cont = emitSpeculative(s, drafted[i], currentOutputs);
+      cont = emitSpeculative(s, drafted[i], currentOutputs, rowBiased[i]);
     }
     if (cont) {
-      emitSpeculative(s, extra, currentOutputs);
+      emitSpeculative(s, extra, currentOutputs, rowBiased[matched]);
     }
 
     // Append the committed tokens to the n-gram history (keeps histLen == newNPast + 1).

--- a/src/main/java/io/gravitee/llama/cpp/ConversationState.java
+++ b/src/main/java/io/gravitee/llama/cpp/ConversationState.java
@@ -82,6 +82,16 @@ public class ConversationState {
 
   // Configuration
   private int maxTokens = -1;
+
+  // Budget-aware EOG bias ("soft landing"): as the token budget runs down, end-of-generation
+  // logits get an increasing boost so the model closes its sentence instead of being severed
+  // mid-word. Disabled by default (startFraction < 0) — enabling it changes the sampled
+  // distribution, so the default path stays bit-identical.
+  private float eogRampStart = -1f;
+  private float eogRampMaxBias = 0f;
+  // Set on the step whose logits were biased, so an EOG produced under pressure is still
+  // reported as LENGTH rather than a natural STOP.
+  private boolean eogRampApplied = false;
   private int topLogprobs = 0;
 
   // Optional speculative decoding: a draft context (separate small model, same vocab) whose
@@ -812,6 +822,54 @@ public class ConversationState {
 
   public int getMaxTokens() {
     return maxTokens;
+  }
+
+  /**
+   * Turns {@link #setMaxTokens(int) maxTokens} from a hard cut into a soft landing: past
+   * {@code startFraction} of the budget, every end-of-generation token's logit is raised by a
+   * quadratic ramp reaching {@code maxBias} nats at the cap, so the model is increasingly likely
+   * to finish its sentence on its own. The hard cap remains as a backstop.
+   *
+   * <p>Costs: completions typically end <em>short</em> of the budget, so {@code maxTokens} becomes
+   * a target rather than a ceiling; and the sampled distribution is no longer the model's own, so
+   * output is not comparable with an unbiased run at the same seed. An EOG produced while the ramp
+   * is active is still reported as {@link FinishReason#LENGTH} — the budget caused it, and callers
+   * (agent loops, OpenAI-compatible clients) rely on that to know the answer was cut short.
+   *
+   * <p>Ignored under speculative decoding: rejection sampling is exact only while draft and target
+   * sample the same distribution, and biasing the target per step would silently break that.
+   *
+   * @param startFraction where the ramp begins, as a fraction of maxTokens (e.g. 0.75); negative
+   *                      disables the ramp
+   * @param maxBias       logit boost in nats at the cap (e.g. 24, which makes EOG effectively
+   *                      certain)
+   */
+  public ConversationState setEogRamp(float startFraction, float maxBias) {
+    this.eogRampStart = startFraction;
+    this.eogRampMaxBias = maxBias;
+    return this;
+  }
+
+  /** Whether a budget-aware EOG ramp is configured (see {@link #setEogRamp(float, float)}). */
+  public boolean hasEogRamp() {
+    return eogRampStart >= 0f && maxTokens > 0;
+  }
+
+  public float getEogRampStart() {
+    return eogRampStart;
+  }
+
+  public float getEogRampMaxBias() {
+    return eogRampMaxBias;
+  }
+
+  /** Marks that this step's logits were biased, so an EOG here is budget-driven, not natural. */
+  public void setEogRampApplied(boolean applied) {
+    this.eogRampApplied = applied;
+  }
+
+  public boolean isEogRampApplied() {
+    return eogRampApplied;
   }
 
   public Integer getNewTokenId() {

--- a/src/main/java/io/gravitee/llama/cpp/ConversationState.java
+++ b/src/main/java/io/gravitee/llama/cpp/ConversationState.java
@@ -645,6 +645,21 @@ public class ConversationState {
     return this;
   }
 
+  /**
+   * Configures tool call detection where the channel can be opened more than one way — Harmony
+   * uses both {@code commentary} and {@code analysis}. Each alternative must be complete from the
+   * start of a run; with only one configured, the other leaks into reasoning as raw text.
+   */
+  public ConversationState setToolCall(
+    java.util.List<String> tokenStarts,
+    String tokenEnd
+  ) {
+    this.stateBounds.add(
+      new StateBounds(GenerationState.TOOLS, tokenStarts, tokenEnd)
+    );
+    return this;
+  }
+
   public List<MtmdMedia> getMedia() {
     return media;
   }

--- a/src/main/java/io/gravitee/llama/cpp/ConversationState.java
+++ b/src/main/java/io/gravitee/llama/cpp/ConversationState.java
@@ -88,6 +88,8 @@ public class ConversationState {
   // mid-word. Disabled by default (startFraction < 0) — enabling it changes the sampled
   // distribution, so the default path stays bit-identical.
   private float eogRampStart = -1f;
+  private char lastNonSpaceChar = 0;
+  private boolean lastEndsLine = false;
   private float eogRampMaxBias = 0f;
   // Set on the step whose logits were biased, so an EOG produced under pressure is still
   // reported as LENGTH rather than a natural STOP.
@@ -851,13 +853,19 @@ public class ConversationState {
    * is active is still reported as {@link FinishReason#LENGTH} — the budget caused it, and callers
    * (agent loops, OpenAI-compatible clients) rely on that to know the answer was cut short.
    *
-   * <p>Ignored under speculative decoding: rejection sampling is exact only while draft and target
-   * sample the same distribution, and biasing the target per step would silently break that.
+   * <p>The boost only applies where the text can actually stop — after sentence-terminating
+   * punctuation or a line break, widened to clause punctuation in the second half of the ramp.
+   * Biasing every step just stops mid-clause a few tokens early, which is the same severed
+   * output arriving sooner; the gate is what turns the budget into a landing.
+   *
+   * <p>Applies under speculative decoding too: rejection sampling is exact for any target
+   * distribution as long as the acceptance test and the residual draw see the same one.
    *
    * @param startFraction where the ramp begins, as a fraction of maxTokens (e.g. 0.75); negative
    *                      disables the ramp
-   * @param maxBias       logit boost in nats at the cap (e.g. 24, which makes EOG effectively
-   *                      certain)
+   * @param maxBias       logit boost in nats at the cap. EOG sits far below the running text in
+   *                      raw logits mid-answer — measured, 24 never wins and 100 does, so size
+   *                      this generously rather than by intuition about probabilities
    */
   public ConversationState setEogRamp(float startFraction, float maxBias) {
     this.eogRampStart = startFraction;
@@ -901,6 +909,29 @@ public class ConversationState {
 
   public void setPiece(String piece) {
     this.piece = piece;
+    // Remember where the text currently stands, for the EOG ramp's boundary gate. Empty pieces
+    // (a buffered marker prefix) must not clear it: nothing was emitted, so the last real
+    // boundary still holds.
+    if (piece != null && !piece.isEmpty()) {
+      lastEndsLine = piece.charAt(piece.length() - 1) == '\n';
+      for (int i = piece.length() - 1; i >= 0; i--) {
+        char c = piece.charAt(i);
+        if (!Character.isWhitespace(c)) {
+          lastNonSpaceChar = c;
+          break;
+        }
+      }
+    }
+  }
+
+  /** Last non-whitespace character emitted, or {@code 0} before any output. */
+  public char getLastNonSpaceChar() {
+    return lastNonSpaceChar;
+  }
+
+  /** Whether the last emitted piece ended a line. */
+  public boolean isLastEndsLine() {
+    return lastEndsLine;
   }
 
   /** Number of generated tokens covered by the current {@link #getPiece() piece}. */

--- a/src/main/java/io/gravitee/llama/cpp/ConversationState.java
+++ b/src/main/java/io/gravitee/llama/cpp/ConversationState.java
@@ -863,9 +863,10 @@ public class ConversationState {
    *
    * @param startFraction where the ramp begins, as a fraction of maxTokens (e.g. 0.75); negative
    *                      disables the ramp
-   * @param maxBias       logit boost in nats at the cap. EOG sits far below the running text in
-   *                      raw logits mid-answer — measured, 24 never wins and 100 does, so size
-   *                      this generously rather than by intuition about probabilities
+   * @param maxBias       logit boost in nats at the cap, i.e. how much margin the landing gets.
+   *                      EOG sits far below the running text in raw logits mid-answer, so a small
+   *                      boost is inert — measured at a 200-token budget, 12 never won, 24 landed
+   *                      at 191, 100 at 169. Size it by intuition about logits, not probabilities
    */
   public ConversationState setEogRamp(float startFraction, float maxBias) {
     this.eogRampStart = startFraction;

--- a/src/main/java/io/gravitee/llama/cpp/DefaultLlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/DefaultLlamaIterator.java
@@ -100,6 +100,9 @@ public final class DefaultLlamaIterator
     currentState.incrementNPast();
     currentState.getTokenHistory().append(currentState.getNewTokenId());
 
+    // Budget-aware EOG boost, written into the logits this sample() is about to read.
+    // -1 is the last output row, which is what sample(context) reads.
+    applyEogRamp(currentState, -1);
     int newToken = sampler.sample(context);
     String tokenPiece = decodeTokenPiece(currentState, newToken);
 

--- a/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
@@ -476,6 +476,65 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
   }
 
   /** Logit row for batch output {@code idx}, reinterpreted as {@code nVocab} floats. */
+  /** Characters that end a sentence — always a legal place to stop. */
+  private static final String SENTENCE_END = ".!?\u2026\u3002\uFF01\uFF1F";
+
+  /** Characters that end a clause — accepted only once the ramp is past halfway. */
+  private static final String CLAUSE_END = ",;:\u2014\u2013)]}\"'\u201d\u00bb";
+
+  /**
+   * Whether the text is somewhere it can stop.
+   *
+   * <p>The gate is the difference between a landing and an early cut. Measured: a bias applied at
+   * every step makes EOG win wherever it happens to overtake the next word, which is mid-clause
+   * ({@code "As the vapor travels, it"}) — the severed output the budget was supposed to avoid,
+   * only sooner. Restricted to boundaries, the bias can only take an exit the text had already
+   * reached.
+   *
+   * <p>Widening with {@code progress} keeps the early ramp conservative — full stops only — and
+   * accepts clause breaks near the cap, where stopping at a comma still beats stopping mid-word.
+   * At the cap everything is accepted: that is the backstop, and the hard limit would sever the
+   * output at the same place anyway.
+   *
+   * @param lastNonSpace last non-whitespace character emitted, {@code 0} if none
+   * @param endsLine     whether the last emitted piece ended a line
+   * @param progress     position within the ramp, 0 at the soft threshold and 1 at the cap
+   */
+  static boolean atStoppingPoint(
+    char lastNonSpace,
+    boolean endsLine,
+    float progress
+  ) {
+    if (progress >= 1f) {
+      return true;
+    }
+    if (lastNonSpace == 0) {
+      return false;
+    }
+    // A line break is a paragraph or list-item boundary: as good a stop as a full stop, and the
+    // only one available in structured output (tables, bullet lists) that rarely ends sentences.
+    if (endsLine || SENTENCE_END.indexOf(lastNonSpace) >= 0) {
+      return true;
+    }
+    return progress >= 0.5f && CLAUSE_END.indexOf(lastNonSpace) >= 0;
+  }
+
+  /** Position within the ramp: 0 at or below the soft threshold, 1 at or past the cap. */
+  static float eogRampProgress(int used, int maxTokens, float startFraction) {
+    if (maxTokens <= 0 || startFraction < 0f) {
+      return 0f;
+    }
+    if (used >= maxTokens) {
+      return 1f;
+    }
+    float soft = maxTokens * startFraction;
+    float span = maxTokens - soft;
+    if (span <= 0f) {
+      return used >= soft ? 1f : 0f;
+    }
+    return Math.max(0f, Math.min(1f, (used - soft) / span));
+  }
+
   /**
    * The EOG logit boost for a given point in the budget: zero until {@code startFraction} of
    * {@code maxTokens} is spent, then quadratic to {@code maxBias} at the cap.
@@ -510,14 +569,6 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
     return maxBias * t * t;
   }
 
-  /**
-   * Applies the budget-aware EOG boost to the logits row this step will sample from, and records
-   * on the state whether it fired. Must run immediately before sampling: {@code
-   * llama_sampler_sample} reads this same native buffer, so writing here is equivalent to a bias
-   * sampler at the head of the chain and composes with top-k/top-p/temperature downstream.
-   *
-   * <p>Skipped entirely for speculative states — see {@link ConversationState#setEogRamp}.
-   */
   /**
    * Applies the budget-aware EOG boost to the logits row this step will sample from, and records
    * on the state whether it fired. Must run immediately before sampling: {@code
@@ -569,6 +620,18 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
       state.getEogRampMaxBias()
     );
     if (bias <= 0f) {
+      return false;
+    }
+    // Only where the text can stop. Under speculation the projected rows share the current
+    // boundary — the future text is unknown — so a verify row may be biased one position early
+    // or late; it costs an accepted token, never correctness.
+    if (
+      !atStoppingPoint(
+        state.getLastNonSpaceChar(),
+        state.isLastEndsLine(),
+        eogRampProgress(used, state.getMaxTokens(), state.getEogRampStart())
+      )
+    ) {
       return false;
     }
     for (int id : state.getTokenizer().getVocab().eogTokens()) {

--- a/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
@@ -333,7 +333,11 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
       // Preserve TOOL_CALL — the model produced tool calls and then stopped.
       // Only set STOP if no tool calls were made.
       if (state.getFinishReason() != FinishReason.TOOL_CALL) {
-        state.setFinishReason(FinishReason.STOP);
+        // An EOG sampled while the budget ramp was boosting it is not a natural stop — the cap
+        // caused it. Report LENGTH so callers still see the answer was cut short.
+        state.setFinishReason(
+          state.isEogRampApplied() ? FinishReason.LENGTH : FinishReason.STOP
+        );
       }
       state.setFinished(true);
       return false;
@@ -472,6 +476,74 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
   }
 
   /** Logit row for batch output {@code idx}, reinterpreted as {@code nVocab} floats. */
+  /**
+   * The EOG logit boost for a given point in the budget: zero until {@code startFraction} of
+   * {@code maxTokens} is spent, then quadratic to {@code maxBias} at the cap.
+   *
+   * <p>Quadratic rather than linear so the first tokens past the threshold are barely nudged and
+   * the pressure arrives late — the model keeps its natural phrasing for most of the ramp and only
+   * finds EOG overwhelming at the end. Pure arithmetic, so it is testable without a model.
+   */
+  static float eogRampBias(
+    int used,
+    int maxTokens,
+    float startFraction,
+    float maxBias
+  ) {
+    if (maxTokens <= 0 || startFraction < 0f) {
+      return 0f;
+    }
+    // At or past the cap the bias is full, checked before the threshold test so a degenerate
+    // ramp (startFraction == 1, i.e. soft == maxTokens) still lands on maxBias rather than 0.
+    if (used >= maxTokens) {
+      return maxBias;
+    }
+    float soft = maxTokens * startFraction;
+    if (used <= soft) {
+      return 0f;
+    }
+    float span = maxTokens - soft;
+    if (span <= 0f) {
+      return maxBias;
+    }
+    float t = Math.min(1f, (used - soft) / span);
+    return maxBias * t * t;
+  }
+
+  /**
+   * Applies the budget-aware EOG boost to the logits row this step will sample from, and records
+   * on the state whether it fired. Must run immediately before sampling: {@code
+   * llama_sampler_sample} reads this same native buffer, so writing here is equivalent to a bias
+   * sampler at the head of the chain and composes with top-k/top-p/temperature downstream.
+   *
+   * <p>Skipped entirely for speculative states — see {@link ConversationState#setEogRamp}.
+   */
+  protected void applyEogRamp(ConversationState state, int batchPos) {
+    state.setEogRampApplied(false);
+    if (!state.hasEogRamp()) {
+      return;
+    }
+    float bias = eogRampBias(
+      state.getAnswerTokens(),
+      state.getMaxTokens(),
+      state.getEogRampStart(),
+      state.getEogRampMaxBias()
+    );
+    if (bias <= 0f) {
+      return;
+    }
+    var vocab = state.getTokenizer().getVocab();
+    var row = logitsRow(state.getContext(), batchPos, vocab.nVocab());
+    for (int id : vocab.eogTokens()) {
+      row.setAtIndex(
+        ValueLayout.JAVA_FLOAT,
+        id,
+        row.getAtIndex(ValueLayout.JAVA_FLOAT, id) + bias
+      );
+    }
+    state.setEogRampApplied(true);
+  }
+
   public MemorySegment logitsRow(LlamaContext ctx, int idx, int nVocab) {
     MemorySegment ptr = LlamaRuntime.llama_get_logits_ith(ctx.segment, idx);
     if (ptr == null || ptr.address() == 0) {

--- a/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
@@ -518,30 +518,67 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
    *
    * <p>Skipped entirely for speculative states — see {@link ConversationState#setEogRamp}.
    */
+  /**
+   * Applies the budget-aware EOG boost to the logits row this step will sample from, and records
+   * on the state whether it fired. Must run immediately before sampling: {@code
+   * llama_sampler_sample} reads this same native buffer, so writing here is equivalent to a bias
+   * sampler at the head of the chain and composes with top-k/top-p/temperature downstream.
+   */
   protected void applyEogRamp(ConversationState state, int batchPos) {
     state.setEogRampApplied(false);
     if (!state.hasEogRamp()) {
       return;
     }
+    var row = logitsRow(
+      state.getContext(),
+      batchPos,
+      state.getTokenizer().getVocab().nVocab()
+    );
+    if (biasEogRow(state, row, state.getAnswerTokens())) {
+      state.setEogRampApplied(true);
+    }
+  }
+
+  /**
+   * Raises every EOG logit in {@code row} for a projected budget position, returning whether any
+   * bias was applied.
+   *
+   * <p>Split out for speculative verification, which evaluates several future positions in one
+   * decode: row {@code i} of a verify batch is the distribution after {@code i} more tokens, so it
+   * takes {@code used + i} rather than the current count.
+   *
+   * <p>Safe under speculation — and deliberately not skipped. Speculative sampling draws exactly
+   * from the target distribution whatever that distribution is; the requirement is only that the
+   * acceptance test and the residual draw see the SAME target. Both derive from this row, so
+   * biasing it here satisfies that and the round remains exact with respect to the biased target.
+   * The draft has no knowledge of the bias, so it keeps proposing continuations near the cap and
+   * acceptance dips for the last few tokens — a throughput cost, not a correctness one.
+   */
+  public boolean biasEogRow(
+    ConversationState state,
+    MemorySegment row,
+    int used
+  ) {
+    if (!state.hasEogRamp()) {
+      return false;
+    }
     float bias = eogRampBias(
-      state.getAnswerTokens(),
+      used,
       state.getMaxTokens(),
       state.getEogRampStart(),
       state.getEogRampMaxBias()
     );
     if (bias <= 0f) {
-      return;
+      return false;
     }
-    var vocab = state.getTokenizer().getVocab();
-    var row = logitsRow(state.getContext(), batchPos, vocab.nVocab());
-    for (int id : vocab.eogTokens()) {
+    for (int id : state.getTokenizer().getVocab().eogTokens()) {
       row.setAtIndex(
         ValueLayout.JAVA_FLOAT,
         id,
         row.getAtIndex(ValueLayout.JAVA_FLOAT, id) + bias
       );
     }
-    state.setEogRampApplied(true);
+    return true;
   }
 
   public MemorySegment logitsRow(LlamaContext ctx, int idx, int nVocab) {

--- a/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
@@ -591,6 +591,56 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
   }
 
   /**
+   * Where the text will stand after {@code count} drafted tokens are appended.
+   *
+   * @param lastNonSpace last non-whitespace character at that point
+   * @param endsLine     whether the text ends a line at that point
+   */
+  public record TextBoundary(char lastNonSpace, boolean endsLine) {}
+
+  /**
+   * Projects the stopping-point boundary forward over drafted tokens.
+   *
+   * <p>A speculative round biases every verify row before a single token is emitted, so the gate
+   * would otherwise judge row {@code i} using text from before the round — stale by up to
+   * {@code nDraft} tokens. Measured effect: the ramp never landed under speculation at all, because
+   * the gate opened where the text was mid-word and stayed shut where a sentence had just ended.
+   * The drafted tokens are already known here, and row {@code i} is only ever used if drafts
+   * {@code 0..i-1} were accepted, so folding their text in is exact for every row that matters.
+   *
+   * <p>Decodes the raw piece bytes rather than the state's streaming decoder, which must not be
+   * advanced out of band. A piece split mid-codepoint yields a replacement character — non-space,
+   * so it reads as "not a boundary", which errs toward leaving the model's phrasing alone.
+   */
+  public TextBoundary projectBoundary(
+    ConversationState state,
+    int[] drafted,
+    int count
+  ) {
+    char lastNonSpace = state.getLastNonSpaceChar();
+    boolean endsLine = state.isLastEndsLine();
+    for (int i = 0; i < count; i++) {
+      byte[] bytes = state.getTokenizer().tokenToPiece(drafted[i]);
+      if (bytes == null || bytes.length == 0) {
+        continue;
+      }
+      String piece = new String(bytes, java.nio.charset.StandardCharsets.UTF_8);
+      if (piece.isEmpty()) {
+        continue;
+      }
+      endsLine = piece.charAt(piece.length() - 1) == '\n';
+      for (int j = piece.length() - 1; j >= 0; j--) {
+        char c = piece.charAt(j);
+        if (!Character.isWhitespace(c)) {
+          lastNonSpace = c;
+          break;
+        }
+      }
+    }
+    return new TextBoundary(lastNonSpace, endsLine);
+  }
+
+  /**
    * Raises every EOG logit in {@code row} for a projected budget position, returning whether any
    * bias was applied.
    *
@@ -610,6 +660,21 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
     MemorySegment row,
     int used
   ) {
+    return biasEogRow(
+      state,
+      row,
+      used,
+      new TextBoundary(state.getLastNonSpaceChar(), state.isLastEndsLine())
+    );
+  }
+
+  /** As above, judging the gate at an explicitly projected boundary. */
+  public boolean biasEogRow(
+    ConversationState state,
+    MemorySegment row,
+    int used,
+    TextBoundary boundary
+  ) {
     if (!state.hasEogRamp()) {
       return false;
     }
@@ -627,8 +692,8 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
     // or late; it costs an accepted token, never correctness.
     if (
       !atStoppingPoint(
-        state.getLastNonSpaceChar(),
-        state.isLastEndsLine(),
+        boundary.lastNonSpace(),
+        boundary.endsLine(),
         eogRampProgress(used, state.getMaxTokens(), state.getEogRampStart())
       )
     ) {
@@ -661,9 +726,23 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
     int token,
     List<LlamaOutput> out
   ) {
+    return emitSpeculative(state, token, out, false);
+  }
+
+  /**
+   * @param rowBiased whether the EOG ramp biased the logits row this token was drawn from. Per
+   *                  row, not per round: a round biases several projected positions, and only the
+   *                  row that actually produced the token says anything about why it appeared.
+   */
+  public boolean emitSpeculative(
+    ConversationState state,
+    int token,
+    List<LlamaOutput> out,
+    boolean rowBiased
+  ) {
     if (state.getTokenizer().isEog(token)) {
       if (state.getFinishReason() != TOOL_CALL) {
-        state.setFinishReason(STOP);
+        state.setFinishReason(rowBiased ? LENGTH : STOP);
       }
       state.setFinished(true);
       flushPendingMarker(state, out);
@@ -672,6 +751,10 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
     String piece = decodeTokenPiece(state, token);
     // updates generation state + token tracking; may buffer or resolve marker pieces
     var emission = processSampledToken(state, token, piece);
+    // Advance the stopping-point state exactly as the autoregressive path does. Without this the
+    // ramp's boundary gate reads punctuation from before the round and opens at the wrong
+    // positions — so whether the ramp works at all would depend on speculation being enabled.
+    state.setPiece(emission.emit());
     // Mirror the autoregressive iterator: the token that reaches the quota is counted but
     // NOT emitted (the AR path stops via hasNotReachedQuota() after incrementing). Drop it
     // here too, otherwise speculative emits one extra token at the boundary.

--- a/src/main/java/io/gravitee/llama/cpp/LlamaRuntime.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaRuntime.java
@@ -1308,6 +1308,20 @@ public final class LlamaRuntime {
     );
   }
 
+  /**
+   * Token attribute bitmask ({@code llama_token_attr}). CONTROL (1&lt;&lt;3) and USER_DEFINED
+   * (1&lt;&lt;4) are the flags that make a token match when text is tokenized with
+   * {@code parse_special}.
+   */
+  public static int llama_vocab_get_attr(MemorySegment vocab, int tokenId) {
+    return llama_h(
+      "llama_vocab_get_attr",
+      new Class<?>[] { MEM_SEG_CLASS, int.class },
+      vocab,
+      tokenId
+    );
+  }
+
   public static int llama_token_to_piece(
     MemorySegment vocab,
     int token,

--- a/src/main/java/io/gravitee/llama/cpp/LlamaVocab.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaVocab.java
@@ -16,6 +16,7 @@
 package io.gravitee.llama.cpp;
 
 import static io.gravitee.llama.cpp.LlamaRuntime.llama_model_get_vocab;
+import static io.gravitee.llama.cpp.LlamaRuntime.llama_n_vocab;
 import static io.gravitee.llama.cpp.LlamaRuntime.llama_token_to_piece;
 import static io.gravitee.llama.cpp.LlamaRuntime.llama_vocab_bos;
 import static io.gravitee.llama.cpp.LlamaRuntime.llama_vocab_eos;
@@ -33,12 +34,55 @@ public final class LlamaVocab extends MemorySegmentAware {
 
   private static final int BUFFER_SIZE = 256;
 
+  /** Lazily scanned once; see {@link #eogTokens()}. */
+  private volatile int[] eogTokens;
+
   public LlamaVocab(LlamaModel model) {
     super(llama_model_get_vocab(model.segment));
   }
 
   public boolean isEog(int tokenId) {
     return llama_vocab_is_eog(this.segment, tokenId);
+  }
+
+  public int nVocab() {
+    return llama_n_vocab(this.segment);
+  }
+
+  /**
+   * Every end-of-generation token id in this vocabulary, ascending.
+   *
+   * <p>A vocabulary usually has several — EOS, EOT, and chat-format terminators such as
+   * {@code <|im_end|>}. Callers that treat only EOS as "the" stop token leave the model an
+   * unbiased alternative, which shows up as a weaker effect rather than a failure.
+   *
+   * <p>Scanned once and cached: {@link #isEog(int)} is a native call, and a vocabulary runs to
+   * six figures, so repeating the scan per token would cost more than whatever it is used for.
+   * The result is shared and must not be mutated.
+   */
+  public int[] eogTokens() {
+    int[] cached = eogTokens;
+    if (cached == null) {
+      synchronized (this) {
+        cached = eogTokens;
+        if (cached == null) {
+          int n = nVocab();
+          int[] found = new int[16];
+          int count = 0;
+          for (int id = 0; id < n; id++) {
+            if (isEog(id)) {
+              if (count == found.length) {
+                found = java.util.Arrays.copyOf(found, count * 2);
+              }
+              found[count++] = id;
+            }
+          }
+          cached = java.util.Arrays.copyOf(found, count);
+          eogTokens = cached;
+        }
+      }
+    }
+    return cached;
   }
 
   /**

--- a/src/main/java/io/gravitee/llama/cpp/LlamaVocab.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaVocab.java
@@ -20,6 +20,7 @@ import static io.gravitee.llama.cpp.LlamaRuntime.llama_n_vocab;
 import static io.gravitee.llama.cpp.LlamaRuntime.llama_token_to_piece;
 import static io.gravitee.llama.cpp.LlamaRuntime.llama_vocab_bos;
 import static io.gravitee.llama.cpp.LlamaRuntime.llama_vocab_eos;
+import static io.gravitee.llama.cpp.LlamaRuntime.llama_vocab_get_attr;
 import static io.gravitee.llama.cpp.LlamaRuntime.llama_vocab_get_text;
 import static io.gravitee.llama.cpp.LlamaRuntime.llama_vocab_is_eog;
 
@@ -36,6 +37,13 @@ public final class LlamaVocab extends MemorySegmentAware {
 
   /** Lazily scanned once; see {@link #eogTokens()}. */
   private volatile int[] eogTokens;
+
+  /** Lazily scanned once; see {@link #specialTokenTexts()}. */
+  private volatile java.util.List<String> specialTokenTexts;
+
+  /** {@code llama_token_attr} flags that make a token match under {@code parse_special}. */
+  private static final int ATTR_CONTROL = 1 << 3;
+  private static final int ATTR_USER_DEFINED = 1 << 4;
 
   public LlamaVocab(LlamaModel model) {
     super(llama_model_get_vocab(model.segment));
@@ -79,6 +87,48 @@ public final class LlamaVocab extends MemorySegmentAware {
           }
           cached = java.util.Arrays.copyOf(found, count);
           eogTokens = cached;
+        }
+      }
+    }
+    return cached;
+  }
+
+  /**
+   * The literal text of every token this vocabulary would parse as special — the exact strings
+   * that become control tokens when text is tokenized with {@code parse_special} enabled.
+   *
+   * <p>Callers rendering untrusted text into a prompt need this: a chat message containing
+   * {@code <|channel|>} or {@code <start_of_turn>} is otherwise tokenized as the real control
+   * token, letting message content forge conversation structure. Neutralising these strings in
+   * caller-supplied text is what makes {@code parse_special} safe on a whole rendered prompt.
+   *
+   * <p>Longest first, so a caller replacing them in order cannot have a short marker consume part
+   * of a longer one. Scanned once and cached; the result is shared and must not be mutated.
+   */
+  public java.util.List<String> specialTokenTexts() {
+    java.util.List<String> cached = specialTokenTexts;
+    if (cached == null) {
+      synchronized (this) {
+        cached = specialTokenTexts;
+        if (cached == null) {
+          int n = nVocab();
+          var found = new java.util.ArrayList<String>();
+          for (int id = 0; id < n; id++) {
+            int attr = llama_vocab_get_attr(this.segment, id);
+            if ((attr & (ATTR_CONTROL | ATTR_USER_DEFINED)) == 0) {
+              continue;
+            }
+            var ptr = llama_vocab_get_text(this.segment, id);
+            if (ptr != null && ptr.address() != 0) {
+              String text = ptr.getString(0);
+              if (!text.isEmpty()) {
+                found.add(text);
+              }
+            }
+          }
+          found.sort((x, y) -> Integer.compare(y.length(), x.length()));
+          cached = java.util.List.copyOf(found);
+          specialTokenTexts = cached;
         }
       }
     }

--- a/src/main/java/io/gravitee/llama/cpp/StateBounds.java
+++ b/src/main/java/io/gravitee/llama/cpp/StateBounds.java
@@ -15,4 +15,38 @@
  */
 package io.gravitee.llama.cpp;
 
-public record StateBounds(GenerationState state, String start, String end) {}
+import java.util.List;
+
+/**
+ * The marker text opening and closing one generation channel.
+ *
+ * <p>{@code starts} is a list because a dialect may open a channel more than one way — Harmony
+ * emits tool calls on both the {@code commentary} and {@code analysis} channels. Configure every
+ * variant: an unmatched one refutes against the close marker and leaks the span as text.
+ *
+ * <p>Markers are matched only at the start of a run, so each alternative must be complete from
+ * that boundary; a shared substring will not match.
+ *
+ * @param state  the channel these bounds delimit
+ * @param starts opening markers; longest match wins
+ * @param end    the closing marker
+ */
+public record StateBounds(
+  GenerationState state,
+  List<String> starts,
+  String end
+) {
+  public StateBounds {
+    starts = starts == null ? List.of() : List.copyOf(starts);
+  }
+
+  /** Single-marker form. */
+  public StateBounds(GenerationState state, String start, String end) {
+    this(state, start == null ? List.of() : List.of(start), end);
+  }
+
+  /** The primary opening marker, or {@code null} if none. */
+  public String start() {
+    return starts.isEmpty() ? null : starts.getFirst();
+  }
+}

--- a/src/main/java/io/gravitee/llama/cpp/modules/StateEvaluation.java
+++ b/src/main/java/io/gravitee/llama/cpp/modules/StateEvaluation.java
@@ -186,14 +186,19 @@ public class StateEvaluation
       ) {
         continue;
       }
-      String marker = bounds.start();
-      if (accumulated.startsWith(marker)) {
-        if (bestMarker == null || marker.length() > bestMarker.length()) {
-          bestMarker = marker;
-          bestTarget = bounds.state();
+      // A channel may have several opening markers (Harmony: commentary and analysis).
+      for (String marker : bounds.starts()) {
+        if (marker == null || marker.isBlank()) {
+          continue;
         }
-      } else if (marker.startsWith(accumulated)) {
-        anyPrefix = true;
+        if (accumulated.startsWith(marker)) {
+          if (bestMarker == null || marker.length() > bestMarker.length()) {
+            bestMarker = marker;
+            bestTarget = bounds.state();
+          }
+        } else if (marker.startsWith(accumulated)) {
+          anyPrefix = true;
+        }
       }
     }
 
@@ -275,7 +280,7 @@ public class StateEvaluation
       .filter(not(e -> this.stateAlreadyOccurred(e.getValue())))
       .map(Entry::getValue)
       .filter(not(StateEvaluation::isNullOrBlank))
-      .filter(stateBounds -> stateBounds.start().equals(piece))
+      .filter(stateBounds -> stateBounds.starts().contains(piece))
       .map(StateBounds::state)
       .findFirst()
       .orElse(GenerationState.ANSWER);
@@ -308,7 +313,13 @@ public class StateEvaluation
   }
 
   private static boolean insideOpenSpan(String prompt, StateBounds bounds) {
-    int lastStart = prompt.lastIndexOf(bounds.start());
+    // Any opening marker may be the unclosed one.
+    int lastStart = -1;
+    for (String marker : bounds.starts()) {
+      if (marker != null && !marker.isBlank()) {
+        lastStart = Math.max(lastStart, prompt.lastIndexOf(marker));
+      }
+    }
     if (lastStart < 0) {
       return false;
     }
@@ -318,7 +329,10 @@ public class StateEvaluation
   }
 
   private static boolean isNullOrBlank(StateBounds stateBounds) {
-    return stateBounds.start() == null || stateBounds.start().isBlank();
+    return stateBounds
+      .starts()
+      .stream()
+      .allMatch(m -> m == null || m.isBlank());
   }
 
   private Boolean stateAlreadyOccurred(StateBounds stateBounds) {

--- a/src/main/java/io/gravitee/llama/cpp/speculative/Eagle3SpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/Eagle3SpeculativeDecoding.java
@@ -113,7 +113,7 @@ public final class Eagle3SpeculativeDecoding
       d.m(),
       seq
     );
-    Verdict v = accept(it, spec, target, d.tokens(), d.snaps(), d.m());
+    Verdict v = accept(it, state, spec, target, d.tokens(), d.snaps(), d.m());
 
     // Encode the verify rows' captured features → g rows (gv[r] = g at target pos nPast+r).
     // Read before any further target decode overwrites the capture buffers.

--- a/src/main/java/io/gravitee/llama/cpp/speculative/ModelDraftSpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/ModelDraftSpeculativeDecoding.java
@@ -147,7 +147,7 @@ public final class ModelDraftSpeculativeDecoding extends SpeculativeDecoding {
     }
 
     decodeVerify(spec.verifyBatch(), target, idLast, nPast, drafted, m, seq);
-    Verdict v = accept(it, spec, target, drafted, snaps, m);
+    Verdict v = accept(it, state, spec, target, drafted, snaps, m);
 
     // Roll back both caches to the accepted boundary.
     int newNPast = nPast + v.matched() + 1;

--- a/src/main/java/io/gravitee/llama/cpp/speculative/MtpSpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/MtpSpeculativeDecoding.java
@@ -85,7 +85,7 @@ public final class MtpSpeculativeDecoding
       d.m(),
       seq
     );
-    Verdict v = accept(it, spec, target, d.tokens(), d.snaps(), d.m());
+    Verdict v = accept(it, state, spec, target, d.tokens(), d.snaps(), d.m());
 
     // Next round's seed: the target's hidden at the last ACCEPTED verify row (input position
     // nPast+matched — the position preceding the new idLast). Read before any further decode.

--- a/src/main/java/io/gravitee/llama/cpp/speculative/NgramSpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/NgramSpeculativeDecoding.java
@@ -51,7 +51,7 @@ public final class NgramSpeculativeDecoding extends SpeculativeDecoding {
 
     decodeVerify(spec.verifyBatch(), target, idLast, nPast, drafted, m, seq);
     // Point-mass draft: snaps == null → q = 1 accept + point-mass residual.
-    Verdict v = accept(it, spec, target, drafted, null, m);
+    Verdict v = accept(it, state, spec, target, drafted, null, m);
 
     // Roll back ONLY the target cache (no draft cache exists).
     int newNPast = nPast + v.matched() + 1;

--- a/src/main/java/io/gravitee/llama/cpp/speculative/SpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/SpeculativeDecoding.java
@@ -84,7 +84,17 @@ public abstract sealed class SpeculativeDecoding
   /* -------------------------------- shared mechanics -------------------------------- */
 
   /** Accepted-prefix length + the correction (partial accept) or bonus (full accept) token. */
-  record Verdict(int matched, int extra) {}
+  /**
+   * @param matched     accepted draft tokens
+   * @param extra       the correction or bonus token
+   * @param rowBiased   per emitted position, whether the EOG ramp biased the row it came from;
+   *                    index i is draft token i, index {@code matched} is {@code extra}
+   */
+  record Verdict(int matched, int extra, boolean[] rowBiased) {
+    boolean biasedAt(int index) {
+      return rowBiased != null && index < rowBiased.length && rowBiased[index];
+    }
+  }
 
   /** One batched target decode of {@code [idLast, drafted[0..m-1]]} with logits on every row. */
   static void decodeVerify(
@@ -111,19 +121,32 @@ public abstract sealed class SpeculativeDecoding
    * more tokens. Biasing before the row is read keeps the acceptance test and the residual draw on
    * the same target, so the round stays an exact sampler of the biased distribution.
    */
-  private static void biasVerifyRow(
+  /**
+   * Biases verify row {@code i} at its projected budget position, returning whether it did.
+   *
+   * <p>The answer is kept per row rather than as a flag on the state: a round biases several
+   * positions, and a sticky flag would attribute an EOG drawn from an unbiased row to budget
+   * pressure just because an earlier row in the same round was biased.
+   */
+  private static boolean biasVerifyRow(
     LlamaIterator<?> it,
     ConversationState state,
     LlamaContext target,
+    int[] drafted,
     int i
   ) {
     if (!state.hasEogRamp()) {
-      return;
+      return false;
     }
     var row = it.logitsRow(target, i, target.nVocab());
-    if (it.biasEogRow(state, row, state.getAnswerTokens() + i)) {
-      state.setEogRampApplied(true);
-    }
+    // Row i is only reached if drafts 0..i-1 were accepted, so their text is where the gate must
+    // be judged — not the text from before the round.
+    return it.biasEogRow(
+      state,
+      row,
+      state.getAnswerTokens() + i,
+      it.projectBoundary(state, drafted, i)
+    );
   }
 
   /**
@@ -142,11 +165,13 @@ public abstract sealed class SpeculativeDecoding
     int m
   ) {
     LlamaSampler chain = spec.chain();
+    // One slot per emittable position: the m draft rows plus the correction/bonus row.
+    boolean[] rowBiased = new boolean[m + 1];
     if (spec.isGreedy()) {
       int matched = 0;
       int correction = -1;
       for (int i = 0; i < m; i++) {
-        biasVerifyRow(it, state, target, i);
+        rowBiased[i] = biasVerifyRow(it, state, target, drafted, i);
         int t = chain.sample(target, i);
         if (t == drafted[i]) {
           matched++;
@@ -155,18 +180,22 @@ public abstract sealed class SpeculativeDecoding
           break;
         }
       }
+      int extra;
       if (matched == m) {
-        biasVerifyRow(it, state, target, m);
+        rowBiased[m] = biasVerifyRow(it, state, target, drafted, m);
+        extra = chain.sample(target, m);
+      } else {
+        // The correction came from row `matched` — already recorded by the loop before it broke.
+        extra = correction;
       }
-      int extra = matched == m ? chain.sample(target, m) : correction;
-      return new Verdict(matched, extra);
+      return new Verdict(matched, extra, rowBiased);
     }
 
     int nVocab = target.nVocab();
     int matched = 0;
     int extra = -1;
     for (int i = 0; i < m; i++) {
-      biasVerifyRow(it, state, target, i);
+      rowBiased[i] = biasVerifyRow(it, state, target, drafted, i);
       float q = snaps == null ? 1.0f : snaps[i].selectedProbability();
       if (
         spec.acceptTarget(chain, it.logitsRow(target, i, nVocab), drafted[i], q)
@@ -180,10 +209,10 @@ public abstract sealed class SpeculativeDecoding
       }
     }
     if (matched == m) {
-      biasVerifyRow(it, state, target, m);
+      rowBiased[m] = biasVerifyRow(it, state, target, drafted, m);
       extra = spec.targetSelect(chain, it.logitsRow(target, m, nVocab));
     }
-    return new Verdict(matched, extra);
+    return new Verdict(matched, extra, rowBiased);
   }
 
   /** Emits the accepted drafts then the extra token (stops early on EOG/quota). */
@@ -196,10 +225,10 @@ public abstract sealed class SpeculativeDecoding
     List<LlamaOutput> out = new ArrayList<>();
     boolean cont = true;
     for (int i = 0; i < v.matched() && cont; i++) {
-      cont = it.emitSpeculative(state, drafted[i], out);
+      cont = it.emitSpeculative(state, drafted[i], out, v.biasedAt(i));
     }
     if (cont) {
-      it.emitSpeculative(state, v.extra(), out);
+      it.emitSpeculative(state, v.extra(), out, v.biasedAt(v.matched()));
     }
     return out;
   }

--- a/src/main/java/io/gravitee/llama/cpp/speculative/SpeculativeDecoding.java
+++ b/src/main/java/io/gravitee/llama/cpp/speculative/SpeculativeDecoding.java
@@ -107,6 +107,26 @@ public abstract sealed class SpeculativeDecoding
   }
 
   /**
+   * Applies the budget EOG ramp to verify row {@code i}, which is the distribution after {@code i}
+   * more tokens. Biasing before the row is read keeps the acceptance test and the residual draw on
+   * the same target, so the round stays an exact sampler of the biased distribution.
+   */
+  private static void biasVerifyRow(
+    LlamaIterator<?> it,
+    ConversationState state,
+    LlamaContext target,
+    int i
+  ) {
+    if (!state.hasEogRamp()) {
+      return;
+    }
+    var row = it.logitsRow(target, i, target.nVocab());
+    if (it.biasEogRow(state, row, state.getAnswerTokens() + i)) {
+      state.setEogRampApplied(true);
+    }
+  }
+
+  /**
    * Accepts drafts against the verify rows: greedy longest-prefix when the config is greedy
    * (lossless), otherwise rejection sampling ({@code min(1, p/q)} accept + residual draw on the
    * first rejection — an exact sampler of the target distribution). {@code snaps == null} means
@@ -114,6 +134,7 @@ public abstract sealed class SpeculativeDecoding
    */
   static Verdict accept(
     LlamaIterator<?> it,
+    ConversationState state,
     Speculation spec,
     LlamaContext target,
     int[] drafted,
@@ -125,6 +146,7 @@ public abstract sealed class SpeculativeDecoding
       int matched = 0;
       int correction = -1;
       for (int i = 0; i < m; i++) {
+        biasVerifyRow(it, state, target, i);
         int t = chain.sample(target, i);
         if (t == drafted[i]) {
           matched++;
@@ -132,6 +154,9 @@ public abstract sealed class SpeculativeDecoding
           correction = t;
           break;
         }
+      }
+      if (matched == m) {
+        biasVerifyRow(it, state, target, m);
       }
       int extra = matched == m ? chain.sample(target, m) : correction;
       return new Verdict(matched, extra);
@@ -141,6 +166,7 @@ public abstract sealed class SpeculativeDecoding
     int matched = 0;
     int extra = -1;
     for (int i = 0; i < m; i++) {
+      biasVerifyRow(it, state, target, i);
       float q = snaps == null ? 1.0f : snaps[i].selectedProbability();
       if (
         spec.acceptTarget(chain, it.logitsRow(target, i, nVocab), drafted[i], q)
@@ -154,6 +180,7 @@ public abstract sealed class SpeculativeDecoding
       }
     }
     if (matched == m) {
+      biasVerifyRow(it, state, target, m);
       extra = spec.targetSelect(chain, it.logitsRow(target, m, nVocab));
     }
     return new Verdict(matched, extra);

--- a/src/test/java/io/gravitee/llama/cpp/EogRampBiasTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/EogRampBiasTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static io.gravitee.llama.cpp.LlamaIterator.eogRampBias;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The budget-aware EOG ramp curve.
+ *
+ * <p>The shape is the whole point: nothing at all until the soft threshold — so a run with the
+ * ramp configured is bit-identical to one without it for most of the budget — then a quadratic
+ * climb that stays gentle for a while and only becomes overwhelming at the cap. A linear ramp
+ * would start nudging the model into early endings as soon as it crossed the threshold.
+ *
+ * <p>No model or native libraries required.
+ *
+ * @author GraviteeSource Team
+ */
+class EogRampBiasTest {
+
+  private static final float START = 0.75f;
+  private static final float MAX_BIAS = 24f;
+
+  private static float bias(int used) {
+    return eogRampBias(used, 200, START, MAX_BIAS);
+  }
+
+  @Test
+  void nothing_happens_before_the_soft_threshold() {
+    assertThat(bias(0)).isZero();
+    assertThat(bias(100)).isZero();
+    assertThat(bias(150)).as("exactly at the threshold").isZero();
+  }
+
+  @Test
+  void the_cap_gets_the_full_bias() {
+    assertThat(bias(200)).isEqualTo(MAX_BIAS);
+    assertThat(bias(250)).as("clamped past the cap").isEqualTo(MAX_BIAS);
+  }
+
+  @Test
+  void the_climb_is_quadratic_not_linear() {
+    // Halfway through the ramp a linear curve would give 12; quadratic gives a quarter of the
+    // max, keeping the model's own phrasing intact for longer.
+    assertThat(bias(175)).isEqualTo(MAX_BIAS * 0.25f, within(0.01f));
+    assertThat(bias(190)).isEqualTo(MAX_BIAS * 0.64f, within(0.01f));
+  }
+
+  @Test
+  void the_curve_is_monotonic() {
+    float previous = -1f;
+    for (int used = 0; used <= 200; used++) {
+      float current = bias(used);
+      assertThat(current).as("used=%d", used).isGreaterThanOrEqualTo(previous);
+      previous = current;
+    }
+  }
+
+  @Test
+  void a_negative_start_fraction_disables_the_ramp() {
+    assertThat(eogRampBias(199, 200, -1f, MAX_BIAS)).isZero();
+  }
+
+  @Test
+  void an_unset_budget_disables_the_ramp() {
+    assertThat(eogRampBias(500, -1, START, MAX_BIAS)).isZero();
+    assertThat(eogRampBias(500, 0, START, MAX_BIAS)).isZero();
+  }
+
+  @Test
+  void a_start_fraction_of_one_biases_only_at_the_cap() {
+    assertThat(eogRampBias(199, 200, 1f, MAX_BIAS)).isZero();
+    assertThat(eogRampBias(200, 200, 1f, MAX_BIAS)).isEqualTo(MAX_BIAS);
+  }
+
+  @Test
+  void a_start_fraction_of_zero_ramps_across_the_whole_budget() {
+    assertThat(eogRampBias(0, 200, 0f, MAX_BIAS)).isZero();
+    assertThat(eogRampBias(100, 200, 0f, MAX_BIAS)).isEqualTo(
+      MAX_BIAS * 0.25f,
+      within(0.01f)
+    );
+    assertThat(eogRampBias(200, 200, 0f, MAX_BIAS)).isEqualTo(MAX_BIAS);
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/EogStoppingPointTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/EogStoppingPointTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp;
+
+import static io.gravitee.llama.cpp.LlamaIterator.atStoppingPoint;
+import static io.gravitee.llama.cpp.LlamaIterator.eogRampProgress;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The boundary gate on the budget-aware EOG ramp.
+ *
+ * <p>Without it the ramp was measured cutting mid-clause — the same severed output the budget was
+ * meant to avoid, only earlier. The gate is what makes the bias a landing: EOG can
+ * only win where the text had already reached an exit.
+ *
+ * <p>No model or native libraries required.
+ *
+ * @author GraviteeSource Team
+ */
+class EogStoppingPointTest {
+
+  @Test
+  void nothing_is_a_stopping_point_before_any_output() {
+    assertThat(atStoppingPoint((char) 0, false, 0.9f)).isFalse();
+  }
+
+  @Test
+  void sentence_punctuation_stops_from_the_very_start_of_the_ramp() {
+    for (char c : ".!?…。".toCharArray()) {
+      assertThat(atStoppingPoint(c, false, 0f)).as("'%c'", c).isTrue();
+    }
+  }
+
+  @Test
+  void a_line_break_is_a_stopping_point() {
+    // The only boundary structured output offers: table rows and list items rarely end in a
+    // full stop, and that is exactly where the ungated ramp used to cut.
+    assertThat(atStoppingPoint('|', true, 0f)).isTrue();
+  }
+
+  @Test
+  void clause_punctuation_waits_for_the_second_half() {
+    assertThat(atStoppingPoint(',', false, 0.4f)).isFalse();
+    assertThat(atStoppingPoint(',', false, 0.5f)).isTrue();
+    assertThat(atStoppingPoint(';', false, 0.8f)).isTrue();
+  }
+
+  @Test
+  void mid_word_is_never_a_stopping_point_until_the_cap() {
+    assertThat(atStoppingPoint('t', false, 0.99f)).isFalse();
+    assertThat(atStoppingPoint('t', false, 1f))
+      .as("the cap is the backstop — the hard limit would sever it here anyway")
+      .isTrue();
+  }
+
+  @Test
+  void progress_is_zero_below_the_threshold_and_one_at_the_cap() {
+    assertThat(eogRampProgress(100, 200, 0.75f)).isZero();
+    assertThat(eogRampProgress(175, 200, 0.75f)).isEqualTo(0.5f, within(0.01f));
+    assertThat(eogRampProgress(200, 200, 0.75f)).isEqualTo(1f);
+    assertThat(eogRampProgress(999, 200, 0.75f)).isEqualTo(1f);
+  }
+
+  @Test
+  void progress_is_zero_when_the_ramp_is_disabled() {
+    assertThat(eogRampProgress(199, 200, -1f)).isZero();
+    assertThat(eogRampProgress(199, -1, 0.75f)).isZero();
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/SpeculativeDecodingTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/SpeculativeDecodingTest.java
@@ -509,6 +509,136 @@ class SpeculativeDecodingTest extends LlamaCppTest {
   }
 
   @Test
+  void eog_ramp_under_speculation_tracks_the_text_and_finishes_as_length() {
+    // The ramp's boundary gate reads state that only the autoregressive path used to update, so a
+    // speculative run judged stopping points from text generated rounds earlier. Two things must
+    // hold here: the gate sees the text actually produced (so the run ends at a boundary, short of
+    // the cap), and a budget-driven EOG reports LENGTH rather than STOP.
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var ctx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+
+    var state = ConversationState.create(
+      arena,
+      ctx,
+      new LlamaTokenizer(vocab, ctx),
+      track(new LlamaSampler(arena).greedy())
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .setNgram(SpeculativeConfig.ngramGreedy(4, 2))
+      .setEogRamp(0.5f, 100f)
+      .initialize(PROMPT);
+
+    String text = new DefaultLlamaIterator(state)
+      .stream()
+      .map(LlamaOutput::content)
+      .reduce("", (a, b) -> a + b);
+
+    System.out.println(
+      "spec+ramp: " +
+        text +
+        " (finish=" +
+        state.getFinishReason() +
+        ", tokens=" +
+        state.getAnswerTokens() +
+        ")"
+    );
+    // The boundary state must reflect the LAST emitted text — that is the regression: it used to
+    // be frozen at whatever preceded the first speculative round. Comparable only below the cap,
+    // where every counted token was also streamed.
+    if (!text.isBlank() && state.getAnswerTokens() < MAX_TOKENS) {
+      String trimmed = text.stripTrailing();
+      assertThat(state.getLastNonSpaceChar()).isEqualTo(
+        trimmed.charAt(trimmed.length() - 1)
+      );
+    }
+    assertThat(state.getFinishReason()).isIn(
+      FinishReason.LENGTH,
+      FinishReason.STOP
+    );
+    // An EOG produced while the ramp was active is budget-driven, so it must not report STOP.
+    if (state.getAnswerTokens() < MAX_TOKENS) {
+      assertThat(state.getFinishReason()).isEqualTo(FinishReason.LENGTH);
+    }
+  }
+
+  @Test
+  void eog_ramp_under_fused_batch_speculation_tracks_each_sequence() {
+    // BatchIterator.acceptSequence is a SECOND implementation of the verify/bias loop, and it is
+    // the one the batch engine (i.e. the server) actually runs. Its per-row bias tracking and the
+    // boundary state have to hold per sequence — a shared or sticky flag would leak one
+    // sequence's budget pressure onto another's finish reason.
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena)
+      .nCtx(512)
+      .nBatch(512)
+      .nUBatch(512)
+      .nSeqMax(2);
+    var batchCtx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+
+    String[] prompts = { "The capital of France is", "Water boils at" };
+    var states = new ConversationState[2];
+    var texts = new StringBuilder[] {
+      new StringBuilder(),
+      new StringBuilder(),
+    };
+
+    var batchIt = new BatchIterator(arena, batchCtx);
+    try {
+      for (int i = 0; i < 2; i++) {
+        states[i] = ConversationState.create(
+          arena,
+          batchCtx,
+          new LlamaTokenizer(vocab, batchCtx),
+          track(new LlamaSampler(arena).greedy()),
+          i
+        )
+          .setMaxTokens(MAX_TOKENS)
+          .setNgram(SpeculativeConfig.ngramGreedy(4, 2))
+          .setEogRamp(0.5f, 100f)
+          .initialize(prompts[i]);
+        batchIt.addState(states[i]);
+      }
+      batchIt.stream().forEach(o -> texts[o.sequenceId()].append(o.content()));
+    } finally {
+      batchIt.close();
+    }
+
+    for (int i = 0; i < 2; i++) {
+      String text = texts[i].toString();
+      System.out.println(
+        "seq" +
+          i +
+          ": " +
+          text +
+          " (finish=" +
+          states[i].getFinishReason() +
+          ", tokens=" +
+          states[i].getAnswerTokens() +
+          ")"
+      );
+      // Only comparable below the cap: the token that REACHES the budget is counted (and lands in
+      // the KV cache, so it legitimately advances the boundary state) but is never streamed —
+      // mirroring the autoregressive path, which stops after incrementing.
+      if (!text.isBlank() && states[i].getAnswerTokens() < MAX_TOKENS) {
+        String trimmed = text.stripTrailing();
+        assertThat(states[i].getLastNonSpaceChar())
+          .as("seq %d boundary state follows its own text", i)
+          .isEqualTo(trimmed.charAt(trimmed.length() - 1));
+      }
+      if (states[i].getAnswerTokens() < MAX_TOKENS) {
+        assertThat(states[i].getFinishReason())
+          .as("seq %d ended early under the ramp", i)
+          .isEqualTo(FinishReason.LENGTH);
+      }
+    }
+  }
+
+  @Test
   void fused_batch_ngram_matches_per_sequence_greedy() {
     Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
     var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
@@ -598,5 +728,64 @@ class SpeculativeDecodingTest extends LlamaCppTest {
     );
     assertThat(text).isNotBlank();
     assertThat(state.acceptRate()).isBetween(0.0, 1.0);
+  }
+
+  @Test
+  void eog_ramp_under_stochastic_speculation() {
+    // The stochastic branch of accept() is a separate code path from the greedy one: acceptance
+    // goes through acceptTarget/residual rather than a plain argmax comparison, and each reads the
+    // biased row. Exactness only holds while the accept test and the residual draw see the SAME
+    // target, so the bias must be applied before either touches the row — this is the path where
+    // getting that wrong would silently skew the distribution instead of failing.
+    Path path = getModelPath(MODEL_PATH, MODEL_TO_DOWNLOAD);
+    var model = track(new LlamaModel(arena, path, new LlamaModelParams(arena)));
+    var cp = new LlamaContextParams(arena).nCtx(512).nBatch(512).nUBatch(512);
+    var ctx = track(new LlamaContext(arena, model, cp));
+    var vocab = new LlamaVocab(model);
+
+    var state = ConversationState.create(
+      arena,
+      ctx,
+      new LlamaTokenizer(vocab, ctx),
+      // A real sampler chain: the ramp writes into the logits row this chain then reads, so the
+      // bias has to survive temperature/top-k/top-p rather than being applied after selection.
+      track(
+        new LlamaSampler(arena)
+          .topK(40)
+          .topP(0.95f, 1)
+          .temperature(0.8f)
+          .seed(42)
+      )
+    )
+      .setMaxTokens(MAX_TOKENS)
+      .setNgram(SpeculativeConfig.ngram(4, 2, 0.8f, 40, 0.95f, 42))
+      .setEogRamp(0.5f, 100f)
+      .initialize(PROMPT);
+
+    String text = new DefaultLlamaIterator(state)
+      .stream()
+      .map(LlamaOutput::content)
+      .reduce("", (a, b) -> a + b);
+
+    System.out.println(
+      "stochastic+ramp: " +
+        text +
+        " (finish=" +
+        state.getFinishReason() +
+        ", tokens=" +
+        state.getAnswerTokens() +
+        ", accept=" +
+        state.acceptRate() +
+        ")"
+    );
+    assertThat(text).isNotBlank();
+    assertThat(state.acceptRate()).isBetween(0.0, 1.0);
+    if (state.getAnswerTokens() < MAX_TOKENS) {
+      String trimmed = text.stripTrailing();
+      assertThat(state.getLastNonSpaceChar()).isEqualTo(
+        trimmed.charAt(trimmed.length() - 1)
+      );
+      assertThat(state.getFinishReason()).isEqualTo(FinishReason.LENGTH);
+    }
   }
 }

--- a/src/test/java/io/gravitee/llama/cpp/modules/SharedPrefixMarkerTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/modules/SharedPrefixMarkerTest.java
@@ -51,6 +51,9 @@ class SharedPrefixMarkerTest {
     "<|end|><|start|>assistant<|channel|>final<|message|>";
   private static final String TOOL_OPEN =
     "<|end|><|start|>assistant<|channel|>commentary to=functions.";
+  /** gpt-oss is told to use commentary, but that is a system-prompt request, not a grammar. */
+  private static final String TOOL_OPEN_ANALYSIS =
+    "<|end|><|start|>assistant<|channel|>analysis to=functions.";
   private static final String TOOL_CLOSE = "<|call|>";
 
   /** Mirrors TokenTracking: accumulates emitted tokens per channel. */
@@ -70,7 +73,11 @@ class SharedPrefixMarkerTest {
       new StateEvaluation.Config(
         List.of(
           new StateBounds(GenerationState.REASONING, REASON_OPEN, REASON_CLOSE),
-          new StateBounds(GenerationState.TOOLS, TOOL_OPEN, TOOL_CLOSE)
+          new StateBounds(
+            GenerationState.TOOLS,
+            List.of(TOOL_OPEN, TOOL_OPEN_ANALYSIS),
+            TOOL_CLOSE
+          )
         )
       )
     );
@@ -154,6 +161,32 @@ class SharedPrefixMarkerTest {
     assertThat(run.tokens().get(GenerationState.TOOLS))
       .as("a resolved tool span must be billed to TOOLS")
       .isPositive();
+  }
+
+  /**
+   * The variant that leaked in practice: the model opens the tool call on the ANALYSIS channel
+   * instead of commentary. With only the commentary marker configured the run refutes against
+   * reasoning-close, and the entire call — markers included — is flushed into the reasoning
+   * channel as text; the reasoning never closes.
+   */
+  @Test
+  void a_tool_call_on_the_analysis_channel_is_recognised_too() {
+    var run = drive(
+      tokenize(
+        REASON_OPEN,
+        "Need to inspect the file.",
+        TOOL_OPEN_ANALYSIS,
+        "read_file<|constrain|>json<|message|>{\"path\":\"/tmp/x\"}",
+        TOOL_CLOSE
+      )
+    );
+
+    assertThat(run.tokens().get(GenerationState.TOOLS))
+      .as("the analysis-channel variant must open a tool span")
+      .isPositive();
+    assertThat(run.reasoning())
+      .as("marker text must not leak into reasoning")
+      .doesNotContain("to=functions.");
   }
 
   /** A tool call with no marker prefix ambiguity behaves the same. */

--- a/src/test/java/io/gravitee/llama/cpp/modules/StateEvaluationTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/modules/StateEvaluationTest.java
@@ -113,7 +113,7 @@ class StateEvaluationTest {
 
   @Test
   void null_start_bounds_never_match_a_generated_piece() {
-    var eval = of(new StateBounds(TOOLS, null, "<|eom_id|>"));
+    var eval = of(new StateBounds(TOOLS, (String) null, "<|eom_id|>"));
 
     assertThat(step(eval, ANSWER, "{\"name\"")).isEqualTo(ANSWER);
   }


### PR DESCRIPTION
## Budget-aware EOG bias, multi-marker channels, special-token introspection

`max_tokens` is a guillotine: generation runs at full tilt until the counter
trips, then stops mid-word. This PR turns it into a pressure, and fixes two
generation-state gaps found while running an agent loop against gpt-oss-20b.

### Budget-aware EOG ramp

`ConversationState.setEogRamp(startFraction, maxBias)`. Past
`startFraction * maxTokens`, every end-of-generation token's logit is raised on a
quadratic curve — gentle at the threshold, overwhelming at the cap — so the model
closes its sentence on its own. The hard cap remains as a backstop.

Below the threshold the logits buffer is untouched, so a run with the ramp
configured is bit-identical to one without it for most of the budget. Completions
typically land **short** of the cap, which makes `max_tokens` a target rather than
a ceiling. An EOG produced under the ramp still reports `FinishReason.LENGTH`:
the budget caused it, and agent loops need that signal to decide whether to
continue.

The bias is written into the logits row just before `llama_sampler_sample`, which
reads the same buffer — equivalent to a `logit_bias` sampler at the head of the
chain, and it composes correctly with top-k/top-p/temperature/penalties
downstream. `llama_sampler_init_logit_bias` was rejected because it copies its
vector at construction, so a ramp would mean rebuilding the sampler every step.
A grammar was rejected because GBNF constrains structure and never sees a token
budget.

All EOG tokens are biased, not just EOS — a vocab has several (`eos`, `eot`,
`<|im_end|>`, …) and biasing one leaves the model an unbiased escape.
`LlamaVocab.eogTokens()` caches the scan, since `isEog` is a native call.

### It applies under speculative decoding too

The first cut skipped the ramp whenever a draft was active, on the assumption
that biasing the target broke rejection sampling. That was wrong: speculative
sampling is exact for *any* target distribution provided the accept test and the
residual are computed against the same one. Each verified row is now biased at
its projected position — the draft tokens plus the bonus row — so a speculative
run reaches the cap on the same curve as an autoregressive one.

### A channel may be opened by more than one marker

`StateBounds.starts` became a list. Harmony is told to emit tool calls on the
`commentary` channel, but that instruction lives in the system prompt, not the
grammar, and the model also uses `analysis`. Markers anchor at the start of a run,
so an unconfigured variant never matches, refutes against the close marker, and
leaks the entire call into the previous channel as text. The single-string
constructor is preserved.

### `LlamaVocab.specialTokenTexts()`

Returns the vocab's control and user-defined token texts, longest-first. Callers
need this to neutralize special-token strings appearing in user content before
templating — `llama_tokenize` parses the whole prompt with `parse_special=true`,
so a `<|channel|>` in a message body becomes a real control token. Verified
against gpt-oss-20b: 21 tokens, matching llama.cpp's own
`special tokens cache size = 21`.