### PR TITLE
fix(state): suppress stray close markers, and stamp a tool call that ends on EOS

### DIFF
--- a/docs/reasoning-and-tool-calls/README.md
+++ b/docs/reasoning-and-tool-calls/README.md
@@ -7,9 +7,9 @@ Many models interleave their output: a chain-of-thought block (e.g. `<think>…<
 
 ## Key types
 - `GenerationState` — enum of the section the model is currently emitting: `ANSWER`, `REASONING`, `TOOLS`.
-- `StateBounds` — record `(GenerationState state, String start, String end)` pairing a section with its delimiter strings.
-- `ConversationState` — owns the generation; `setReasoning(start, end)` / `setToolCall(start, end)` register the delimiters before `initialize(prompt)`.
-- `FinishReason` — terminal reason; `TOOL_CALL` (label `"tool_calls"`) is reported when output ends inside a tool-call block, alongside `EOS` / `STOP` / `LENGTH`.
+- `StateBounds` — record `(GenerationState state, List<String> starts, List<String> ends, boolean repeatable)` pairing a section with its delimiters and its re-entry rule. **Both ends take a list**: a channel can be entered and left more than one way. Single-marker constructors are kept.
+- `ConversationState` — owns the generation; `setReasoning(...)` / `setToolCall(...)` register the delimiters before `initialize(prompt)`, each in single-marker, many-opens, or many-opens/many-closes form.
+- `FinishReason` — terminal reason; `TOOL_CALL` (label `"tool_calls"`) is reported when output leaves **or ends inside** a tool-call block, alongside `EOS` / `STOP` / `LENGTH`.
 - `DefaultLlamaIterator` — drives token-by-token generation; `getGenerationState()` on the state reflects the active section as you stream.
 
 ## Usage
@@ -72,7 +72,11 @@ it.stream().forEach(chunk -> {
 | Method | Section | Effect |
 | --- | --- | --- |
 | `setReasoning(String start, String end)` | `REASONING` | Registers a `StateBounds(REASONING, start, end)`; tokens between the delimiters count toward `getReasoningTokens()`. |
-| `setToolCall(String start, String end)` | `TOOLS` | Registers a `StateBounds(TOOLS, start, end)`; tokens between the delimiters count toward `getToolsTokens()`; ending here yields `FinishReason.TOOL_CALL`. |
+| `setReasoning(List<String> starts, List<String> ends)` | `REASONING` | Same, with alternatives on either end. Harmony reaches its final channel after `<\|end\|>` when answering directly and after `<\|call\|>` when a tool call intervened — configure both, or the unmatched one leaks. |
+| `setToolCall(String start, String end)` | `TOOLS` | Registers a `StateBounds(TOOLS, start, end)`; tokens between the delimiters count toward `getToolsTokens()`; leaving or ending here yields `FinishReason.TOOL_CALL`. |
+| `setToolCall(List<String> starts, String end)` | `TOOLS` | Several opening markers, one close — a dialect may open the tool channel more than one way (Harmony: commentary and analysis). |
+| `setToolCall(List<String> starts, List<String> ends)` | `TOOLS` | Alternatives on both ends. |
+| `setReasoning(List<String> starts, List<String> ends, boolean repeatable)` | `REASONING` | Same, plus whether the channel may be entered AGAIN after it closes. |
 | `getReasoningTokens()` / `getToolsTokens()` / `getAnswerTokens()` | — | Per-section output token counts; `getInputTokens()` and `getTotalTokenCount()` cover the prompt and grand total. |
 
 | `GenerationState` | Meaning |
@@ -84,6 +88,20 @@ it.stream().forEach(chunk -> {
 ## Notes
 - Configure `setReasoning` / `setToolCall` **before** `initialize(prompt)` — `initialize` resets generation state (and re-reads the registered `StateBounds`). Both methods are chainable and return the same `ConversationState`.
 - The delimiter strings must match what the model actually emits (driven by its chat template / system prompt). The tool-call test, for example, instructs the model via the system prompt to wrap calls in `<tool_call>…</tool_call>` and then registers those exact delimiters.
+- **Delimiters are syntax, not content — they are suppressed.** The emission for a confirmed marker is empty, and its tokens are billed to the channel it opened, so a caller streaming `emit()` never has to strip them.
+- **A marker split across tokens is buffered, not leaked.** Text that is a strict prefix of a candidate is withheld (empty emission) until the marker completes or the text diverges; on divergence the buffered text is released into the current channel, in order, and the divergent piece is re-scanned. Generation that stops mid-marker flushes the fragment rather than dropping it, so no token is lost. The cost is one token of latency on text that merely *starts* like a marker.
+- **Markers match at the start of a run, longest first.** A marker only matches where a run begins — after the previous one resolved, or at the start of generation. A variant that is not configured never matches: it refutes, and the whole header lands in the current channel as visible text. Shortening a marker to a shared substring is not a substitute, because the run boundary is the full header.
+- **A close marker arriving in `ANSWER` is suppressed too.** No span is open for it to close, so it can only be stray syntax — and models emit it: after a tool call the next turn starts fresh in `ANSWER` and dialects like Harmony still prefix the reply with their final-channel header. List that bare header among the closes, or it reaches the caller as `<|channel|>final<|message|>DONE`.
+- **A turn that ends inside the tool channel reports `TOOL_CALL`.** When the close marker is itself an EOS token (Harmony's `<|call|>`) generation halts on it, so no transition is ever observed mid-stream; without this the turn looks like a plain stop and downstream renders the span as prose instead of executing it. An empty span never counts — a provisional entry that resolves straight back out captured nothing to call.
+- **A channel occurs once unless it declares otherwise.** `repeatable` defaults to
+  `true` for `TOOLS` (models emit several calls) and `false` elsewhere — the ChatML
+  rule, and what stops a literal `<think>` in an answer from re-opening reasoning.
+  Harmony breaks that assumption: one generation can run analysis, return to the
+  final channel, then open a commentary preamble. A channel that cannot re-open
+  stops matching, so the second header reaches the caller as raw text and its
+  tokens are counted as answer. Pass `repeatable = true` for such dialects.
+- **Channels chain rather than nest.** In any state the candidates are the current state's closes and the *other* states' opens, so a tool call opening straight out of a reasoning span closes it implicitly.
+- **A prompt can seed the starting state.** `initialState(prompt)` begins generation inside a span the prompt left open — a chat template ending in `<think>`, or a continuation — because the model never re-emits that opening marker.
 - These delimiters are not appended to the prompt; they are pure output classifiers. Detection works on the decoded text stream, so multi-token delimiters are handled.
 - `getAnswerTokens()` always reflects the `ANSWER` section even when reasoning/tool calls are configured; the three section counts plus the input count sum to `getTotalTokenCount()`.
 - `FinishReason.TOOL_CALL` is a marker that generation stopped inside a tool call; the natural terminal reasons remain `EOS`, `STOP`, and `LENGTH`. `isFinished()` distinguishes a real stop (EOG/length) from a marker set while generation could otherwise continue.

--- a/docs/text-generation/README.md
+++ b/docs/text-generation/README.md
@@ -79,7 +79,8 @@ LlamaRuntime.llama_backend_free();
 | `minP(float p, int minKeep)` | Drop tokens below `p` × top-token prob (at least `minKeep`). |
 | `mirostat(int seed, float tau, float eta)` | Mirostat v2 adaptive-perplexity sampling. |
 | `penalties(int lastN, float repeat, float freq, float present)` | Repetition / frequency / presence penalties over the last `lastN` tokens. |
-| `grammar(LlamaVocab vocab, String grammar, String root)` | Constrain output to a GBNF grammar. |
+| `grammar(LlamaVocab vocab, String grammar, String root)` | Constrain **all** output to a GBNF grammar. |
+| `grammarLazy(LlamaVocab vocab, String grammar, String root, List<String> triggerPatterns, List<Integer> triggerTokens)` | Arm the grammar only once a trigger matches, and apply it from the pattern's **first capture group** onward. This is what makes a constrained region inside free text possible — constraining tool-call arguments with `grammar()` would force the model to answer in JSON even when it is only talking. Patterns are matched from the start of the generated output, so they normally read `^[\s\S]*?<escaped marker>([\s\S]*)`. |
 | `seed(int seed)` | Append the final distribution sampler with a fixed RNG seed (reproducible). |
 
 ### Generation limits (`ConversationState`, fluent)

--- a/src/main/java/io/gravitee/llama/cpp/ConversationState.java
+++ b/src/main/java/io/gravitee/llama/cpp/ConversationState.java
@@ -653,7 +653,7 @@ public class ConversationState {
    * start of a run; with only one configured, the other leaks into reasoning as raw text.
    */
   public ConversationState setToolCall(
-    java.util.List<String> tokenStarts,
+    List<String> tokenStarts,
     String tokenEnd
   ) {
     this.stateBounds.add(
@@ -671,8 +671,8 @@ public class ConversationState {
    * tool call intervenes. One marker covers one path and leaks the other's header as text.
    */
   public ConversationState setReasoning(
-    java.util.List<String> tokenStarts,
-    java.util.List<String> tokenEnds
+    List<String> tokenStarts,
+    List<String> tokenEnds
   ) {
     this.stateBounds.add(
       new StateBounds(GenerationState.REASONING, tokenStarts, tokenEnds)
@@ -680,14 +680,6 @@ public class ConversationState {
     return this;
   }
 
-  /**
-   * Configures tool call detection where the channel can be left more than one way.
-   *
-   * <p>{@code <|call|>} ends a tool call, but when the model continues into an answer the
-   * final-channel header follows immediately and belongs to the marker — otherwise it is
-   * stranded in the answer. Listing both lets the longer win when it arrives and the shorter
-   * settle the span when generation stops at the call, which is the normal agent flow.
-   */
   /**
    * Configures reasoning detection for a dialect that re-enters the channel.
    *
@@ -697,8 +689,8 @@ public class ConversationState {
    * caller as raw text — and its tokens are billed as answer.
    */
   public ConversationState setReasoning(
-    java.util.List<String> tokenStarts,
-    java.util.List<String> tokenEnds,
+    List<String> tokenStarts,
+    List<String> tokenEnds,
     boolean repeatable
   ) {
     this.stateBounds.add(
@@ -712,9 +704,17 @@ public class ConversationState {
     return this;
   }
 
+  /**
+   * Configures tool call detection where the channel can be left more than one way.
+   *
+   * <p>{@code <|call|>} ends a tool call, but when the model continues into an answer the
+   * final-channel header follows immediately and belongs to the marker — otherwise it is
+   * stranded in the answer. Listing both lets the longer win when it arrives and the shorter
+   * settle the span when generation stops at the call, which is the normal agent flow.
+   */
   public ConversationState setToolCall(
-    java.util.List<String> tokenStarts,
-    java.util.List<String> tokenEnds
+    List<String> tokenStarts,
+    List<String> tokenEnds
   ) {
     this.stateBounds.add(
       new StateBounds(GenerationState.TOOLS, tokenStarts, tokenEnds)

--- a/src/main/java/io/gravitee/llama/cpp/ConversationState.java
+++ b/src/main/java/io/gravitee/llama/cpp/ConversationState.java
@@ -688,6 +688,30 @@ public class ConversationState {
    * stranded in the answer. Listing both lets the longer win when it arrives and the shorter
    * settle the span when generation stops at the call, which is the normal agent flow.
    */
+  /**
+   * Configures reasoning detection for a dialect that re-enters the channel.
+   *
+   * <p>Harmony chains channels rather than wrapping one span: a generation can run
+   * analysis, return to the final channel, and then open commentary. Left
+   * non-repeatable, the second opening never matches and its header reaches the
+   * caller as raw text — and its tokens are billed as answer.
+   */
+  public ConversationState setReasoning(
+    java.util.List<String> tokenStarts,
+    java.util.List<String> tokenEnds,
+    boolean repeatable
+  ) {
+    this.stateBounds.add(
+      new StateBounds(
+        GenerationState.REASONING,
+        tokenStarts,
+        tokenEnds,
+        repeatable
+      )
+    );
+    return this;
+  }
+
   public ConversationState setToolCall(
     java.util.List<String> tokenStarts,
     java.util.List<String> tokenEnds

--- a/src/main/java/io/gravitee/llama/cpp/ConversationState.java
+++ b/src/main/java/io/gravitee/llama/cpp/ConversationState.java
@@ -662,6 +662,42 @@ public class ConversationState {
     return this;
   }
 
+  /**
+   * Configures reasoning detection where the channel can be left more than one way.
+   *
+   * <p>Harmony needs this: reasoning ends into the final channel via
+   * {@code <|end|><|start|>assistant<|channel|>final<|message|>} when the model answers
+   * directly, but the run before the final channel is terminated by {@code <|call|>} when a
+   * tool call intervenes. One marker covers one path and leaks the other's header as text.
+   */
+  public ConversationState setReasoning(
+    java.util.List<String> tokenStarts,
+    java.util.List<String> tokenEnds
+  ) {
+    this.stateBounds.add(
+      new StateBounds(GenerationState.REASONING, tokenStarts, tokenEnds)
+    );
+    return this;
+  }
+
+  /**
+   * Configures tool call detection where the channel can be left more than one way.
+   *
+   * <p>{@code <|call|>} ends a tool call, but when the model continues into an answer the
+   * final-channel header follows immediately and belongs to the marker — otherwise it is
+   * stranded in the answer. Listing both lets the longer win when it arrives and the shorter
+   * settle the span when generation stops at the call, which is the normal agent flow.
+   */
+  public ConversationState setToolCall(
+    java.util.List<String> tokenStarts,
+    java.util.List<String> tokenEnds
+  ) {
+    this.stateBounds.add(
+      new StateBounds(GenerationState.TOOLS, tokenStarts, tokenEnds)
+    );
+    return this;
+  }
+
   public List<MtmdMedia> getMedia() {
     return media;
   }

--- a/src/main/java/io/gravitee/llama/cpp/DefaultLlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/DefaultLlamaIterator.java
@@ -117,6 +117,9 @@ public final class DefaultLlamaIterator
       var flush = currentState
         .getStateEvaluation()
         .flushPending(currentState.getGenerationState());
+      // Flushing can settle a held marker and therefore change channel — see
+      // LlamaIterator#flushPendingMarker.
+      currentState.setGenerationState(flush.state());
       if (flush.emitTokens() > 0) {
         incrementTokenCount(flush.emitTokens());
         currentState.setPiece(flush.emit());

--- a/src/main/java/io/gravitee/llama/cpp/DefaultLlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/DefaultLlamaIterator.java
@@ -114,12 +114,22 @@ public final class DefaultLlamaIterator
       currentState.setFinished(true);
       // Generation ended while a multi-token marker prefix may still be buffered — flush it
       // to the current channel as one final emission instead of dropping it.
-      var flush = currentState
-        .getStateEvaluation()
-        .flushPending(currentState.getGenerationState());
+      var previousState = currentState.getGenerationState();
+      var flush = currentState.getStateEvaluation().flushPending(previousState);
       // Flushing can settle a held marker and therefore change channel — see
       // LlamaIterator#flushPendingMarker.
       currentState.setGenerationState(flush.state());
+      // ...and a turn that ends in the tool channel is a tool call — see the same
+      // stamp in LlamaIterator#flushPendingMarker for why, and for the empty-span guard.
+      if (
+        previousState == GenerationState.TOOLS &&
+        currentState
+          .getTokenTracking()
+          .getOutputTokenCount(GenerationState.TOOLS) >
+        0
+      ) {
+        currentState.setFinishReason(FinishReason.TOOL_CALL);
+      }
       if (flush.emitTokens() > 0) {
         incrementTokenCount(flush.emitTokens());
         currentState.setPiece(flush.emit());

--- a/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
@@ -787,14 +787,26 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
     ConversationState state,
     List<LlamaOutput> out
   ) {
-    var flush = state
-      .getStateEvaluation()
-      .flushPending(state.getGenerationState());
+    var previousState = state.getGenerationState();
+    var flush = state.getStateEvaluation().flushPending(previousState);
     // A flush can now close a span: when generation stops on a marker that is also the
     // prefix of a longer alternative (<|call|> ending an agent turn), the held match is
     // settled here. Adopt the emitted channel so the turn is not reported as still inside
     // the tool call, and so its tokens are attributed to the right one.
     state.setGenerationState(flush.state());
+
+    // A turn that ENDS in the tool channel is a tool call, whether its close marker
+    // settled here or never arrived at all. processSampledToken only stamps TOOL_CALL on a
+    // transition it sees mid-stream, so an agent turn whose <|call|> IS the EOS token
+    // finished as STOP and the span was rendered to the user as content instead of being
+    // extracted and run. Same empty-span guard as the mid-stream path: a provisional entry
+    // into TOOLS that resolves straight back out captured nothing.
+    if (
+      previousState == GenerationState.TOOLS &&
+      state.getTokenTracking().getOutputTokenCount(GenerationState.TOOLS) > 0
+    ) {
+      state.setFinishReason(FinishReason.TOOL_CALL);
+    }
     if (flush.emitTokens() > 0) {
       state
         .getTokenTracking()

--- a/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaIterator.java
@@ -790,12 +790,17 @@ public abstract class LlamaIterator<T> implements Iterator<T> {
     var flush = state
       .getStateEvaluation()
       .flushPending(state.getGenerationState());
+    // A flush can now close a span: when generation stops on a marker that is also the
+    // prefix of a longer alternative (<|call|> ending an agent turn), the held match is
+    // settled here. Adopt the emitted channel so the turn is not reported as still inside
+    // the tool call, and so its tokens are attributed to the right one.
+    state.setGenerationState(flush.state());
     if (flush.emitTokens() > 0) {
       state
         .getTokenTracking()
         .consume(
           new io.gravitee.llama.cpp.modules.TokenTracking.Context(
-            state.getGenerationState(),
+            flush.state(),
             flush.emitTokens()
           )
         );

--- a/src/main/java/io/gravitee/llama/cpp/LlamaRuntime.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaRuntime.java
@@ -1480,6 +1480,43 @@ public final class LlamaRuntime {
     );
   }
 
+  /**
+   * Lazy grammar sampler: the grammar stays dormant until one of
+   * {@code trigger_patterns} matches from the start of the generated output, or one of
+   * {@code trigger_tokens} is sampled. Constrained regions inside otherwise free text —
+   * a tool call in the middle of prose — need this; the eager
+   * {@link #llama_sampler_init_grammar} would force the whole response to match.
+   */
+  public static MemorySegment llama_sampler_init_grammar_lazy_patterns(
+    MemorySegment vocab,
+    MemorySegment grammar,
+    MemorySegment root,
+    MemorySegment triggerPatterns,
+    long numTriggerPatterns,
+    MemorySegment triggerTokens,
+    long numTriggerTokens
+  ) {
+    return llama_h(
+      "llama_sampler_init_grammar_lazy_patterns",
+      new Class<?>[] {
+        MEM_SEG_CLASS,
+        MEM_SEG_CLASS,
+        MEM_SEG_CLASS,
+        MEM_SEG_CLASS,
+        long.class,
+        MEM_SEG_CLASS,
+        long.class,
+      },
+      vocab,
+      grammar,
+      root,
+      triggerPatterns,
+      numTriggerPatterns,
+      triggerTokens,
+      numTriggerTokens
+    );
+  }
+
   public static MemorySegment llama_sampler_init_penalties(
     int penaltyLastN,
     float penaltyRepeat,

--- a/src/main/java/io/gravitee/llama/cpp/LlamaSampler.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaSampler.java
@@ -114,8 +114,10 @@ public final class LlamaSampler extends MemorySegmentAware implements Freeable {
    * llama.cpp counterpart of vLLM's structural tags.
    *
    * <p>The grammar is fed content starting at the pattern's first capture group, so a
-   * pattern normally wraps the payload it wants to constrain, e.g.
-   * {@code "<\\|channel\\|>commentary to=functions\\.\\w+<\\|constrain\\|>json<\\|message\\|>(.*)"}.
+   * pattern wraps the payload it wants to constrain. Patterns are matched from the start
+   * of the generated output, so any prose before the trigger must be consumed by the
+   * pattern itself, e.g.
+   * {@code "^[\\s\\S]*?<\\|channel\\|>commentary to=functions\\.\\w+<\\|constrain\\|>json<\\|message\\|>([\\s\\S]*)"}.
    *
    * @param vocab           the model vocabulary
    * @param grammar         GBNF grammar text

--- a/src/main/java/io/gravitee/llama/cpp/LlamaSampler.java
+++ b/src/main/java/io/gravitee/llama/cpp/LlamaSampler.java
@@ -20,6 +20,8 @@ import static io.gravitee.llama.cpp.LlamaRuntime.*;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SegmentAllocator;
+import java.lang.foreign.ValueLayout;
+import java.util.List;
 
 /**
  * @author Rémi SULTAN (remi.sultan at graviteesource.com)
@@ -97,6 +99,76 @@ public final class LlamaSampler extends MemorySegmentAware implements Freeable {
     llama_sampler_chain_add(
       this.segment,
       llama_sampler_init_grammar(vocab.segment, grammarSegment, rootSegment)
+    );
+    return this;
+  }
+
+  /**
+   * Adds a LAZY grammar: the constraint arms only once one of {@code triggerPatterns}
+   * matches the generated text, and then applies from that match onward.
+   *
+   * <p>This is what makes constrained tool calls possible without breaking ordinary
+   * replies. {@link #grammar} forces the WHOLE response to match, so a model asked to
+   * chat would have to answer in JSON. With a trigger — for Harmony, the tool-call
+   * header — prose stays free and only the arguments are constrained, which is the
+   * llama.cpp counterpart of vLLM's structural tags.
+   *
+   * <p>The grammar is fed content starting at the pattern's first capture group, so a
+   * pattern normally wraps the payload it wants to constrain, e.g.
+   * {@code "<\\|channel\\|>commentary to=functions\\.\\w+<\\|constrain\\|>json<\\|message\\|>(.*)"}.
+   *
+   * @param vocab           the model vocabulary
+   * @param grammar         GBNF grammar text
+   * @param root            the grammar's root rule
+   * @param triggerPatterns regexes that arm the grammar; empty means never
+   * @param triggerTokens   token ids that arm the grammar; may be empty
+   */
+  public LlamaSampler grammarLazy(
+    LlamaVocab vocab,
+    String grammar,
+    String root,
+    List<String> triggerPatterns,
+    List<Integer> triggerTokens
+  ) {
+    var grammarSegment = allocator.allocateFrom(grammar);
+    var rootSegment = allocator.allocateFrom(root);
+
+    // const char** — an array of pointers, each to its own NUL-terminated string.
+    var patterns = triggerPatterns == null
+      ? List.<String>of()
+      : triggerPatterns;
+    MemorySegment patternArray = allocator.allocate(
+      ValueLayout.ADDRESS,
+      Math.max(patterns.size(), 1)
+    );
+    for (int i = 0; i < patterns.size(); i++) {
+      patternArray.setAtIndex(
+        ValueLayout.ADDRESS,
+        i,
+        allocator.allocateFrom(patterns.get(i))
+      );
+    }
+
+    var tokens = triggerTokens == null ? List.<Integer>of() : triggerTokens;
+    MemorySegment tokenArray = allocator.allocate(
+      ValueLayout.JAVA_INT,
+      Math.max(tokens.size(), 1)
+    );
+    for (int i = 0; i < tokens.size(); i++) {
+      tokenArray.setAtIndex(ValueLayout.JAVA_INT, i, tokens.get(i));
+    }
+
+    llama_sampler_chain_add(
+      this.segment,
+      llama_sampler_init_grammar_lazy_patterns(
+        vocab.segment,
+        grammarSegment,
+        rootSegment,
+        patternArray,
+        patterns.size(),
+        tokenArray,
+        tokens.size()
+      )
     );
     return this;
   }

--- a/src/main/java/io/gravitee/llama/cpp/StateBounds.java
+++ b/src/main/java/io/gravitee/llama/cpp/StateBounds.java
@@ -34,11 +34,34 @@ import java.util.List;
 public record StateBounds(
   GenerationState state,
   List<String> starts,
-  List<String> ends
+  List<String> ends,
+  boolean repeatable
 ) {
   public StateBounds {
     starts = starts == null ? List.of() : List.copyOf(starts);
     ends = ends == null ? List.of() : List.copyOf(ends);
+  }
+
+  /**
+   * Whether this channel may be entered again after it closes.
+   *
+   * <p>A single {@code <think>…</think>} block per generation is a property of
+   * ChatML, not of reasoning: Harmony CHAINS channels, so one generation can run
+   * analysis, return to the final channel, and then open commentary — and a
+   * channel that cannot re-open stops matching, leaving its header to reach the
+   * caller as raw text. TOOLS has always been re-entrant for the same reason
+   * (models emit several calls); this makes the exemption configurable instead
+   * of hard-coded to one enum constant.
+   *
+   * <p>Defaults preserve the historical behaviour: TOOLS repeats, everything
+   * else occurs at most once.
+   */
+  public StateBounds(
+    GenerationState state,
+    List<String> starts,
+    List<String> ends
+  ) {
+    this(state, starts, ends, GenerationState.TOOLS.equals(state));
   }
 
   /** Single-marker form. */
@@ -48,6 +71,16 @@ public record StateBounds(
       start == null ? List.of() : List.of(start),
       end == null ? List.of() : List.of(end)
     );
+  }
+
+  /** Many openings and closings, with explicit re-entry. */
+  public StateBounds(
+    GenerationState state,
+    List<String> starts,
+    String end,
+    boolean repeatable
+  ) {
+    this(state, starts, end == null ? List.of() : List.of(end), repeatable);
   }
 
   /** Many openings, one closing. */

--- a/src/main/java/io/gravitee/llama/cpp/StateBounds.java
+++ b/src/main/java/io/gravitee/llama/cpp/StateBounds.java
@@ -34,15 +34,37 @@ import java.util.List;
 public record StateBounds(
   GenerationState state,
   List<String> starts,
-  String end
+  List<String> ends
 ) {
   public StateBounds {
     starts = starts == null ? List.of() : List.copyOf(starts);
+    ends = ends == null ? List.of() : List.copyOf(ends);
   }
 
   /** Single-marker form. */
   public StateBounds(GenerationState state, String start, String end) {
-    this(state, start == null ? List.of() : List.of(start), end);
+    this(
+      state,
+      start == null ? List.of() : List.of(start),
+      end == null ? List.of() : List.of(end)
+    );
+  }
+
+  /** Many openings, one closing. */
+  public StateBounds(GenerationState state, List<String> starts, String end) {
+    this(state, starts, end == null ? List.of() : List.of(end));
+  }
+
+  /**
+   * The primary closing marker, or {@code null} if none.
+   *
+   * <p>A channel may be left more than one way — Harmony reaches the final
+   * channel after {@code <|end|>} when the model answers directly and after
+   * {@code <|call|>} when a tool call intervened — so callers that must consider
+   * every exit use {@link #ends()}.
+   */
+  public String end() {
+    return ends.isEmpty() ? null : ends.getFirst();
   }
 
   /** The primary opening marker, or {@code null} if none. */

--- a/src/main/java/io/gravitee/llama/cpp/StateBounds.java
+++ b/src/main/java/io/gravitee/llama/cpp/StateBounds.java
@@ -20,6 +20,10 @@ import java.util.List;
 /**
  * The marker text opening and closing one generation channel.
  *
+ * <p>{@code ends} is a list for the same reason: a channel may be left more than one
+ * way — Harmony's tool run ends on {@code <|call|>} alone when generation stops there,
+ * or on the longer final-channel header when the model continues into an answer.
+ *
  * <p>{@code starts} is a list because a dialect may open a channel more than one way — Harmony
  * emits tool calls on both the {@code commentary} and {@code analysis} channels. Configure every
  * variant: an unmatched one refutes against the close marker and leaks the span as text.
@@ -27,9 +31,10 @@ import java.util.List;
  * <p>Markers are matched only at the start of a run, so each alternative must be complete from
  * that boundary; a shared substring will not match.
  *
- * @param state  the channel these bounds delimit
- * @param starts opening markers; longest match wins
- * @param end    the closing marker
+ * @param state      the channel these bounds delimit
+ * @param starts     opening markers; longest match wins
+ * @param ends       closing markers; longest match wins
+ * @param repeatable whether the channel may be entered again after it closes
  */
 public record StateBounds(
   GenerationState state,

--- a/src/main/java/io/gravitee/llama/cpp/modules/StateEvaluation.java
+++ b/src/main/java/io/gravitee/llama/cpp/modules/StateEvaluation.java
@@ -215,8 +215,14 @@ public class StateEvaluation
     // (b) the other states' open markers (cross-transitions when not in ANSWER)
     for (Entry<GenerationState, StateBounds> e : states.entrySet()) {
       StateBounds bounds = e.getValue();
+      // A channel's OWN openers count while inside it, when it repeats. Models
+      // re-announce the channel they are already in — Harmony emits a second
+      // <|channel|>analysis<|message|> mid-thought — and skipping it leaves the
+      // header in the reasoning text as raw protocol. The transition is a no-op;
+      // the point is that the marker is recognised, and therefore suppressed.
+      boolean ownChannel = bounds.state() == currentState;
       if (
-        bounds.state() == currentState ||
+        (ownChannel && !bounds.repeatable()) ||
         stateAlreadyOccurred(bounds) ||
         isNullOrBlank(bounds)
       ) {
@@ -344,8 +350,9 @@ public class StateEvaluation
   }
 
   private void setAlreadyOccurredIfNecessary(GenerationState currentState) {
-    boolean isTools = !TOOLS.equals(currentState);
-    this.occurredState.put(currentState, isTools);
+    var bounds = states.get(currentState);
+    boolean closesForGood = bounds == null || !bounds.repeatable();
+    this.occurredState.put(currentState, closesForGood);
   }
 
   private GenerationState detectNewState(String piece) {
@@ -419,7 +426,7 @@ public class StateEvaluation
       return true;
     }
 
-    if (TOOLS.equals(stateBounds.state())) {
+    if (stateBounds.repeatable()) {
       return false;
     }
 

--- a/src/main/java/io/gravitee/llama/cpp/modules/StateEvaluation.java
+++ b/src/main/java/io/gravitee/llama/cpp/modules/StateEvaluation.java
@@ -60,6 +60,16 @@ public class StateEvaluation
   private final StringBuilder pending = new StringBuilder();
   private int pendingTokens;
 
+  /**
+   * A marker that has matched completely while a LONGER candidate sharing its
+   * prefix is still possible — {@code <|call|>} is complete while
+   * {@code <|call|><|start|>assistant…} may still be arriving. Held rather than
+   * acted on, and settled when the stream diverges or ends.
+   */
+  private String provisionalMarker;
+
+  private GenerationState provisionalTarget;
+
   @Override
   public boolean isInitialized() {
     return states != null && !states.isEmpty();
@@ -119,6 +129,20 @@ public class StateEvaluation
     if (pendingTokens == 0) {
       return new Emission(currentState, "", 0);
     }
+    if (provisionalMarker != null) {
+      // Generation ended while a longer close marker was still possible — the agent flow,
+      // where <|call|> IS the last token. Settle for the match that did complete so the
+      // span closes and the turn does not end reported as still inside it.
+      String marker = provisionalMarker;
+      GenerationState target = provisionalTarget;
+      if (currentState != GenerationState.ANSWER) {
+        setAlreadyOccurredIfNecessary(currentState);
+      }
+      String remainder = pending.toString().substring(marker.length());
+      int settled = pendingTokens;
+      resetBuffer();
+      return new Emission(target, remainder, settled);
+    }
     String text = pending.toString();
     int n = pendingTokens;
     resetBuffer();
@@ -165,11 +189,15 @@ public class StateEvaluation
 
     // (a) the current state's close marker
     if (currentState != GenerationState.ANSWER) {
-      String marker = states.get(currentState).end();
-      if (marker != null && !marker.isBlank()) {
+      for (String marker : states.get(currentState).ends()) {
+        if (marker == null || marker.isBlank()) {
+          continue;
+        }
         if (accumulated.startsWith(marker)) {
-          bestMarker = marker;
-          bestTarget = GenerationState.ANSWER;
+          if (bestMarker == null || marker.length() > bestMarker.length()) {
+            bestMarker = marker;
+            bestTarget = GenerationState.ANSWER;
+          }
         } else if (marker.startsWith(accumulated)) {
           anyPrefix = true;
         }
@@ -202,6 +230,18 @@ public class StateEvaluation
       }
     }
 
+    if (bestMarker != null && anyPrefix) {
+      // Matched, but a LONGER candidate is still viable. Committing now makes the longer
+      // marker unreachable forever; waiting without remembering this match strands the
+      // state machine when it never arrives. Hold it, and settle on divergence or at the
+      // end of the stream.
+      provisionalMarker = bestMarker;
+      provisionalTarget = bestTarget;
+      pending.append(piece);
+      pendingTokens++;
+      return new Emission(currentState, "", 0);
+    }
+
     if (bestMarker != null) {
       // Confirmed: marker text suppressed; the boundary-spanning remainder (if any) is the
       // first text of the post-flip channel; all covered tokens are counted post-flip.
@@ -226,6 +266,19 @@ public class StateEvaluation
       return new Emission(currentState, piece, 1);
     }
 
+    if (provisionalMarker != null) {
+      // The longer candidate never came: settle for the match we held.
+      String marker = provisionalMarker;
+      GenerationState target = provisionalTarget;
+      if (currentState != GenerationState.ANSWER) {
+        setAlreadyOccurredIfNecessary(currentState);
+      }
+      String remainder = accumulated.substring(marker.length());
+      int n = pendingTokens + 1;
+      resetBuffer();
+      return new Emission(target, remainder, n);
+    }
+
     // Refutation: the accumulated text diverged from every candidate. Flush the buffered
     // text to the current channel and re-scan the refuting piece alone (it may itself start
     // a marker prefix).
@@ -246,6 +299,8 @@ public class StateEvaluation
   private void resetBuffer() {
     pending.setLength(0);
     pendingTokens = 0;
+    provisionalMarker = null;
+    provisionalTarget = null;
   }
 
   /* ----- piece-mode internals (unchanged semantics) ----- */
@@ -260,7 +315,7 @@ public class StateEvaluation
       return GenerationState.ANSWER;
     }
 
-    if (state.end().equals(piece)) {
+    if (state.ends().contains(piece)) {
       setAlreadyOccurredIfNecessary(currentState);
       return GenerationState.ANSWER;
     }
@@ -323,8 +378,12 @@ public class StateEvaluation
     if (lastStart < 0) {
       return false;
     }
-    String end = bounds.end();
-    int lastEnd = end == null || end.isBlank() ? -1 : prompt.lastIndexOf(end);
+    int lastEnd = -1;
+    for (String end : bounds.ends()) {
+      if (end != null && !end.isBlank()) {
+        lastEnd = Math.max(lastEnd, prompt.lastIndexOf(end));
+      }
+    }
     return lastStart > lastEnd;
   }
 

--- a/src/main/java/io/gravitee/llama/cpp/modules/StateEvaluation.java
+++ b/src/main/java/io/gravitee/llama/cpp/modules/StateEvaluation.java
@@ -187,9 +187,17 @@ public class StateEvaluation
     GenerationState bestTarget = null;
     boolean anyPrefix = false;
 
-    // (a) the current state's close marker
-    if (currentState != GenerationState.ANSWER) {
-      for (String marker : states.get(currentState).ends()) {
+    // (a) close markers.
+    //
+    // In ANSWER these are EVERY state's closes, not none. A close marker reaching the
+    // answer channel is stray syntax by definition — the span it would have ended is not
+    // open — and models do emit them there: after a tool call, generation restarts fresh
+    // in ANSWER and Harmony still prefixes its reply with the final-channel header, so
+    // without this the header is unmatchable and lands in the user's content as
+    // "<|channel|>final<|message|>DONE". Matching only suppresses; the state is already
+    // ANSWER, so nothing else changes.
+    for (StateBounds bounds : closeCandidates(currentState)) {
+      for (String marker : bounds.ends()) {
         if (marker == null || marker.isBlank()) {
           continue;
         }
@@ -294,6 +302,18 @@ public class StateEvaluation
       flushed + restart.emit(),
       flushedTokens + restart.emitTokens()
     );
+  }
+
+  /**
+   * The states whose close markers are candidates right now: the current state when
+   * inside a span, every configured state when in ANSWER — where a close marker can
+   * only be leftover syntax.
+   */
+  private List<StateBounds> closeCandidates(GenerationState currentState) {
+    if (currentState != GenerationState.ANSWER) {
+      return List.of(states.get(currentState));
+    }
+    return List.copyOf(states.values());
   }
 
   private void resetBuffer() {

--- a/src/test/java/io/gravitee/llama/cpp/modules/CloseAlternativesTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/modules/CloseAlternativesTest.java
@@ -323,6 +323,47 @@ class CloseAlternativesTest {
   }
 
   @Test
+  void a_close_marker_arriving_in_the_answer_is_suppressed_not_leaked() {
+    // Deliberate: a close marker in ANSWER is protocol, never content. Letting it
+    // through would let generated output poison the conversation template — a
+    // "</think>" re-fed as content becomes live syntax on the next turn. The
+    // marker is deleted; the surrounding prose survives and stays in ANSWER.
+    var eval = new StateEvaluation();
+    eval.initialize(
+      new StateEvaluation.Config(
+        List.of(
+          new StateBounds(GenerationState.REASONING, "<think>", "</think>")
+        )
+      )
+    );
+
+    var answer = new StringBuilder();
+    GenerationState state = GenerationState.ANSWER;
+    for (String piece : List.of("Wrap it in ", "</think>", " like so.")) {
+      var emission = eval.evaluateToken(state, 0, piece);
+      state = emission.state();
+      append(
+        new StringBuilder(),
+        new StringBuilder(),
+        answer,
+        state,
+        emission.emit()
+      );
+    }
+    var flushed = eval.flushPending(state);
+    append(
+      new StringBuilder(),
+      new StringBuilder(),
+      answer,
+      flushed.state(),
+      flushed.emit()
+    );
+
+    assertThat(answer.toString()).isEqualTo("Wrap it in  like so.");
+    assertThat(flushed.state()).isEqualTo(GenerationState.ANSWER);
+  }
+
+  @Test
   void a_repeatable_channel_absorbs_its_own_opener_while_inside_it() {
     // Models re-announce the channel they are already in: Harmony emits a second
     // <|channel|>analysis<|message|> mid-thought. A state's own openers used to be

--- a/src/test/java/io/gravitee/llama/cpp/modules/CloseAlternativesTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/modules/CloseAlternativesTest.java
@@ -248,4 +248,113 @@ class CloseAlternativesTest {
     assertThat(reasoning.toString()).isEqualTo("body");
     assertThat(answer.toString()).isEqualTo("tail");
   }
+
+  @Test
+  void a_repeatable_channel_can_be_re_entered_in_one_generation() {
+    // Harmony chains channels: analysis, back to final, then commentary — all in
+    // ONE generation. Non-repeatable, the second opening stops matching and its
+    // header reaches the caller as raw text ("<|channel|>commentary<|message|>Now
+    // step 2..."), with the prose billed as answer.
+    var eval = new StateEvaluation();
+    eval.initialize(
+      new StateEvaluation.Config(
+        List.of(
+          new StateBounds(
+            GenerationState.REASONING,
+            List.of(
+              "<|channel|>analysis<|message|>",
+              "<|channel|>commentary<|message|>"
+            ),
+            List.of("<|channel|>final<|message|>"),
+            true
+          )
+        )
+      )
+    );
+
+    assertThat(
+      eval
+        .evaluateToken(
+          GenerationState.ANSWER,
+          1,
+          "<|channel|>analysis<|message|>"
+        )
+        .state()
+    ).isEqualTo(GenerationState.REASONING);
+    assertThat(
+      eval
+        .evaluateToken(
+          GenerationState.REASONING,
+          2,
+          "<|channel|>final<|message|>"
+        )
+        .state()
+    ).isEqualTo(GenerationState.ANSWER);
+
+    var reopened = eval.evaluateToken(
+      GenerationState.ANSWER,
+      3,
+      "<|channel|>commentary<|message|>"
+    );
+
+    assertThat(reopened.state()).isEqualTo(GenerationState.REASONING);
+    assertThat(reopened.emit()).isEmpty();
+  }
+
+  @Test
+  void a_non_repeatable_channel_still_occurs_once() {
+    // The guard this preserves: a model that types "<think>" in its answer must
+    // not re-open reasoning after the real block closed.
+    var eval = new StateEvaluation();
+    eval.initialize(
+      new StateEvaluation.Config(
+        List.of(
+          new StateBounds(GenerationState.REASONING, "<think>", "</think>")
+        )
+      )
+    );
+
+    eval.evaluateToken(GenerationState.ANSWER, 1, "<think>");
+    eval.evaluateToken(GenerationState.REASONING, 2, "</think>");
+    var second = eval.evaluateToken(GenerationState.ANSWER, 3, "<think>");
+
+    assertThat(second.state()).isEqualTo(GenerationState.ANSWER);
+    assertThat(second.emit()).isEqualTo("<think>");
+  }
+
+  @Test
+  void a_repeatable_channel_absorbs_its_own_opener_while_inside_it() {
+    // Models re-announce the channel they are already in: Harmony emits a second
+    // <|channel|>analysis<|message|> mid-thought. A state's own openers used to be
+    // skipped as candidates, so that header stayed in the reasoning text as raw
+    // protocol.
+    var eval = new StateEvaluation();
+    eval.initialize(
+      new StateEvaluation.Config(
+        List.of(
+          new StateBounds(
+            GenerationState.REASONING,
+            List.of("<|channel|>analysis<|message|>"),
+            List.of("<|channel|>final<|message|>"),
+            true
+          )
+        )
+      )
+    );
+
+    eval.evaluateToken(
+      GenerationState.ANSWER,
+      1,
+      "<|channel|>analysis<|message|>"
+    );
+    eval.evaluateToken(GenerationState.REASONING, 2, "thinking... ");
+    var again = eval.evaluateToken(
+      GenerationState.REASONING,
+      3,
+      "<|channel|>analysis<|message|>"
+    );
+
+    assertThat(again.state()).isEqualTo(GenerationState.REASONING);
+    assertThat(again.emit()).isEmpty();
+  }
 }

--- a/src/test/java/io/gravitee/llama/cpp/modules/CloseAlternativesTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/modules/CloseAlternativesTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.llama.cpp.modules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.llama.cpp.GenerationState;
+import io.gravitee.llama.cpp.StateBounds;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Leaving a channel by more than one marker — the other half of the Harmony
+ * (gpt-oss) problem that {@link SharedPrefixMarkerTest} covers for openings.
+ *
+ * <p>Reasoning reaches the final channel through
+ * {@code <|end|><|start|>assistant<|channel|>final<|message|>} when the model
+ * answers directly, but through {@code <|call|>} when a tool call intervened.
+ * A tool call itself either ends generation — {@code <|call|>} is an EOS token,
+ * the normal agent flow — or is followed immediately by the final-channel
+ * header. Configure one exit and the other path leaks its header into the
+ * answer as visible syntax.
+ *
+ * <p>The delicate case is a complete match that may still grow: {@code <|call|>}
+ * matches while {@code <|call|><|start|>assistant…} may still be arriving.
+ * Committing at once makes the longer marker unreachable; waiting without
+ * remembering the match leaves the machine stuck inside the tool channel when
+ * the longer form never comes.
+ *
+ * <p>No model or native libraries required.
+ *
+ * @author GraviteeSource Team
+ */
+class CloseAlternativesTest {
+
+  private static final String REASON_OPEN = "<|channel|>analysis<|message|>";
+  private static final String FINAL_HEADER =
+    "<|start|>assistant<|channel|>final<|message|>";
+  private static final String TOOL_OPEN = "<|start|>assistant to=functions.";
+
+  private record Run(
+    String reasoning,
+    String tools,
+    String answer,
+    GenerationState finalState
+  ) {}
+
+  private static Run drive(List<String> pieces) {
+    var evaluation = new StateEvaluation();
+    evaluation.initialize(
+      new StateEvaluation.Config(
+        List.of(
+          new StateBounds(
+            GenerationState.REASONING,
+            List.of(REASON_OPEN),
+            List.of("<|end|>" + FINAL_HEADER, "<|call|>" + FINAL_HEADER)
+          ),
+          new StateBounds(
+            GenerationState.TOOLS,
+            // Both alignments: a close marker sharing the <|end|> prefix buffers
+            // it away from the start of the run.
+            List.of("<|end|>" + TOOL_OPEN, TOOL_OPEN),
+            List.of("<|call|>" + FINAL_HEADER, "<|call|>")
+          )
+        )
+      )
+    );
+
+    var reasoning = new StringBuilder();
+    var tools = new StringBuilder();
+    var answer = new StringBuilder();
+
+    GenerationState state = GenerationState.ANSWER;
+    for (String piece : pieces) {
+      var emission = evaluation.evaluateToken(state, 0, piece);
+      state = emission.state();
+      append(reasoning, tools, answer, state, emission.emit());
+    }
+    var flushed = evaluation.flushPending(state);
+    state = flushed.state();
+    append(reasoning, tools, answer, state, flushed.emit());
+
+    return new Run(
+      reasoning.toString(),
+      tools.toString(),
+      answer.toString(),
+      state
+    );
+  }
+
+  private static void append(
+    StringBuilder reasoning,
+    StringBuilder tools,
+    StringBuilder answer,
+    GenerationState state,
+    String text
+  ) {
+    if (text == null || text.isEmpty()) {
+      return;
+    }
+    switch (state) {
+      case REASONING -> reasoning.append(text);
+      case TOOLS -> tools.append(text);
+      default -> answer.append(text);
+    }
+  }
+
+  @Test
+  void answering_directly_leaves_reasoning_by_the_end_marker() {
+    var run = drive(
+      List.of(
+        "<|channel|>",
+        "analysis",
+        "<|message|>",
+        "Think",
+        ".",
+        "<|end|>",
+        "<|start|>",
+        "assistant",
+        "<|channel|>",
+        "final",
+        "<|message|>",
+        "Hello",
+        "!"
+      )
+    );
+
+    assertThat(run.reasoning()).isEqualTo("Think.");
+    assertThat(run.answer()).isEqualTo("Hello!");
+  }
+
+  @Test
+  void a_tool_call_that_ends_generation_still_closes_its_span() {
+    // <|call|> is an EOS token, so nothing follows it. The longer alternative
+    // never arrives and the span must settle at flush — otherwise the turn ends
+    // reported as still inside the tool call, with a stray <|call|> emitted.
+    var run = drive(
+      List.of(
+        "<|channel|>",
+        "analysis",
+        "<|message|>",
+        "Need",
+        " a",
+        " file",
+        "<|end|>",
+        "<|start|>",
+        "assistant",
+        " to=functions.",
+        "write",
+        "<|channel|>",
+        "commentary",
+        "<|message|>",
+        "{\"p\":1}",
+        "<|call|>"
+      )
+    );
+
+    assertThat(run.tools()).isEqualTo(
+      "write<|channel|>commentary<|message|>{\"p\":1}"
+    );
+    assertThat(run.answer()).doesNotContain("<|call|>");
+    assertThat(run.finalState()).isEqualTo(GenerationState.ANSWER);
+  }
+
+  @Test
+  void a_tool_call_the_model_continues_past_hides_the_final_header() {
+    var run = drive(
+      List.of(
+        "<|channel|>",
+        "analysis",
+        "<|message|>",
+        "Need",
+        " a",
+        " file",
+        "<|end|>",
+        "<|start|>",
+        "assistant",
+        " to=functions.",
+        "write",
+        "<|channel|>",
+        "commentary",
+        "<|message|>",
+        "{\"p\":1}",
+        "<|call|>",
+        "<|start|>",
+        "assistant",
+        "<|channel|>",
+        "final",
+        "<|message|>",
+        "Created",
+        "!"
+      )
+    );
+
+    assertThat(run.tools()).isEqualTo(
+      "write<|channel|>commentary<|message|>{\"p\":1}"
+    );
+    assertThat(run.answer()).isEqualTo("Created!");
+    assertThat(run.answer()).doesNotContain("<|channel|>", "<|start|>");
+  }
+
+  @Test
+  void the_longest_matching_close_wins() {
+    var evaluation = new StateEvaluation();
+    evaluation.initialize(
+      new StateEvaluation.Config(
+        List.of(
+          new StateBounds(
+            GenerationState.REASONING,
+            List.of("<open>"),
+            List.of("<close>", "<close>extra")
+          )
+        )
+      )
+    );
+
+    var reasoning = new StringBuilder();
+    var answer = new StringBuilder();
+    GenerationState state = GenerationState.ANSWER;
+    for (String piece : List.of("<open>", "body", "<close>", "extra", "tail")) {
+      var emission = evaluation.evaluateToken(state, 0, piece);
+      state = emission.state();
+      append(reasoning, new StringBuilder(), answer, state, emission.emit());
+    }
+    var flushed = evaluation.flushPending(state);
+    append(
+      reasoning,
+      new StringBuilder(),
+      answer,
+      flushed.state(),
+      flushed.emit()
+    );
+
+    // "<close>extra" is the longer match, so "extra" is syntax, not content.
+    assertThat(reasoning.toString()).isEqualTo("body");
+    assertThat(answer.toString()).isEqualTo("tail");
+  }
+}

--- a/src/test/java/io/gravitee/llama/cpp/modules/StateEvaluationTest.java
+++ b/src/test/java/io/gravitee/llama/cpp/modules/StateEvaluationTest.java
@@ -243,14 +243,23 @@ class StateEvaluationTest {
     assertThat(closeSecond.emit()).isEmpty(); // marker text suppressed
     assertThat(closeSecond.emitTokens()).isEqualTo(2);
 
-    // Reasoning does not re-enter once closed.
+    // Reasoning does not re-enter once closed. The open marker is no longer a
+    // candidate, but "<|channel>" is still a prefix of the CLOSE marker, which is
+    // a candidate in ANSWER too — stray close markers are suppressed there, since
+    // a model that has just returned from a tool call still emits its channel
+    // header. So this buffers for one token rather than emitting immediately...
     var reOpen = eval.evaluateToken(ANSWER, 200, "<|channel>");
     assertThat(reOpen.state()).isEqualTo(ANSWER);
-    assertThat(reOpen.emit()).isEqualTo("<|channel>");
-    assertThat(reOpen.emitTokens()).isEqualTo(1);
-    assertThat(eval.evaluateToken(ANSWER, 201, "thought").state()).isEqualTo(
-      ANSWER
-    );
+    assertThat(reOpen.emit()).isEmpty();
+    assertThat(reOpen.emitTokens()).isZero();
+
+    // ...and "thought" refutes the close marker, so the buffered text is released
+    // into ANSWER with it. Delayed by one token, never lost, never re-entering
+    // REASONING.
+    var refuted = eval.evaluateToken(ANSWER, 201, "thought");
+    assertThat(refuted.state()).isEqualTo(ANSWER);
+    assertThat(refuted.emit()).isEqualTo("<|channel>thought");
+    assertThat(refuted.emitTokens()).isEqualTo(2);
   }
 
   @Test


### PR DESCRIPTION
A close marker arriving in ANSWER was unmatchable: candidates were only the
current state's closes and the other states' opens, and ANSWER has neither. But
after a tool call the next turn starts fresh in ANSWER and the model still emits
its final-channel header, so replies read "<|channel|>final<|message|>DONE". In
ANSWER every state's close markers are now candidates — one arriving there is
stray syntax by definition, since the span it would end is not open — and
matching only suppresses.

And a turn ENDING in the tool channel was reported as a plain stop.
processSampledToken stamps TOOL_CALL on a transition it sees mid-stream, but
<|call|> is an EOS token, so the agent flow never produces one: the span was
rendered as prose instead of extracted and run. Both flush sites now stamp it,
with the same empty-span guard as the mid-stream path.

Also wraps llama_sampler_init_grammar_lazy_patterns (LlamaSampler#grammarLazy)
so a grammar can arm on a trigger rather than constraining a whole response.
Symbol-verified against the shipped dylib, not yet exercised at runtime.